### PR TITLE
Fix/minor model standarization

### DIFF
--- a/docs/MODEL_LANGUAGE.md
+++ b/docs/MODEL_LANGUAGE.md
@@ -38,6 +38,7 @@ Conventions:
 - Use suffixes for units: `_c`, `_pct`, `_ms`, `_s`, `_kw`, `_kwh`, `_h`.
 - Use `_cycle_time_s` when the model integrates over time; expose `cycle_time_s` only when the integration step must be user-visible.
 - Internal helpers can be prefixed with `_`.
+- Hidden helper attributes (prefixed with `_`) should generally be placed at the end of the `attributes` list.
 - Use `k__` prefix for primary control inputs: setpoints, modes, enable/disable flags,
   or attributes that are written from external protocols and drive behavior.
   Avoid `k__` on derived or telemetry-only attributes.

--- a/docs/MODEL_LANGUAGE.md
+++ b/docs/MODEL_LANGUAGE.md
@@ -36,7 +36,7 @@ attributes:
 
 Conventions:
 - Use suffixes for units: `_c`, `_pct`, `_ms`, `_s`, `_kw`, `_kwh`, `_h`.
-- Use `cycle_time_s` when the model integrates over time.
+- Use `_cycle_time_s` when the model integrates over time; expose `cycle_time_s` only when the integration step must be user-visible.
 - Internal helpers can be prefixed with `_`.
 - Use `k__` prefix for primary control inputs: setpoints, modes, enable/disable flags,
   or attributes that are written from external protocols and drive behavior.

--- a/library/domains/iot/abb/abb_jra_s4_230_5_1__knx.yaml
+++ b/library/domains/iot/abb/abb_jra_s4_230_5_1__knx.yaml
@@ -31,7 +31,6 @@ meta_parameters:
     default: "2"
 
 attributes:
-  cycle_time_s: 0.2
   invert_move_long: 1
   invert_position: 1
   position_tolerance_pct: 0.5
@@ -75,7 +74,8 @@ attributes:
   c4_stop_cmd: 0
   c4_position_set_raw_cmd: -1.0
   c4_position_state_raw: 0
-
+  _cycle_time_s: 0.2
+  
 actions:
   # ------------------------------------------------------------------
   # Channel 1
@@ -131,7 +131,7 @@ actions:
   - function: $in(k__c1_position_pct)
     name: integrate_position_c1
     params:
-      delta_pct: "($in(cycle_time_s) / max(1.0, $in(c1_travel_time_s))) * 100.0"
+      delta_pct: "($in(_cycle_time_s) / max(1.0, $in(c1_travel_time_s))) * 100.0"
     call: (
           (
             min(
@@ -242,7 +242,7 @@ actions:
   - function: $in(k__c2_position_pct)
     name: integrate_position_c2
     params:
-      delta_pct: "($in(cycle_time_s) / max(1.0, $in(c2_travel_time_s))) * 100.0"
+      delta_pct: "($in(_cycle_time_s) / max(1.0, $in(c2_travel_time_s))) * 100.0"
     call: (
           (
             min(
@@ -353,7 +353,7 @@ actions:
   - function: $in(k__c3_position_pct)
     name: integrate_position_c3
     params:
-      delta_pct: "($in(cycle_time_s) / max(1.0, $in(c3_travel_time_s))) * 100.0"
+      delta_pct: "($in(_cycle_time_s) / max(1.0, $in(c3_travel_time_s))) * 100.0"
     call: (
           (
             min(
@@ -464,7 +464,7 @@ actions:
   - function: $in(k__c4_position_pct)
     name: integrate_position_c4
     params:
-      delta_pct: "($in(cycle_time_s) / max(1.0, $in(c4_travel_time_s))) * 100.0"
+      delta_pct: "($in(_cycle_time_s) / max(1.0, $in(c4_travel_time_s))) * 100.0"
     call: (
           (
             min(

--- a/library/domains/iot/generic/energy_meter_iem3000__modbus.yaml
+++ b/library/domains/iot/generic/energy_meter_iem3000__modbus.yaml
@@ -8,6 +8,14 @@ description: |
     - 3000..3110: instantaneous measurements (Float32, input registers)
     - 45100..45102: total active energy import/export (Float32, holding registers)
 
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5023
+  modbus_unit_id:
+    type: int
+    default: 1
+
 attributes:
   # Phase currents (A)
   k__current_l1_a: 12.0
@@ -44,7 +52,7 @@ attributes:
   k__energy_import_total_kwh: 0.0
   k__energy_export_total_kwh: 0.0
 
-  cycle_time_s: 1.0
+  _cycle_time_s: 1.0
 
 actions:
   - function: $in(current_avg_a)
@@ -117,18 +125,18 @@ actions:
   - function: $in(k__energy_import_total_kwh)
     name: integrate_energy_import
     description: Integrate imported energy (kWh) from total active power (kW).
-    call: $in(k__energy_import_total_kwh) + max(0.0, $in(k__active_power_total_kw)) * $in(cycle_time_s) / 3600.0
+    call: $in(k__energy_import_total_kwh) + max(0.0, $in(k__active_power_total_kw)) * $in(_cycle_time_s) / 3600.0
 
   - function: $in(k__energy_export_total_kwh)
     name: integrate_energy_export
     description: Integrate exported energy (kWh) from total active power (kW).
-    call: $in(k__energy_export_total_kwh) + max(0.0, -$in(k__active_power_total_kw)) * $in(cycle_time_s) / 3600.0
+    call: $in(k__energy_export_total_kwh) + max(0.0, -$in(k__active_power_total_kw)) * $in(_cycle_time_s) / 3600.0
 
 communication:
   - modbus_slave:
       host: 0.0.0.0
-      port: 5023
-      unit_id: 1
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
       zero_fill: true
       mapping:
         # Currents (A) Float32


### PR DESCRIPTION
This pull request refactors how cycle time attributes are handled across device models, standardizing the use of internal helper attributes and improving documentation. The main changes involve renaming `cycle_time_s` to `_cycle_time_s` for internal integration steps, updating all references to use the new naming, and making helper attribute placement conventions explicit. Additionally, Modbus communication parameters are now configurable via meta parameters.

**Attribute naming and usage standardization:**

* Updated documentation in `docs/MODEL_LANGUAGE.md` to clarify that helper attributes should be prefixed with `_` and placed at the end of the `attributes` list; also clarified when to use `cycle_time_s` vs `_cycle_time_s`.
* Renamed `cycle_time_s` to `_cycle_time_s` in both `abb_jra_s4_230_5_1__knx.yaml` and `energy_meter_iem3000__modbus.yaml`, and updated all action formulas to reference the new attribute name. [[1]](diffhunk://#diff-adec32242ec7de2466028c0c09621fdba2fd9acfad3ca96948387639cbc1dcc8L34) [[2]](diffhunk://#diff-adec32242ec7de2466028c0c09621fdba2fd9acfad3ca96948387639cbc1dcc8R77) [[3]](diffhunk://#diff-adec32242ec7de2466028c0c09621fdba2fd9acfad3ca96948387639cbc1dcc8L134-R134) [[4]](diffhunk://#diff-adec32242ec7de2466028c0c09621fdba2fd9acfad3ca96948387639cbc1dcc8L245-R245) [[5]](diffhunk://#diff-adec32242ec7de2466028c0c09621fdba2fd9acfad3ca96948387639cbc1dcc8L356-R356) [[6]](diffhunk://#diff-adec32242ec7de2466028c0c09621fdba2fd9acfad3ca96948387639cbc1dcc8L467-R467) [[7]](diffhunk://#diff-66379795111ae1a0fbd63ff3276b2ed4a446859bff4f69eb83d56c4390d746dfL47-R55) [[8]](diffhunk://#diff-66379795111ae1a0fbd63ff3276b2ed4a446859bff4f69eb83d56c4390d746dfL120-R139)

**Configuration improvements:**

* Added `modbus_port` and `modbus_unit_id` as configurable meta parameters in `energy_meter_iem3000__modbus.yaml`, and updated the communication section to use these parameters. [[1]](diffhunk://#diff-66379795111ae1a0fbd63ff3276b2ed4a446859bff4f69eb83d56c4390d746dfR11-R18) [[2]](diffhunk://#diff-66379795111ae1a0fbd63ff3276b2ed4a446859bff4f69eb83d56c4390d746dfL120-R139)