### PR TITLE
feat: add ABB M1M Modbus TCP power meter model

### DIFF
--- a/docs/LLM_SPEC.md
+++ b/docs/LLM_SPEC.md
@@ -29,6 +29,60 @@ Single source of truth for LLM and agent contributions.
 - Add helper tooling in `tools/` if it does not change runtime behavior.
 - Add new packs or profiles with matching catalog updates.
 
+## Operational flow for new-device-model generation automations
+Use this flow only for automations whose primary objective is creating a new
+device model YAML (plus required integration updates such as catalog/profile/tests).
+Do not treat this as a mandatory flow for unrelated repository tasks.
+
+1) Input contract
+- Start from a clear objective and acceptance criteria.
+- Confirm target domain/pack and protocol.
+- For vendor/protocol-specific models, require first-party documentation links.
+
+2) Implementation scope
+- Add/update model YAML in `library/domains/...`.
+- Keep naming rules (`lower_snake_case`, `name` aligned with file stem).
+- Update catalogs/profiles/pack docs as required by AGENTS.md.
+- Keep changes additive and backward-compatible.
+
+3) Runtime smoke gate (required)
+- Add a minimal integration smoke test for each new model.
+- Smoke test must load/register the model via `spx_python`, create/reset/start an instance, and assert it reaches `running`.
+- For protocol models, verify at least one protocol-level read/write probe on the exposed endpoint (for Modbus: resolve endpoint and read key registers).
+- On failure, capture diagnostic context from instance state and CI logs.
+
+4) Validation before push
+- Run:
+  - `poetry run python tools/validate_models.py`
+  - `poetry run pytest`
+
+5) CI remediation loop
+- After push, monitor CI for the branch.
+- If CI fails: fetch failing job logs, apply targeted fixes, commit, and push on the same branch.
+- Retry CI remediation up to 3 consecutive attempts.
+
+6) Success path
+- Open or update a PR with base branch `develop` only.
+- Never target `main` from automation.
+- Include source links, rationale, and test/validation evidence in the PR body.
+
+7) Failure fallback (after 3 failed CI remediation attempts)
+- Stop automated fix attempts.
+- Open an issue in the repository summarizing:
+  - branch and commit,
+  - failing workflow/job URLs,
+  - last observed error signature,
+  - attempted fixes,
+  - explicit blocker and next recommended manual action.
+- Leave merge from `develop` to `main` to a human maintainer.
+
+## Prompt minimization guidance
+- Keep automation prompts short.
+- Put stable process rules in this file and reference them from prompts.
+- Prompt content should focus on task-specific objective, constraints, and deliverables.
+- Avoid repeating generic flow, branch policy, and retry policy in every automation prompt.
+- For new-device-model generation prompts, reference this section instead of duplicating it.
+
 ## Golden examples
 
 Minimal model YAML:

--- a/docs/LLM_SPEC.md
+++ b/docs/LLM_SPEC.md
@@ -43,6 +43,10 @@ Do not treat this as a mandatory flow for unrelated repository tasks.
 - Add/update model YAML in `library/domains/...`.
 - Keep naming rules (`lower_snake_case`, `name` aligned with file stem).
 - Update catalogs/profiles/pack docs as required by AGENTS.md.
+- Register the model in the target pack explicitly:
+  - add `packages: [<target_pack>]` in `library/catalog/models.yaml`,
+  - include the model in at least one target-pack profile in `profiles/<target_pack>/*.yaml`,
+  - if one-click sample provisioning is expected for the pack, add `default_instances` (and `start_instances` when needed) in `library/catalog/industries.yaml`.
 - Keep changes additive and backward-compatible.
 
 3) Runtime smoke gate (required)
@@ -50,6 +54,7 @@ Do not treat this as a mandatory flow for unrelated repository tasks.
 - Smoke test must load/register the model via `spx_python`, create/reset/start an instance, and assert it reaches `running`.
 - For protocol models, verify at least one protocol-level read/write probe on the exposed endpoint (for Modbus: resolve endpoint and read key registers).
 - On failure, capture diagnostic context from instance state and CI logs.
+- Place the smoke test under the target pack integration suite (`tests/packs/<target_pack>/integration/`).
 
 4) Validation before push
 - Run:
@@ -61,12 +66,17 @@ Do not treat this as a mandatory flow for unrelated repository tasks.
 - If CI fails: fetch failing job logs, apply targeted fixes, commit, and push on the same branch.
 - Retry CI remediation up to 3 consecutive attempts.
 
-6) Success path
+6) Process upgrade gate (required for new-model workflow)
+- Keep or add a CI-visible guard that enforces: new model YAML changes must include runtime smoke coverage in the target pack integration tests.
+- The guard may be implemented as a pytest check, validation script check, or equivalent repository-native CI check.
+- If the guard fails, treat it as a blocker and fix it before opening/updating the PR.
+
+7) Success path
 - Open or update a PR with base branch `develop` only.
 - Never target `main` from automation.
 - Include source links, rationale, and test/validation evidence in the PR body.
 
-7) Failure fallback (after 3 failed CI remediation attempts)
+8) Failure fallback (after 3 failed CI remediation attempts)
 - Stop automated fix attempts.
 - Open an issue in the repository summarizing:
   - branch and commit,

--- a/docs/LLM_TASK_TEMPLATE.md
+++ b/docs/LLM_TASK_TEMPLATE.md
@@ -23,8 +23,15 @@ Use this template for new-device-model generation tasks.
 ## Files touched
 - 
 
+## Pack registration checklist (required)
+- Catalog entry includes target pack in `packages`:
+- Target pack profile includes the model path:
+- `library/catalog/industries.yaml` update needed?
+- If one-click sample provisioning is expected: `default_instances` / `start_instances` updated:
+
 ## Runtime smoke test plan (required for new model YAML)
 - Model path:
+- Target pack:
 - Smoke test path:
 - Bootstrap method (`spx_python` + instance start):
 - Protocol probe(s):
@@ -41,6 +48,11 @@ poetry run pytest
 - Attempt 2/3:
 - Attempt 3/3:
 - Stop after 3 failed CI attempts and create issue.
+
+## Process upgrade gate (required for new model workflow)
+- CI-visible rule ensuring new model YAML changes include smoke coverage:
+- Guard implementation path (pytest/validation script):
+- Guard result:
 
 ## PR summary (target `develop`)
 - Source links (first-party):

--- a/docs/LLM_TASK_TEMPLATE.md
+++ b/docs/LLM_TASK_TEMPLATE.md
@@ -1,12 +1,21 @@
 # LLM Task Template
 
+Use this template for new-device-model generation tasks.
+
 ## Goal
 - What is the change and why?
+- What are the explicit acceptance criteria?
+
+## Inputs
+- Target domain / pack:
+- Target protocol:
+- Required source constraints (if vendor/protocol-specific):
+- Branch policy: PR base is `develop` only.
 
 ## Base example
 - Closest existing model/profile/test used as a starting point:
 
-## Plan
+## Plan (implementation)
 1. 
 2. 
 3. 
@@ -14,14 +23,36 @@
 ## Files touched
 - 
 
+## Runtime smoke test plan (required for new model YAML)
+- Model path:
+- Smoke test path:
+- Bootstrap method (`spx_python` + instance start):
+- Protocol probe(s):
+- Expected running/healthy criteria:
+
 ## Validation
 ```bash
 poetry run python tools/validate_models.py
 poetry run pytest
 ```
 
-## PR summary
-- 
+## CI remediation loop
+- Attempt 1/3:
+- Attempt 2/3:
+- Attempt 3/3:
+- Stop after 3 failed CI attempts and create issue.
+
+## PR summary (target `develop`)
+- Source links (first-party):
+- Register/attribute rationale:
+- `k__` / `cmd__` decisions:
+- Validation/test evidence:
+
+## Failure issue summary (if CI failed 3 times)
+- Workflow/job links:
+- Last error signature:
+- Attempted fixes:
+- Blocker and recommended manual action:
 
 ## Risks or follow-ups
 - 

--- a/installer/cli.py
+++ b/installer/cli.py
@@ -238,6 +238,13 @@ def _build_noninteractive_selection(
 
     instances = resolve_default_instances(packages, index) if install_examples else []
     start_instances = resolve_start_instances(packages, index) if install_examples else []
+    if install_examples and (
+        "smart_building_pack" in packages
+        or "industrial_iiot_pack" in packages
+        or "embedded_lab_pack" in packages
+    ):
+        allowed = set(start_instances)
+        instances = [entry for entry in instances if entry.get("instance_key") in allowed]
 
     return WizardSelection(
         packages=packages,

--- a/installer/wizard.py
+++ b/installer/wizard.py
@@ -46,16 +46,22 @@ class InstallerWizard:
         self._print_banner()
         packages, protocol_filters = self._prompt_packages(index.industries, index)
         protocol_only = bool(protocol_filters) and not packages
-        profiles = [] if protocol_only else self._prompt_profiles(packages, index)
-        install_examples = False
+        profiles: List[str] = []
+        install_models = False
+        install_instances = False
         start_instances: List[str] = []
         if not protocol_only:
-            install_examples = self._prompt_yes_no(
-                "\nInstall bundled example models/tests? [Y/n]: ",
+            install_models = self._prompt_yes_no(
+                "\nAdd models from selected packages? [Y/n]: ",
                 default=True,
             )
-            if install_examples:
-                start_instances = self._prompt_start_instances(packages, index)
+            if install_models:
+                install_instances = self._prompt_yes_no(
+                    "Add default instances? [Y/n]: ",
+                    default=True,
+                )
+                if install_instances:
+                    start_instances = self._prompt_start_instances(packages, index)
         install_spx_ui = self._prompt_yes_no("Include SPX UI frontend container? [Y/n]: ", default=True)
         offline_bundle = self._prompt_yes_no(
             "Prepare offline installation bundle instead of immediate launch? [y/N]: ",
@@ -67,18 +73,26 @@ class InstallerWizard:
             model_ids = []
             service_ids = self._prompt_protocol_services(protocol_filters, index)
         else:
-            model_ids = resolve_model_ids(packages, profiles, protocol_filters, index)
+            model_ids = resolve_model_ids(packages, profiles, protocol_filters, index) if install_models else []
             service_ids = resolve_service_ids(model_ids, packages, profiles, index)
-        instances = resolve_default_instances(packages, index) if install_examples else []
-        if install_examples:
+        instances = resolve_default_instances(packages, index) if install_instances else []
+        if install_instances:
             allowed = {entry.get("instance_key") for entry in instances if entry.get("instance_key")}
             start_instances = [key for key in start_instances if key in allowed]
+        if install_instances and (
+            "smart_building_pack" in packages
+            or "industrial_iiot_pack" in packages
+            or "embedded_lab_pack" in packages
+        ):
+            allowed = set(start_instances)
+            instances = [entry for entry in instances if entry.get("instance_key") in allowed]
 
         self._print_summary(
             packages,
             profiles,
             protocol_filters,
-            install_examples,
+            install_models,
+            install_instances,
             install_spx_ui,
             offline_bundle,
             license_key,
@@ -93,7 +107,7 @@ class InstallerWizard:
             packages=packages,
             profiles=profiles,
             protocols=protocol_filters,
-            install_examples=install_examples,
+            install_examples=install_models,
             install_spx_ui=install_spx_ui,
             offline_bundle=offline_bundle,
             license_key=license_key,
@@ -405,7 +419,8 @@ class InstallerWizard:
         packages: Sequence[str],
         profiles: Sequence[str],
         protocols: Sequence[str],
-        install_examples: bool,
+        install_models: bool,
+        install_instances: bool,
         install_spx_ui: bool,
         offline_bundle: bool,
         license_key: str,
@@ -433,7 +448,8 @@ class InstallerWizard:
             print("\nProtocols:")
             for proto in protocols:
                 print(f"  • {self._format_protocol_label(proto)}")
-        print(f"\nInstall examples: {ui.success('yes') if install_examples else ui.warn('no')}")
+        print(f"\nInstall models: {ui.success('yes') if install_models else ui.warn('no')}")
+        print(f"Install instances: {ui.success('yes') if install_instances else ui.warn('no')}")
         print(f"Include SPX UI: {ui.success('yes') if install_spx_ui else ui.warn('no')}")
         print(f"Offline bundle: {ui.success('yes') if offline_bundle else ui.warn('no')}")
         print(f"SPX product key: {ui.heading(license_key or 'N/A')}")

--- a/library/catalog/industries.yaml
+++ b/library/catalog/industries.yaml
@@ -151,6 +151,8 @@ industries:
         instance: spx_pid_controller
       - model: Energy.EnergyMeter3Ph.Modbus
         instance: spx_energy_meter_3ph_modbus
+      - model: Energy.PowerMeter.AbbM1M.Modbus
+        instance: spx_abb_m1m_power_meter_modbus
       - model: Process.PressureTransmitter.Modbus
         instance: spx_pressure_transmitter
       - model: Process.ProcessCell.OpcUa

--- a/library/catalog/industries.yaml
+++ b/library/catalog/industries.yaml
@@ -93,6 +93,12 @@ industries:
         instance: spx_vacuum_gauge
       - model: Process.VacuumGaugeMultichannel.Modbus
         instance: spx_vacuum_gauge_multichannel
+    start_instances:
+      - spx_health_monitor_ble
+      - spx_temp_sensor_ble
+      - spx_env_sensor_mqtt
+      - spx_lab_multimeter
+      - spx_vacuum_gauge
     path: library/industries/embedded_lab_pack
   - id: industrial_iiot_pack
     name: Industrial Pack (Industry 4.0)

--- a/library/catalog/models.yaml
+++ b/library/catalog/models.yaml
@@ -331,6 +331,15 @@ models:
       - id: modbus_tcp_gateway
     packages: [smart_building_pack]
     profiles: [bms_quickstart]
+  - id: Energy.PowerMeter.AbbM1M.Modbus
+    name: ABB M1M Power Meter (Modbus TCP)
+    path: library/domains/iot/abb/abb_m1m_power_meter__modbus.yaml
+    domain: iot
+    protocols: [modbus]
+    services:
+      - id: modbus_tcp_gateway
+    packages: [industrial_iiot_pack]
+    profiles: [process_cell_quickstart]
   - id: Energy.EVSE.Ocpp
     name: EVSE / Charge Point (OCPP 1.6)
     path: library/domains/energy/emobility/evse__ocpp.yaml

--- a/library/domains/iot/abb/abb_m1m_power_meter__modbus.yaml
+++ b/library/domains/iot/abb/abb_m1m_power_meter__modbus.yaml
@@ -272,7 +272,7 @@ communication:
         reactive_power_total_raw: { address: [23330,23331], group: i_r, type: uint_32 }
         apparent_power_total_raw: { address: [23338,23339], group: i_r, type: uint_32 }
         frequency_raw:         { address: [23346,23347], group: i_r, type: uint_32 }
-        power_factor_total_raw:{ address: [23360,23361], group: i_r, type: uint_32 }
+        power_factor_total_raw: { address: [23360,23361], group: i_r, type: uint_32 }
 
 scenarios:
   nominal_load:

--- a/library/domains/iot/abb/abb_m1m_power_meter__modbus.yaml
+++ b/library/domains/iot/abb/abb_m1m_power_meter__modbus.yaml
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: MIT
+
+name: abb_m1m_power_meter__modbus
+description: |
+  Minimal Modbus TCP (slave) simulation of ABB M1M power meters with key
+  real-time measurements mapped from the M1M Modbus register list. The model
+  exposes scaled 32-bit register values for voltages, currents, power, frequency,
+  and power factor.
+
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5027
+  modbus_unit_id:
+    type: int
+    default: 1
+
+attributes:
+  k__load_kw: 12.0
+  k__power_factor: 0.96
+  k__voltage_nominal_v: 230.0
+  k__frequency_nominal_hz: 50.0
+  power_factor_leading: 0
+
+  voltage_drop_per_kw: 0.35
+  voltage_floor_v: 200.0
+  voltage_ceiling_v: 245.0
+
+  frequency_droop_per_kw: 0.02
+  frequency_floor_hz: 47.5
+  frequency_ceiling_hz: 52.0
+
+  voltage_system_v: 0.0
+  voltage_l1_v: 0.0
+  voltage_l2_v: 0.0
+  voltage_l3_v: 0.0
+  voltage_l1_l2_v: 0.0
+  voltage_l2_l3_v: 0.0
+  voltage_l3_l1_v: 0.0
+
+  current_l1_a: 0.0
+  current_l2_a: 0.0
+  current_l3_a: 0.0
+  current_avg_a: 0.0
+
+  active_power_total_kw: 0.0
+  reactive_power_total_kvar: 0.0
+  apparent_power_total_kva: 0.0
+  frequency_hz: 0.0
+  power_factor_total: 0.0
+
+  voltage_system_raw: 0
+  voltage_l1_raw: 0
+  voltage_l2_raw: 0
+  voltage_l3_raw: 0
+  voltage_l1_l2_raw: 0
+  voltage_l2_l3_raw: 0
+  voltage_l3_l1_raw: 0
+
+  current_total_raw: 0
+  current_l1_raw: 0
+  current_l2_raw: 0
+  current_l3_raw: 0
+
+  active_power_total_raw: 0
+  reactive_power_total_raw: 0
+  apparent_power_total_raw: 0
+  frequency_raw: 0
+  power_factor_total_raw: 0
+
+actions:
+  - function: $in(voltage_system_v)
+    name: compute_voltage_system
+    description: Compute base line-to-neutral voltage with load-dependent sag.
+    call: max(
+          $in(voltage_floor_v),
+          min(
+            $in(voltage_ceiling_v),
+            $in(k__voltage_nominal_v) - $in(voltage_drop_per_kw) * max(0.0, $in(k__load_kw))
+          )
+        )
+
+  - function: $in(voltage_l1_v)
+    name: compute_voltage_l1
+    description: Apply small deterministic unbalance on phase L1.
+    call: $in(voltage_system_v) + 0.3
+
+  - function: $in(voltage_l2_v)
+    name: compute_voltage_l2
+    description: Apply small deterministic unbalance on phase L2.
+    call: $in(voltage_system_v) - 0.2
+
+  - function: $in(voltage_l3_v)
+    name: compute_voltage_l3
+    description: Apply small deterministic unbalance on phase L3.
+    call: $in(voltage_system_v) - 0.1
+
+  - function: $in(voltage_l1_l2_v)
+    name: compute_voltage_l1_l2
+    description: Line voltage L1-L2 from phase voltages.
+    call: 1.7320508075688772 * (($in(voltage_l1_v) + $in(voltage_l2_v)) / 2.0)
+
+  - function: $in(voltage_l2_l3_v)
+    name: compute_voltage_l2_l3
+    description: Line voltage L2-L3 from phase voltages.
+    call: 1.7320508075688772 * (($in(voltage_l2_v) + $in(voltage_l3_v)) / 2.0)
+
+  - function: $in(voltage_l3_l1_v)
+    name: compute_voltage_l3_l1
+    description: Line voltage L3-L1 from phase voltages.
+    call: 1.7320508075688772 * (($in(voltage_l3_v) + $in(voltage_l1_v)) / 2.0)
+
+  - function: $in(current_avg_a)
+    name: compute_current_avg
+    description: Compute average line current from total load.
+    call: |
+      (lambda load_kw, v_ll, pf:
+        0.0 if load_kw <= 0.0 else (load_kw * 1000.0) / max(1.0, (1.7320508075688772 * v_ll * pf))
+      )(
+        max(0.0, $in(k__load_kw)),
+        ($in(voltage_l1_l2_v) + $in(voltage_l2_l3_v) + $in(voltage_l3_l1_v)) / 3.0,
+        max(0.1, min(1.0, abs($in(k__power_factor))))
+      )
+
+  - function: $in(current_l1_a)
+    name: compute_current_l1
+    description: Assign per-phase current with minor deterministic spread.
+    call: $in(current_avg_a) * 1.02
+
+  - function: $in(current_l2_a)
+    name: compute_current_l2
+    description: Assign per-phase current with minor deterministic spread.
+    call: $in(current_avg_a) * 0.99
+
+  - function: $in(current_l3_a)
+    name: compute_current_l3
+    description: Assign per-phase current with minor deterministic spread.
+    call: $in(current_avg_a) * 0.99
+
+  - function: $in(active_power_total_kw)
+    name: compute_active_power_total
+    description: Active power follows load demand.
+    call: max(0.0, $in(k__load_kw))
+
+  - function: $in(apparent_power_total_kva)
+    name: compute_apparent_power_total
+    description: Apparent power derived from active power and power factor.
+    call: $in(active_power_total_kw) / max(0.1, min(1.0, abs($in(k__power_factor))))
+
+  - function: $in(reactive_power_total_kvar)
+    name: compute_reactive_power_total
+    description: Reactive power magnitude derived from apparent and active power.
+    call: (
+          max(0.0, ($in(apparent_power_total_kva) ** 2) - ($in(active_power_total_kw) ** 2))
+        ) ** 0.5 * (-1.0 if $in(power_factor_leading) else 1.0)
+
+  - function: $in(power_factor_total)
+    name: compute_power_factor_total
+    description: Report absolute power factor (sign handled via reactive power).
+    call: max(0.0, min(1.0, abs($in(k__power_factor))))
+
+  - function: $in(frequency_hz)
+    name: compute_frequency
+    description: Frequency droops with higher load.
+    call: max(
+          $in(frequency_floor_hz),
+          min(
+            $in(frequency_ceiling_hz),
+            $in(k__frequency_nominal_hz) - $in(frequency_droop_per_kw) * max(0.0, $in(active_power_total_kw))
+          )
+        )
+
+  - function: $in(voltage_system_raw)
+    name: encode_voltage_system
+    description: Encode system voltage (0.1 V units).
+    call: int(round($in(voltage_system_v) * 10.0))
+
+  - function: $in(voltage_l1_raw)
+    name: encode_voltage_l1
+    description: Encode phase L1 voltage (0.1 V units).
+    call: int(round($in(voltage_l1_v) * 10.0))
+
+  - function: $in(voltage_l2_raw)
+    name: encode_voltage_l2
+    description: Encode phase L2 voltage (0.1 V units).
+    call: int(round($in(voltage_l2_v) * 10.0))
+
+  - function: $in(voltage_l3_raw)
+    name: encode_voltage_l3
+    description: Encode phase L3 voltage (0.1 V units).
+    call: int(round($in(voltage_l3_v) * 10.0))
+
+  - function: $in(voltage_l1_l2_raw)
+    name: encode_voltage_l1_l2
+    description: Encode line voltage L1-L2 (0.1 V units).
+    call: int(round($in(voltage_l1_l2_v) * 10.0))
+
+  - function: $in(voltage_l2_l3_raw)
+    name: encode_voltage_l2_l3
+    description: Encode line voltage L2-L3 (0.1 V units).
+    call: int(round($in(voltage_l2_l3_v) * 10.0))
+
+  - function: $in(voltage_l3_l1_raw)
+    name: encode_voltage_l3_l1
+    description: Encode line voltage L3-L1 (0.1 V units).
+    call: int(round($in(voltage_l3_l1_v) * 10.0))
+
+  - function: $in(current_total_raw)
+    name: encode_current_total
+    description: Encode total line current (0.01 A units).
+    call: int(round($in(current_avg_a) * 100.0))
+
+  - function: $in(current_l1_raw)
+    name: encode_current_l1
+    description: Encode phase L1 current (0.01 A units).
+    call: int(round($in(current_l1_a) * 100.0))
+
+  - function: $in(current_l2_raw)
+    name: encode_current_l2
+    description: Encode phase L2 current (0.01 A units).
+    call: int(round($in(current_l2_a) * 100.0))
+
+  - function: $in(current_l3_raw)
+    name: encode_current_l3
+    description: Encode phase L3 current (0.01 A units).
+    call: int(round($in(current_l3_a) * 100.0))
+
+  - function: $in(active_power_total_raw)
+    name: encode_active_power_total
+    description: Encode total active power (0.01 W units).
+    call: int(round($in(active_power_total_kw) * 100000.0))
+
+  - function: $in(reactive_power_total_raw)
+    name: encode_reactive_power_total
+    description: Encode total reactive power (0.01 var units).
+    call: int(round(abs($in(reactive_power_total_kvar)) * 100000.0))
+
+  - function: $in(apparent_power_total_raw)
+    name: encode_apparent_power_total
+    description: Encode total apparent power (0.01 VA units).
+    call: int(round($in(apparent_power_total_kva) * 100000.0))
+
+  - function: $in(frequency_raw)
+    name: encode_frequency
+    description: Encode frequency (0.01 Hz units).
+    call: int(round($in(frequency_hz) * 100.0))
+
+  - function: $in(power_factor_total_raw)
+    name: encode_power_factor_total
+    description: Encode power factor (0.001 units).
+    call: int(round($in(power_factor_total) * 1000.0))
+
+communication:
+  - modbus_slave:
+      host: 0.0.0.0
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
+      zero_fill: true
+      mapping:
+        voltage_system_raw:    { address: [23296,23297], group: i_r, type: uint_32 }
+        voltage_l1_raw:        { address: [23298,23299], group: i_r, type: uint_32 }
+        voltage_l2_raw:        { address: [23300,23301], group: i_r, type: uint_32 }
+        voltage_l3_raw:        { address: [23302,23303], group: i_r, type: uint_32 }
+        voltage_l1_l2_raw:     { address: [23304,23305], group: i_r, type: uint_32 }
+        voltage_l2_l3_raw:     { address: [23306,23307], group: i_r, type: uint_32 }
+        voltage_l3_l1_raw:     { address: [23308,23309], group: i_r, type: uint_32 }
+        current_total_raw:     { address: [23310,23311], group: i_r, type: uint_32 }
+        current_l1_raw:        { address: [23312,23313], group: i_r, type: uint_32 }
+        current_l2_raw:        { address: [23314,23315], group: i_r, type: uint_32 }
+        current_l3_raw:        { address: [23316,23317], group: i_r, type: uint_32 }
+        active_power_total_raw:   { address: [23322,23323], group: i_r, type: uint_32 }
+        reactive_power_total_raw: { address: [23330,23331], group: i_r, type: uint_32 }
+        apparent_power_total_raw: { address: [23338,23339], group: i_r, type: uint_32 }
+        frequency_raw:         { address: [23346,23347], group: i_r, type: uint_32 }
+        power_factor_total_raw:{ address: [23360,23361], group: i_r, type: uint_32 }
+
+scenarios:
+  nominal_load:
+    description: Balanced nominal load at high power factor.
+    duration: 30.0
+    overrides:
+      $in(k__load_kw): 10.0
+      $in(k__power_factor): 0.98
+
+  overload:
+    description: Elevated load with voltage sag.
+    duration: 25.0
+    overrides:
+      $in(k__load_kw): 25.0
+      $in(k__power_factor): 0.92
+      $in(voltage_drop_per_kw): 0.6
+
+  low_power_factor:
+    description: Inductive load with low power factor.
+    duration: 30.0
+    overrides:
+      $in(k__load_kw): 18.0
+      $in(k__power_factor): 0.72
+      $in(power_factor_leading): 0
+
+  recovery:
+    description: Return to lighter load and nominal voltage.
+    duration: 20.0
+    overrides:
+      $in(k__load_kw): 8.0
+      $in(k__power_factor): 0.99
+      $in(voltage_drop_per_kw): 0.25

--- a/library/industries/industrial_iiot_pack/README.md
+++ b/library/industries/industrial_iiot_pack/README.md
@@ -5,7 +5,7 @@ factory monitoring. The present iteration links the models we already maintain;
 additional Redfish device twins can land alongside.
 
 - **Protocols**: Modbus TCP, MQTT, HTTP, SCPI, OPC UA.
-- **Models**: motion control, process instrumentation, QA instrumentation, vendor-specific controllers (Eurotherm, Siemens, WAGO).
+- **Models**: motion control, process instrumentation, QA instrumentation, vendor-specific controllers (ABB M1M, Eurotherm, Siemens, WAGO).
 - **OPC UA**: process-focused twins:
   * `Process.ProcessCell.OpcUa` – thermal/pressure loop mirroring AsyncUA tests.
   * `Process.Workcell.OpcUa` – robotic/machining gniazdo z pomiarem cykli i alarmami.

--- a/profiles/industrial_iiot_pack/process_cell_quickstart.yaml
+++ b/profiles/industrial_iiot_pack/process_cell_quickstart.yaml
@@ -6,6 +6,7 @@ models:
   - library/domains/motion_controllers/generic/stepper_controller__modbus.yaml
   - library/domains/thermal_controllers/generic/thermal_controller__modbus.yaml
   - library/domains/vacuum_systems/generic/vacuum_gauge__modbus.yaml
+  - library/domains/iot/abb/abb_m1m_power_meter__modbus.yaml
   - library/domains/iot/generic/process_cell__opcua.yaml
   - library/domains/iot/generic/production_workcell__opcua.yaml
   - library/domains/iot/generic/packaging_line__opcua.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "spx-examples"
-version = "1.0.3-alpha.1"
+version = "1.0.3"
 description = "Runnable SPX examples and smoke tests using the Python client against SPX Server."
 authors = ["Aleksander Stanik <aleksander.stanik@hammerheadsengineers.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "spx-examples"
-version = "1.0.2-rc.1"
+version = "1.0.2"
 description = "Runnable SPX examples and smoke tests using the Python client against SPX Server."
 authors = ["Aleksander Stanik <aleksander.stanik@hammerheadsengineers.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "spx-examples"
-version = "1.0.3"
+version = "1.1.0-alpha.1"
 description = "Runnable SPX examples and smoke tests using the Python client against SPX Server."
 authors = ["Aleksander Stanik <aleksander.stanik@hammerheadsengineers.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "spx-examples"
-version = "1.0.2"
+version = "1.0.3-alpha.1"
 description = "Runnable SPX examples and smoke tests using the Python client against SPX Server."
 authors = ["Aleksander Stanik <aleksander.stanik@hammerheadsengineers.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "spx-examples"
-version = "1.1.0-alpha.1"
+version = "1.1.0-alpha.2"
 description = "Runnable SPX examples and smoke tests using the Python client against SPX Server."
 authors = ["Aleksander Stanik <aleksander.stanik@hammerheadsengineers.com>"]
 license = "MIT"

--- a/tests/installer/test_wizard.py
+++ b/tests/installer/test_wizard.py
@@ -95,13 +95,13 @@ def test_wizard_with_inputs(monkeypatch: pytest.MonkeyPatch, manifest_index: Man
 
     wizard = InstallerWizard(loader=FakeLoader())
 
-    inputs = iter(["1", "1", "", "n", "n"])
+    inputs = iter(["1", "", "", "n", "n"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     selection = wizard.run()
 
     assert selection.packages == ["pack_a"]
-    assert selection.profiles == ["profile_a"]
+    assert selection.profiles == []
     assert selection.protocols == []
     assert selection.install_examples is True
     assert selection.install_spx_ui is False

--- a/tests/packs/industrial_iiot_pack/integration/test_modbus_abb_m1m_smoke.py
+++ b/tests/packs/industrial_iiot_pack/integration/test_modbus_abb_m1m_smoke.py
@@ -8,8 +8,7 @@ import unittest
 from typing import Optional, Sequence
 
 from tests.common.modbus_utils import wait_for_modbus_endpoint
-from tests.common.repo import repo_root
-from tests.common.spx_utils import bootstrap_model_instance, wait_for_condition
+from tests.common.spx_utils import require_existing_instance, wait_for_condition
 
 try:  # pymodbus >= 3.x
     from pymodbus.client import ModbusTcpClient  # type: ignore
@@ -20,10 +19,8 @@ except Exception:  # pragma: no cover - fallback for pymodbus < 3.x
         ModbusTcpClient = None  # type: ignore
 
 
-ROOT = repo_root()
-MODEL_PATH = ROOT / "library" / "domains" / "iot" / "abb" / "abb_m1m_power_meter__modbus.yaml"
-MODEL_KEY = "tests__abb_m1m_power_meter_modbus"
-INSTANCE_KEY = "tests__abb_m1m_power_meter_modbus"
+MODEL_ID = "Energy.PowerMeter.AbbM1M.Modbus"
+INSTANCE_KEY = "spx_abb_m1m_power_meter_modbus"
 SPX_BASE_URL = os.environ.get("SPX_BASE_URL", "http://localhost:8000")
 READ_RETRY_TIMEOUT = float(os.environ.get("ABB_M1M_SMOKE_READ_TIMEOUT", "6.0"))
 
@@ -127,18 +124,27 @@ class TestModbusAbbM1MSmokeIntegration(unittest.TestCase):
         if not product_key:
             raise unittest.SkipTest("SPX_PRODUCT_KEY must be set to run integration tests.")
 
-        (
+        cls._client = spx_python.init(address=SPX_BASE_URL, product_key=product_key)
+        cls._instance = require_existing_instance(
             cls._client,
-            cls._instance,
-            cls._model_changed,
-        ) = bootstrap_model_instance(
-            spx_python,
-            product_key=product_key,
-            base_url=SPX_BASE_URL,
-            model_path=MODEL_PATH,
-            model_key=MODEL_KEY,
-            instance_key=INSTANCE_KEY,
+            INSTANCE_KEY,
+            expected_model_id=MODEL_ID,
+            ensure_running=False,
         )
+        cls._model_changed = False
+
+        try:
+            cls._instance.stop()
+        except Exception:
+            pass
+        try:
+            cls._instance.reset()
+        except Exception:
+            pass
+        try:
+            cls._instance.start()
+        except Exception:
+            pass
 
     @classmethod
     def _debug_snapshot(cls) -> str:

--- a/tests/packs/industrial_iiot_pack/integration/test_modbus_abb_m1m_smoke.py
+++ b/tests/packs/industrial_iiot_pack/integration/test_modbus_abb_m1m_smoke.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import os
+import time
+import unittest
+from typing import Optional, Sequence
+
+from tests.common.modbus_utils import wait_for_modbus_endpoint
+from tests.common.repo import repo_root
+from tests.common.spx_utils import bootstrap_model_instance, wait_for_condition
+
+try:  # pymodbus >= 3.x
+    from pymodbus.client import ModbusTcpClient  # type: ignore
+except Exception:  # pragma: no cover - fallback for pymodbus < 3.x
+    try:
+        from pymodbus.client.sync import ModbusTcpClient  # type: ignore
+    except Exception:  # pragma: no cover - pymodbus unavailable
+        ModbusTcpClient = None  # type: ignore
+
+
+ROOT = repo_root()
+MODEL_PATH = ROOT / "library" / "domains" / "iot" / "abb" / "abb_m1m_power_meter__modbus.yaml"
+MODEL_KEY = "tests__abb_m1m_power_meter_modbus"
+INSTANCE_KEY = "tests__abb_m1m_power_meter_modbus"
+SPX_BASE_URL = os.environ.get("SPX_BASE_URL", "http://localhost:8000")
+READ_RETRY_TIMEOUT = float(os.environ.get("ABB_M1M_SMOKE_READ_TIMEOUT", "6.0"))
+
+
+def _instance_state(instance) -> Optional[str]:
+    try:
+        state = instance.state
+    except Exception:
+        state = None
+    if isinstance(state, str):
+        return state
+
+    try:
+        doc = instance.get()
+    except Exception:
+        doc = None
+    if isinstance(doc, dict):
+        value = doc.get("state")
+        if isinstance(value, str):
+            return value
+        attr = doc.get("attr")
+        if isinstance(attr, dict):
+            state_attr = attr.get("state")
+            if isinstance(state_attr, dict):
+                state_value = state_attr.get("value")
+                if isinstance(state_value, str):
+                    return state_value
+    return None
+
+
+def _float_attr(attribute) -> Optional[float]:
+    try:
+        value = attribute.internal_value
+    except Exception:
+        value = None
+    if value is None:
+        value = attribute
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _read_input_registers(client, address: int, count: int, unit_id: int):
+    try:
+        return client.read_input_registers(address=address, count=count, slave=unit_id)
+    except TypeError:
+        return client.read_input_registers(address=address, count=count, unit=unit_id)
+
+
+def _decode_u32_be(registers: Sequence[int]) -> int:
+    if len(registers) != 2:
+        raise ValueError(f"Expected 2 registers, got {len(registers)}")
+    return ((int(registers[0]) & 0xFFFF) << 16) | (int(registers[1]) & 0xFFFF)
+
+
+def _read_u32_with_retry(client, address: int, unit_id: int, *, timeout: float) -> int:
+    deadline = time.time() + max(0.1, timeout)
+    last_error: Optional[BaseException] = None
+    last_value: Optional[int] = None
+
+    while time.time() < deadline:
+        try:
+            response = _read_input_registers(client, address=address, count=2, unit_id=unit_id)
+            if response is None:
+                raise RuntimeError(f"No Modbus response at address {address}")
+            if response.isError():  # pragma: no cover - delegated to pymodbus
+                raise RuntimeError(f"Modbus error at address {address}: {response}")
+
+            value = _decode_u32_be(response.registers)
+            last_value = value
+            if value > 0:
+                return value
+        except Exception as exc:
+            last_error = exc
+        time.sleep(0.2)
+
+    if last_error is not None:
+        raise AssertionError(
+            f"Unable to read positive u32 from address {address} within {timeout}s: {last_error}"
+        ) from last_error
+    raise AssertionError(
+        f"Unable to read positive u32 from address {address} within {timeout}s; last_value={last_value!r}"
+    )
+
+
+class TestModbusAbbM1MSmokeIntegration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if ModbusTcpClient is None:  # pragma: no cover - dependency missing
+            raise unittest.SkipTest(
+                "pymodbus is not available. Install pymodbus to run Modbus integration tests."
+            )
+
+        try:
+            import spx_python  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise unittest.SkipTest(f"spx_python not available: {exc}") from exc
+
+        product_key = os.environ.get("SPX_PRODUCT_KEY")
+        if not product_key:
+            raise unittest.SkipTest("SPX_PRODUCT_KEY must be set to run integration tests.")
+
+        (
+            cls._client,
+            cls._instance,
+            cls._model_changed,
+        ) = bootstrap_model_instance(
+            spx_python,
+            product_key=product_key,
+            base_url=SPX_BASE_URL,
+            model_path=MODEL_PATH,
+            model_key=MODEL_KEY,
+            instance_key=INSTANCE_KEY,
+        )
+
+    @classmethod
+    def _debug_snapshot(cls) -> str:
+        state = _instance_state(cls._instance)
+        try:
+            port, unit_id = wait_for_modbus_endpoint(
+                cls._instance,
+                comm_keys=("modbus_slave", "modbus_tcp"),
+                timeout=1.0,
+                interval=0.1,
+            )
+            endpoint = f"{port}/{unit_id}"
+        except Exception as exc:
+            endpoint = f"unresolved ({exc})"
+
+        attrs = cls._instance["attributes"]
+        voltage = _float_attr(attrs["voltage_system_v"])
+        power = _float_attr(attrs["active_power_total_kw"])
+        frequency = _float_attr(attrs["frequency_hz"])
+        return (
+            f"state={state!r}, endpoint={endpoint}, "
+            f"voltage_system_v={voltage!r}, active_power_total_kw={power!r}, frequency_hz={frequency!r}"
+        )
+
+    def test_instance_starts_and_endpoint_resolves(self):
+        is_running = wait_for_condition(
+            lambda: (_instance_state(self._instance) or "").lower() == "running",
+            timeout=10.0,
+            interval=0.2,
+        )
+        self.assertTrue(is_running, f"ABB M1M instance did not reach RUNNING ({self._debug_snapshot()})")
+
+        port, unit_id = wait_for_modbus_endpoint(
+            self._instance,
+            comm_keys=("modbus_slave", "modbus_tcp"),
+            timeout=10.0,
+            interval=0.2,
+        )
+        self.assertGreater(port, 0, f"Invalid Modbus port resolved ({self._debug_snapshot()})")
+        self.assertGreater(unit_id, 0, f"Invalid Modbus unit id resolved ({self._debug_snapshot()})")
+
+    def test_modbus_key_registers_match_runtime_attributes(self):
+        port, unit_id = wait_for_modbus_endpoint(
+            self._instance,
+            comm_keys=("modbus_slave", "modbus_tcp"),
+            timeout=10.0,
+            interval=0.2,
+        )
+
+        client = ModbusTcpClient(host="127.0.0.1", port=port, timeout=1.0)
+        if not wait_for_condition(lambda: bool(client.connect()), timeout=5.0, interval=0.2):
+            self.fail(f"Modbus endpoint is unreachable at 127.0.0.1:{port} (unit {unit_id})")
+
+        try:
+            voltage_raw = _read_u32_with_retry(
+                client,
+                address=23296,
+                unit_id=unit_id,
+                timeout=READ_RETRY_TIMEOUT,
+            )
+            active_power_raw = _read_u32_with_retry(
+                client,
+                address=23322,
+                unit_id=unit_id,
+                timeout=READ_RETRY_TIMEOUT,
+            )
+            frequency_raw = _read_u32_with_retry(
+                client,
+                address=23346,
+                unit_id=unit_id,
+                timeout=READ_RETRY_TIMEOUT,
+            )
+        finally:
+            client.close()
+
+        attrs = self._instance["attributes"]
+        voltage_system_v = _float_attr(attrs["voltage_system_v"])
+        active_power_total_kw = _float_attr(attrs["active_power_total_kw"])
+        frequency_hz = _float_attr(attrs["frequency_hz"])
+
+        self.assertIsNotNone(voltage_system_v, "Unable to read attribute 'voltage_system_v'")
+        self.assertIsNotNone(active_power_total_kw, "Unable to read attribute 'active_power_total_kw'")
+        self.assertIsNotNone(frequency_hz, "Unable to read attribute 'frequency_hz'")
+
+        voltage_from_modbus = voltage_raw / 10.0
+        active_power_from_modbus = active_power_raw / 100000.0
+        frequency_from_modbus = frequency_raw / 100.0
+
+        self.assertAlmostEqual(
+            voltage_from_modbus,
+            float(voltage_system_v),
+            delta=2.0,
+            msg=f"Voltage mismatch ({self._debug_snapshot()})",
+        )
+        self.assertAlmostEqual(
+            active_power_from_modbus,
+            float(active_power_total_kw),
+            delta=0.5,
+            msg=f"Active power mismatch ({self._debug_snapshot()})",
+        )
+        self.assertAlmostEqual(
+            frequency_from_modbus,
+            float(frequency_hz),
+            delta=0.2,
+            msg=f"Frequency mismatch ({self._debug_snapshot()})",
+        )

--- a/tests/packs/industrial_iiot_pack/unit/test_pack_catalog.py
+++ b/tests/packs/industrial_iiot_pack/unit/test_pack_catalog.py
@@ -68,3 +68,9 @@ def test_pack_profiles_reference_catalog_models() -> None:
             model_entry = models_by_path[model_path]
             packages = model_entry.get("packages", []) or []
             assert PACK_ID in packages, f"Catalog model {model_entry.get('id')} is missing '{PACK_ID}' in packages"
+
+
+def test_pack_includes_abb_m1m_power_meter() -> None:
+    models = models_for_pack(PACK_ID)
+    model_ids = {entry.get("id") for entry in models}
+    assert "Energy.PowerMeter.AbbM1M.Modbus" in model_ids

--- a/tests/packs/industrial_iiot_pack/unit/test_pack_catalog.py
+++ b/tests/packs/industrial_iiot_pack/unit/test_pack_catalog.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import yaml
 
 from tests.common.repo import repo_root
@@ -16,6 +18,11 @@ from tests.shared.pack_catalog import (
 
 
 PACK_ID = "industrial_iiot_pack"
+REQUIRED_SMOKE_TESTS = {
+    "Energy.PowerMeter.AbbM1M.Modbus": Path(
+        "tests/packs/industrial_iiot_pack/integration/test_modbus_abb_m1m_smoke.py"
+    )
+}
 
 
 def test_pack_catalog_models_exist_and_load() -> None:
@@ -74,3 +81,27 @@ def test_pack_includes_abb_m1m_power_meter() -> None:
     models = models_for_pack(PACK_ID)
     model_ids = {entry.get("id") for entry in models}
     assert "Energy.PowerMeter.AbbM1M.Modbus" in model_ids
+
+
+def test_pack_default_instances_include_abb_m1m_power_meter() -> None:
+    industry = find_industry(PACK_ID)
+    default_model_ids = {
+        entry.get("model")
+        for entry in industry.get("default_instances", []) or []
+        if isinstance(entry, dict)
+    }
+    assert "Energy.PowerMeter.AbbM1M.Modbus" in default_model_ids
+
+
+def test_required_pack_smoke_tests_are_present() -> None:
+    root = repo_root()
+    models_by_id = model_index_by_id()
+
+    for model_id, smoke_rel in REQUIRED_SMOKE_TESTS.items():
+        assert model_id in models_by_id, f"Required smoke-test model id is missing: {model_id}"
+        model_entry = models_by_id[model_id]
+        packages = model_entry.get("packages", []) or []
+        assert PACK_ID in packages, f"Model {model_id} is not assigned to '{PACK_ID}'"
+
+        smoke_path = root / smoke_rel
+        assert smoke_path.exists(), f"Required smoke test is missing: {smoke_rel}"


### PR DESCRIPTION
## Summary
- add new vendor-specific Modbus TCP model: `abb_m1m_power_meter__modbus`
- integrate model into industrial pack catalog/profile/docs
- add pack unit coverage for model presence
- fix one YAML syntax issue in model mapping (`power_factor_total_raw` key formatting)

## Device Source (official first-party)
- Manufacturer: ABB
- Official product page: https://new.abb.com/low-voltage/products/energy-metering-products/m1m-power-meters
- Direct official Modbus documentation URL: https://search.abb.com/library/Download.aspx?DocumentID=9AKK108467A2704&LanguageCode=en&DocumentPartId=&Action=Launch
- Document version/revision/date: **M1M 96 Modbus Manual V1.3C_EN** (rev `V1.3C`), PDF metadata `CreationDate: 2024-05-28`, `ModDate: 2024-11-11`
- First-party proof: both sources are ABB-owned domains (`new.abb.com`, `search.abb.com` / ABB Library)

## Changed files
- `library/domains/iot/abb/abb_m1m_power_meter__modbus.yaml`
- `library/catalog/models.yaml`
- `profiles/industrial_iiot_pack/process_cell_quickstart.yaml`
- `library/industries/industrial_iiot_pack/README.md`
- `tests/packs/industrial_iiot_pack/unit/test_pack_catalog.py`

## Rationale (register subset and attributes)
- selected essential real-time registers from ABB manual for practical monitoring/simulation value:
  - voltages: `0x5B00..0x5B0C`
  - currents: `0x5B0E..0x5B14`
  - active/reactive/apparent total power: `0x5B1A`, `0x5B22`, `0x5B2A`
  - frequency: `0x5B32`
  - total power factor: `0x5B40`
- used vendor scaling from documentation (0.1 V, 0.01 A, 0.01 power units, 0.01 Hz, 0.001 PF)
- deterministic physics kept minimal and realistic: load-driven voltage sag, power-factor-based power derivation, frequency droop, deterministic phase imbalance
- scenarios include nominal, overload/fault-like, low-PF degraded, and recovery states

## `k__` / `cmd__` decisions
- `k__` used only for primary control inputs affecting behavior:
  - `k__load_kw`
  - `k__power_factor`
  - `k__voltage_nominal_v`
  - `k__frequency_nominal_hz`
- no `cmd__` attributes were needed because model has no trigger/edge command semantics
- derived telemetry and encoded register values intentionally kept without `k__`

## Validation and tests
- `poetry run python tools/validate_models.py` ✅
- `poetry run pytest` ✅ (`65 passed, 110 skipped, 1 warning`)
