### PR TITLE
feat: add Socomec DIRIS A-40 Modbus model

### DIFF
--- a/library/catalog/industries.yaml
+++ b/library/catalog/industries.yaml
@@ -19,6 +19,8 @@ industries:
         instance: spx_hvac_flexit_nordic_bacnet
       - model: Energy.EnergyMeterIem3000.Modbus
         instance: spx_energy_meter_iem3000_modbus
+      - model: Energy.EnergyMeterDirisA40.Modbus
+        instance: spx_energy_meter_diris_a40_modbus
       - model: Weather.WeatherFeed.Http
         instance: spx_weather_feed
       - model: Weather.WeatherGateway.WagoPfc200.VaisalaWxt530.Mqtt

--- a/library/catalog/models.yaml
+++ b/library/catalog/models.yaml
@@ -340,6 +340,15 @@ models:
       - id: modbus_tcp_gateway
     packages: [industrial_iiot_pack]
     profiles: [process_cell_quickstart]
+  - id: Energy.EnergyMeterDirisA40.Modbus
+    name: Socomec DIRIS A-40 Energy Meter (Modbus TCP)
+    path: library/domains/iot/socomec/diris_a40__modbus.yaml
+    domain: iot
+    protocols: [modbus]
+    services:
+      - id: modbus_tcp_gateway
+    packages: [smart_building_pack]
+    profiles: [bms_quickstart]
   - id: Energy.EVSE.Ocpp
     name: EVSE / Charge Point (OCPP 1.6)
     path: library/domains/energy/emobility/evse__ocpp.yaml

--- a/library/catalog/models.yaml
+++ b/library/catalog/models.yaml
@@ -331,6 +331,15 @@ models:
       - id: modbus_tcp_gateway
     packages: [smart_building_pack]
     profiles: [bms_quickstart]
+  - id: Energy.EnergyMeterDirisA40.Modbus
+    name: Socomec DIRIS A-40 Energy Meter (Modbus TCP)
+    path: library/domains/iot/socomec/diris_a40__modbus.yaml
+    domain: iot
+    protocols: [modbus]
+    services:
+      - id: modbus_tcp_gateway
+    packages: [smart_building_pack]
+    profiles: [bms_quickstart]
   - id: Energy.EVSE.Ocpp
     name: EVSE / Charge Point (OCPP 1.6)
     path: library/domains/energy/emobility/evse__ocpp.yaml

--- a/library/domains/iot/socomec/diris_a40__modbus.yaml
+++ b/library/domains/iot/socomec/diris_a40__modbus.yaml
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: MIT
+
+name: diris_a40__modbus
+description: |
+  Minimal Modbus TCP (slave) simulation of the Socomec DIRIS A-40 energy meter.
+  Register mapping follows the DIRIS A-40 Modbus table (v1.7.4):
+    - 264..349: instantaneous metrology (Float32 input registers)
+    - 19843..19847: total active energy import/export (UInt32 input registers)
+
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5026
+  modbus_unit_id:
+    type: int
+    default: 1
+
+attributes:
+  # Phase currents (A)
+  k__current_l1_a: 12.0
+  k__current_l2_a: 10.5
+  k__current_l3_a: 11.2
+  current_avg_a: 0.0
+
+  # Phase-to-neutral voltages (V)
+  k__voltage_l1_n_v: 230.0
+  k__voltage_l2_n_v: 229.5
+  k__voltage_l3_n_v: 231.0
+  voltage_ln_avg_v: 0.0
+
+  # Line-to-line voltages (V) (derived from L-N; suitable for demo dashboards)
+  voltage_l1_l2_v: 0.0
+  voltage_l2_l3_v: 0.0
+  voltage_l3_l1_v: 0.0
+
+  # Power (kW/kVAR/kVA)
+  k__power_factor: 0.95
+  power_factor_leading: 0
+  active_power_l1_kw: 0.0
+  active_power_l2_kw: 0.0
+  active_power_l3_kw: 0.0
+  k__active_power_total_kw: 0.0
+  k__reactive_power_total_kvar: 0.0
+  k__apparent_power_total_kva: 0.0
+
+  # Frequency (Hz)
+  k__frequency_hz: 50.0
+
+  # Cumulative energy (kWh)
+  k__energy_import_total_kwh: 0.0
+  k__energy_export_total_kwh: 0.0
+
+  _modbus_active_power_l1_w: 0.0
+  _modbus_active_power_l2_w: 0.0
+  _modbus_active_power_l3_w: 0.0
+  _modbus_energy_import_total_kwh: 0
+  _modbus_energy_export_total_kwh: 0
+
+  _cycle_time_s: 1.0
+
+actions:
+  - function: $in(current_avg_a)
+    name: compute_current_avg
+    description: Average phase current.
+    call: ($in(k__current_l1_a) + $in(k__current_l2_a) + $in(k__current_l3_a)) / 3.0
+
+  - function: $in(voltage_ln_avg_v)
+    name: compute_voltage_ln_avg
+    description: Average phase-to-neutral voltage.
+    call: ($in(k__voltage_l1_n_v) + $in(k__voltage_l2_n_v) + $in(k__voltage_l3_n_v)) / 3.0
+
+  - function: $in(voltage_l1_l2_v)
+    name: compute_voltage_l1_l2
+    description: Approximate L1-L2 voltage from phase-to-neutral values (balanced phasor assumption).
+    call: 1.7320508075688772 * (($in(k__voltage_l1_n_v) + $in(k__voltage_l2_n_v)) / 2.0)
+
+  - function: $in(voltage_l2_l3_v)
+    name: compute_voltage_l2_l3
+    description: Approximate L2-L3 voltage from phase-to-neutral values (balanced phasor assumption).
+    call: 1.7320508075688772 * (($in(k__voltage_l2_n_v) + $in(k__voltage_l3_n_v)) / 2.0)
+
+  - function: $in(voltage_l3_l1_v)
+    name: compute_voltage_l3_l1
+    description: Approximate L3-L1 voltage from phase-to-neutral values (balanced phasor assumption).
+    call: 1.7320508075688772 * (($in(k__voltage_l3_n_v) + $in(k__voltage_l1_n_v)) / 2.0)
+
+  - function: $in(k__apparent_power_total_kva)
+    name: compute_apparent_power
+    description: Total apparent power (sum of per-phase V*I).
+    call: 1e-3
+         * (
+             $in(k__voltage_l1_n_v) * $in(k__current_l1_a)
+             + $in(k__voltage_l2_n_v) * $in(k__current_l2_a)
+             + $in(k__voltage_l3_n_v) * $in(k__current_l3_a)
+           )
+
+  - function: $in(active_power_l1_kw)
+    name: compute_active_power_l1
+    description: Phase L1 active power.
+    call: 1e-3 * $in(k__power_factor) * $in(k__voltage_l1_n_v) * $in(k__current_l1_a)
+
+  - function: $in(active_power_l2_kw)
+    name: compute_active_power_l2
+    description: Phase L2 active power.
+    call: 1e-3 * $in(k__power_factor) * $in(k__voltage_l2_n_v) * $in(k__current_l2_a)
+
+  - function: $in(active_power_l3_kw)
+    name: compute_active_power_l3
+    description: Phase L3 active power.
+    call: 1e-3 * $in(k__power_factor) * $in(k__voltage_l3_n_v) * $in(k__current_l3_a)
+
+  - function: $in(k__active_power_total_kw)
+    name: compute_active_power_total
+    description: Total active power (sum of per-phase values).
+    call: $in(active_power_l1_kw) + $in(active_power_l2_kw) + $in(active_power_l3_kw)
+
+  - function: $in(k__reactive_power_total_kvar)
+    name: compute_reactive_power_total
+    description: Approximate total reactive power magnitude from active/apparent power.
+    call: (
+          max(0.0, ($in(k__apparent_power_total_kva) ** 2) - ($in(k__active_power_total_kw) ** 2)) ** 0.5
+        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+
+  - function: $in(k__energy_import_total_kwh)
+    name: integrate_energy_import
+    description: Integrate imported energy (kWh) from total active power (kW).
+    call: $in(k__energy_import_total_kwh) + max(0.0, $in(k__active_power_total_kw)) * $in(_cycle_time_s) / 3600.0
+
+  - function: $in(k__energy_export_total_kwh)
+    name: integrate_energy_export
+    description: Integrate exported energy (kWh) from total active power (kW).
+    call: $in(k__energy_export_total_kwh) + max(0.0, -$in(k__active_power_total_kw)) * $in(_cycle_time_s) / 3600.0
+
+  - function: $in(_modbus_active_power_l1_w)
+    name: compute_modbus_active_power_l1
+    description: Convert L1 active power to watts for Modbus registers.
+    call: $in(active_power_l1_kw) * 1000.0
+
+  - function: $in(_modbus_active_power_l2_w)
+    name: compute_modbus_active_power_l2
+    description: Convert L2 active power to watts for Modbus registers.
+    call: $in(active_power_l2_kw) * 1000.0
+
+  - function: $in(_modbus_active_power_l3_w)
+    name: compute_modbus_active_power_l3
+    description: Convert L3 active power to watts for Modbus registers.
+    call: $in(active_power_l3_kw) * 1000.0
+
+  - function: $in(_modbus_energy_import_total_kwh)
+    name: compute_modbus_energy_import
+    description: Round imported energy to integer kWh for Modbus registers.
+    call: int(round(max(0.0, $in(k__energy_import_total_kwh))))
+
+  - function: $in(_modbus_energy_export_total_kwh)
+    name: compute_modbus_energy_export
+    description: Round exported energy to integer kWh for Modbus registers.
+    call: int(round(max(0.0, $in(k__energy_export_total_kwh))))
+
+communication:
+  - modbus_slave:
+      host: 0.0.0.0
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
+      zero_fill: true
+      mapping:
+        # Frequency (Hz) Float32
+        k__frequency_hz:    { address: [264,265], group: i_r, type: float }
+
+        # Line-to-line voltages (V) Float32
+        voltage_l1_l2_v:    { address: [266,267], group: i_r, type: float }
+        voltage_l2_l3_v:    { address: [268,269], group: i_r, type: float }
+        voltage_l3_l1_v:    { address: [270,271], group: i_r, type: float }
+
+        # Phase-to-neutral voltages (V) Float32
+        k__voltage_l1_n_v:  { address: [284,285], group: i_r, type: float }
+        k__voltage_l2_n_v:  { address: [286,287], group: i_r, type: float }
+        k__voltage_l3_n_v:  { address: [288,289], group: i_r, type: float }
+
+        # Currents (A) Float32
+        k__current_l1_a:    { address: [308,309], group: i_r, type: float }
+        k__current_l2_a:    { address: [310,311], group: i_r, type: float }
+        k__current_l3_a:    { address: [312,313], group: i_r, type: float }
+
+        # Active power (W) Float32
+        _modbus_active_power_l1_w: { address: [344,345], group: i_r, type: float }
+        _modbus_active_power_l2_w: { address: [346,347], group: i_r, type: float }
+        _modbus_active_power_l3_w: { address: [348,349], group: i_r, type: float }
+
+        # Energy totals (kWh) UInt32
+        _modbus_energy_import_total_kwh: { address: [19843,19844], group: i_r, type: uint_32 }
+        _modbus_energy_export_total_kwh: { address: [19846,19847], group: i_r, type: uint_32 }
+
+scenarios:
+  peak_demand:
+    description: High load with balanced phases and near-unity power factor.
+    duration: 30.0
+    overrides:
+      $in(k__current_l1_a): 45.0
+      $in(k__current_l2_a): 44.0
+      $in(k__current_l3_a): 46.0
+      $in(k__power_factor): 0.98
+      $in(power_factor_leading): 0
+
+  pv_export:
+    description: Simulated PV export using negative phase currents.
+    duration: 30.0
+    overrides:
+      $in(k__current_l1_a): -8.0
+      $in(k__current_l2_a): -7.5
+      $in(k__current_l3_a): -7.8
+      $in(k__power_factor): 0.99
+      $in(power_factor_leading): 1
+
+  low_power_factor_lagging:
+    description: Inductive load with low power factor.
+    duration: 45.0
+    overrides:
+      $in(k__power_factor): 0.65
+      $in(power_factor_leading): 0
+
+  voltage_sag:
+    description: Phase-to-neutral voltage sag across all phases.
+    duration: 30.0
+    overrides:
+      $in(k__voltage_l1_n_v): 205.0
+      $in(k__voltage_l2_n_v): 208.0
+      $in(k__voltage_l3_n_v): 210.0
+
+  frequency_drift:
+    description: Off-nominal grid frequency condition.
+    duration: 20.0
+    overrides:
+      $in(k__frequency_hz): 49.2

--- a/library/industries/smart_building_pack/README.md
+++ b/library/industries/smart_building_pack/README.md
@@ -17,6 +17,7 @@ to validate multi-protocol integrations, test gateways, or build demo dashboards
   - Flexit Nordic HVAC (BACnet): `library/domains/iot/generic/hvac_flexit_nordic__bacnet.yaml`
   - Thermal controller (Modbus): `library/domains/thermal_controllers/generic/thermal_controller__modbus.yaml`
   - Energy meter iEM3000 (Modbus): `library/domains/iot/generic/energy_meter_iem3000__modbus.yaml`
+  - Energy meter DIRIS A-40 (Modbus): `library/domains/iot/socomec/diris_a40__modbus.yaml`
 - Lighting
   - Lighting panel (OPC UA): `library/domains/iot/generic/lighting_panel__opcua.yaml`
   - Lighting zone (KNX): `library/domains/iot/generic/lighting_zone__knx.yaml`

--- a/profiles/smart_building_pack/bms_quickstart.yaml
+++ b/profiles/smart_building_pack/bms_quickstart.yaml
@@ -9,6 +9,7 @@ models:
   - library/domains/thermal_controllers/generic/thermal_controller__modbus.yaml
   - library/domains/iot/generic/hvac_flexit_nordic__bacnet.yaml
   - library/domains/iot/generic/energy_meter_iem3000__modbus.yaml
+  - library/domains/iot/socomec/diris_a40__modbus.yaml
   - library/domains/weather/weather_forecast__http.yaml
   - library/domains/weather/weather_gateway_wago_pfc200__vaisala_wxt530__mqtt.yaml
   - library/domains/iot/generic/bms_controller__opcua.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "spx-examples"
-version = "1.1.0-rc.1"
+version = "1.1.0-alpha.3"
 description = "Runnable SPX examples and smoke tests using the Python client against SPX Server."
 authors = ["Aleksander Stanik <aleksander.stanik@hammerheadsengineers.com>"]
 license = "MIT"

--- a/tests/packs/smart_building_pack/integration/test_modbus_diris_a40_smoke.py
+++ b/tests/packs/smart_building_pack/integration/test_modbus_diris_a40_smoke.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import os
+import unittest
+from typing import Sequence
+
+from tests.common.modbus_utils import wait_for_modbus_endpoint
+from tests.common.spx_utils import require_existing_instance, wait_seconds
+from tests.devices.modbus_sut_base import ModbusTcpClient, ModbusSUTBase
+
+SPX_BASE_URL = os.environ.get("SPX_BASE_URL", "http://localhost:8000")
+INSTANCE_KEY = "spx_energy_meter_diris_a40_modbus"
+MODEL_ID = "Energy.EnergyMeterDirisA40.Modbus"
+
+
+def _read_input_registers(client, address: int, count: int, unit_id: int) -> Sequence[int]:
+    try:
+        result = client.read_input_registers(address, count=count, slave=unit_id)
+    except TypeError:
+        result = client.read_input_registers(address, count=count, unit=unit_id)
+    if result is None:
+        raise RuntimeError(f"Modbus read returned no response at address {address}")
+    if result.isError():
+        raise RuntimeError(f"Modbus read failed at address {address}")
+    return result.registers
+
+
+def _decode_float(registers: Sequence[int]) -> float:
+    return float(ModbusSUTBase.modbus_to_float(registers, "ABCD"))
+
+
+def _decode_u32(registers: Sequence[int]) -> int:
+    return int((int(registers[0]) << 16) | int(registers[1]))
+
+
+def _attr_float(attributes, name: str) -> float:
+    value = attributes[name].internal_value
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(value or 0.0)
+
+
+class TestModbusDirisA40Smoke(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if ModbusTcpClient is None:  # pragma: no cover - dependency missing
+            raise unittest.SkipTest(
+                "pymodbus is not available. Install pymodbus to run Modbus integration tests."
+            )
+
+        try:
+            import spx_python  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise unittest.SkipTest(f"spx_python not available: {exc}") from exc
+
+        product_key = os.environ.get("SPX_PRODUCT_KEY")
+        if not product_key:
+            raise unittest.SkipTest("SPX_PRODUCT_KEY must be set to run integration tests.")
+
+        cls._client = spx_python.init(address=SPX_BASE_URL, product_key=product_key)
+        cls._instance = require_existing_instance(
+            cls._client,
+            INSTANCE_KEY,
+            expected_model_id=MODEL_ID,
+            ensure_running=False,
+        )
+        try:
+            cls._instance.stop()
+        except Exception:
+            pass
+        try:
+            cls._instance.reset()
+        except Exception:
+            pass
+        try:
+            cls._instance.start()
+        except Exception:
+            pass
+
+    def setUp(self):
+        instance = getattr(self.__class__, "_instance", None)
+        if instance is None:  # pragma: no cover - defensive
+            self.skipTest("DIRIS A-40 instance not initialised")
+        self._instance = instance
+
+        wait_seconds(0.2)
+
+        try:
+            port, unit_id = wait_for_modbus_endpoint(instance, timeout=10.0, interval=0.2)
+        except TimeoutError as exc:
+            self.skipTest(str(exc))
+
+        self._modbus_port = port
+        self._modbus_unit_id = unit_id
+
+        self._client = ModbusTcpClient(host="127.0.0.1", port=port)
+        if not self._client.connect():
+            self.skipTest(f"Modbus server not reachable at 127.0.0.1:{port}")
+
+    def tearDown(self):
+        client = getattr(self, "_client", None)
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                pass
+
+    def test_instantaneous_registers_match_model(self):
+        attrs = self._instance["attributes"]
+
+        freq_regs = _read_input_registers(self._client, 264, 2, self._modbus_unit_id)
+        freq_hz = _decode_float(freq_regs)
+        self.assertAlmostEqual(freq_hz, _attr_float(attrs, "k__frequency_hz"), delta=0.5)
+
+        v1_regs = _read_input_registers(self._client, 284, 2, self._modbus_unit_id)
+        v1 = _decode_float(v1_regs)
+        self.assertAlmostEqual(v1, _attr_float(attrs, "k__voltage_l1_n_v"), delta=1.0)
+
+        i1_regs = _read_input_registers(self._client, 308, 2, self._modbus_unit_id)
+        i1 = _decode_float(i1_regs)
+        self.assertAlmostEqual(i1, _attr_float(attrs, "k__current_l1_a"), delta=0.5)
+
+        p1_regs = _read_input_registers(self._client, 344, 2, self._modbus_unit_id)
+        p1_w = _decode_float(p1_regs)
+        expected_p1_w = _attr_float(attrs, "active_power_l1_kw") * 1000.0
+        self.assertAlmostEqual(p1_w, expected_p1_w, delta=200.0)
+
+    def test_energy_registers_match_model(self):
+        attrs = self._instance["attributes"]
+
+        import_regs = _read_input_registers(self._client, 19843, 2, self._modbus_unit_id)
+        export_regs = _read_input_registers(self._client, 19846, 2, self._modbus_unit_id)
+        import_kwh = _decode_u32(import_regs)
+        export_kwh = _decode_u32(export_regs)
+
+        expected_import = int(round(max(0.0, _attr_float(attrs, "k__energy_import_total_kwh"))))
+        expected_export = int(round(max(0.0, _attr_float(attrs, "k__energy_export_total_kwh"))))
+
+        self.assertLessEqual(abs(import_kwh - expected_import), 1)
+        self.assertLessEqual(abs(export_kwh - expected_export), 1)


### PR DESCRIPTION
## Summary
- add new Modbus TCP model: `diris_a40__modbus` (Socomec DIRIS A-40)
- integrate model into smart building pack catalogs/profile/default instances/docs
- add runtime smoke integration test for Modbus register reachability and value parity

## Files
- `library/domains/iot/socomec/diris_a40__modbus.yaml`
- `library/catalog/models.yaml`
- `library/catalog/industries.yaml`
- `profiles/smart_building_pack/bms_quickstart.yaml`
- `library/industries/smart_building_pack/README.md`
- `tests/packs/smart_building_pack/integration/test_modbus_diris_a40_smoke.py`

## Validation
- `python tools/validate_models.py` ✅
- `pytest` ✅ (64 passed, 112 skipped)
- CI (branch head `d8ef512`) ✅

## Sources (first-party)
- Product page: https://www.socomec.us/low-voltage-network-monitoring/energy-meter-dirisa40
- Modbus communication table (DIRIS A-40): https://www.socomec.us/sites/default/files/2022-07/Communication-table-DIRIS-A40_MODBUS_TABLES_2022-01_CMT_EN.html
