### PR TITLE
feat: add Siemens PAC3200 Modbus model

### DIFF
--- a/library/catalog/industries.yaml
+++ b/library/catalog/industries.yaml
@@ -19,6 +19,8 @@ industries:
         instance: spx_hvac_flexit_nordic_bacnet
       - model: Energy.EnergyMeterIem3000.Modbus
         instance: spx_energy_meter_iem3000_modbus
+      - model: Energy.EnergyMeterPac3200.Modbus
+        instance: spx_energy_meter_pac3200_modbus
       - model: Weather.WeatherFeed.Http
         instance: spx_weather_feed
       - model: Weather.WeatherGateway.WagoPfc200.VaisalaWxt530.Mqtt

--- a/library/catalog/models.yaml
+++ b/library/catalog/models.yaml
@@ -331,6 +331,15 @@ models:
       - id: modbus_tcp_gateway
     packages: [smart_building_pack]
     profiles: [bms_quickstart]
+  - id: Energy.EnergyMeterPac3200.Modbus
+    name: Siemens SENTRON PAC3200 Power Meter (Modbus)
+    path: library/domains/iot/siemens/siemens_pac3200__modbus.yaml
+    domain: iot
+    protocols: [modbus]
+    services:
+      - id: modbus_tcp_gateway
+    packages: [smart_building_pack]
+    profiles: [bms_quickstart]
   - id: Energy.PowerMeter.AbbM1M.Modbus
     name: ABB M1M Power Meter (Modbus TCP)
     path: library/domains/iot/abb/abb_m1m_power_meter__modbus.yaml

--- a/library/domains/iot/siemens/siemens_pac3200__modbus.yaml
+++ b/library/domains/iot/siemens/siemens_pac3200__modbus.yaml
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: MIT
+
+name: siemens_pac3200__modbus
+description: |
+  Minimal Modbus TCP (slave) simulation of the Siemens SENTRON PAC3200 power meter.
+  Register mapping follows the PAC3200 measured-variable table (Float32) for voltages,
+  currents, frequency, total power and power factor. Energy counters are simulated
+  internally but not exposed via Modbus because the PAC3200 uses 64-bit registers for
+  energy totals.
+
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5026
+  modbus_unit_id:
+    type: int
+    default: 1
+
+attributes:
+  # Phase currents (A)
+  k__current_l1_a: 12.0
+  k__current_l2_a: 10.5
+  k__current_l3_a: 11.2
+  current_avg_a: 0.0
+
+  # Phase-to-neutral voltages (V)
+  k__voltage_l1_n_v: 230.0
+  k__voltage_l2_n_v: 229.5
+  k__voltage_l3_n_v: 231.0
+  voltage_ln_avg_v: 0.0
+
+  # Line-to-line voltages (V)
+  voltage_l1_l2_v: 0.0
+  voltage_l2_l3_v: 0.0
+  voltage_l3_l1_v: 0.0
+  voltage_ll_avg_v: 0.0
+
+  # Power
+  k__power_factor: 0.95
+  power_factor_leading: 0
+  power_factor_l1: 0.0
+  power_factor_l2: 0.0
+  power_factor_l3: 0.0
+  apparent_power_l1_va: 0.0
+  apparent_power_l2_va: 0.0
+  apparent_power_l3_va: 0.0
+  active_power_l1_w: 0.0
+  active_power_l2_w: 0.0
+  active_power_l3_w: 0.0
+  reactive_power_l1_var: 0.0
+  reactive_power_l2_var: 0.0
+  reactive_power_l3_var: 0.0
+  active_power_total_w: 0.0
+  reactive_power_total_var: 0.0
+  apparent_power_total_va: 0.0
+
+  # Frequency (Hz)
+  k__frequency_hz: 50.0
+
+  # Cumulative energy (Wh)
+  energy_import_total_wh: 0.0
+  energy_export_total_wh: 0.0
+
+  _cycle_time_s: 1.0
+
+actions:
+  - function: $in(current_avg_a)
+    name: compute_current_avg
+    description: Average phase current.
+    call: ($in(k__current_l1_a) + $in(k__current_l2_a) + $in(k__current_l3_a)) / 3.0
+
+  - function: $in(voltage_ln_avg_v)
+    name: compute_voltage_ln_avg
+    description: Average phase-to-neutral voltage.
+    call: ($in(k__voltage_l1_n_v) + $in(k__voltage_l2_n_v) + $in(k__voltage_l3_n_v)) / 3.0
+
+  - function: $in(voltage_l1_l2_v)
+    name: compute_voltage_l1_l2
+    description: Approximate L1-L2 voltage from phase-to-neutral values (balanced phasor assumption).
+    call: 1.7320508075688772 * (($in(k__voltage_l1_n_v) + $in(k__voltage_l2_n_v)) / 2.0)
+
+  - function: $in(voltage_l2_l3_v)
+    name: compute_voltage_l2_l3
+    description: Approximate L2-L3 voltage from phase-to-neutral values (balanced phasor assumption).
+    call: 1.7320508075688772 * (($in(k__voltage_l2_n_v) + $in(k__voltage_l3_n_v)) / 2.0)
+
+  - function: $in(voltage_l3_l1_v)
+    name: compute_voltage_l3_l1
+    description: Approximate L3-L1 voltage from phase-to-neutral values (balanced phasor assumption).
+    call: 1.7320508075688772 * (($in(k__voltage_l3_n_v) + $in(k__voltage_l1_n_v)) / 2.0)
+
+  - function: $in(voltage_ll_avg_v)
+    name: compute_voltage_ll_avg
+    description: Average line-to-line voltage.
+    call: ($in(voltage_l1_l2_v) + $in(voltage_l2_l3_v) + $in(voltage_l3_l1_v)) / 3.0
+
+  - function: $in(power_factor_l1)
+    name: compute_power_factor_l1
+    description: Phase L1 power factor.
+    call: $in(k__power_factor)
+
+  - function: $in(power_factor_l2)
+    name: compute_power_factor_l2
+    description: Phase L2 power factor.
+    call: $in(k__power_factor)
+
+  - function: $in(power_factor_l3)
+    name: compute_power_factor_l3
+    description: Phase L3 power factor.
+    call: $in(k__power_factor)
+
+  - function: $in(apparent_power_l1_va)
+    name: compute_apparent_power_l1
+    description: Phase L1 apparent power.
+    call: $in(k__voltage_l1_n_v) * $in(k__current_l1_a)
+
+  - function: $in(apparent_power_l2_va)
+    name: compute_apparent_power_l2
+    description: Phase L2 apparent power.
+    call: $in(k__voltage_l2_n_v) * $in(k__current_l2_a)
+
+  - function: $in(apparent_power_l3_va)
+    name: compute_apparent_power_l3
+    description: Phase L3 apparent power.
+    call: $in(k__voltage_l3_n_v) * $in(k__current_l3_a)
+
+  - function: $in(active_power_l1_w)
+    name: compute_active_power_l1
+    description: Phase L1 active power.
+    call: $in(power_factor_l1) * $in(apparent_power_l1_va)
+
+  - function: $in(active_power_l2_w)
+    name: compute_active_power_l2
+    description: Phase L2 active power.
+    call: $in(power_factor_l2) * $in(apparent_power_l2_va)
+
+  - function: $in(active_power_l3_w)
+    name: compute_active_power_l3
+    description: Phase L3 active power.
+    call: $in(power_factor_l3) * $in(apparent_power_l3_va)
+
+  - function: $in(reactive_power_l1_var)
+    name: compute_reactive_power_l1
+    description: Phase L1 reactive power.
+    call: (
+          max(0.0, ($in(apparent_power_l1_va) ** 2) - ($in(active_power_l1_w) ** 2)) ** 0.5
+        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+
+  - function: $in(reactive_power_l2_var)
+    name: compute_reactive_power_l2
+    description: Phase L2 reactive power.
+    call: (
+          max(0.0, ($in(apparent_power_l2_va) ** 2) - ($in(active_power_l2_w) ** 2)) ** 0.5
+        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+
+  - function: $in(reactive_power_l3_var)
+    name: compute_reactive_power_l3
+    description: Phase L3 reactive power.
+    call: (
+          max(0.0, ($in(apparent_power_l3_va) ** 2) - ($in(active_power_l3_w) ** 2)) ** 0.5
+        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+
+  - function: $in(apparent_power_total_va)
+    name: compute_apparent_power_total
+    description: Total apparent power (sum of per-phase values).
+    call: $in(apparent_power_l1_va) + $in(apparent_power_l2_va) + $in(apparent_power_l3_va)
+
+  - function: $in(active_power_total_w)
+    name: compute_active_power_total
+    description: Total active power (sum of per-phase values).
+    call: $in(active_power_l1_w) + $in(active_power_l2_w) + $in(active_power_l3_w)
+
+  - function: $in(reactive_power_total_var)
+    name: compute_reactive_power_total
+    description: Total reactive power (sum of per-phase values).
+    call: $in(reactive_power_l1_var) + $in(reactive_power_l2_var) + $in(reactive_power_l3_var)
+
+  - function: $in(energy_import_total_wh)
+    name: integrate_energy_import
+    description: Integrate imported energy (Wh) from total active power (W).
+    call: $in(energy_import_total_wh) + max(0.0, $in(active_power_total_w)) * $in(_cycle_time_s) / 3600.0
+
+  - function: $in(energy_export_total_wh)
+    name: integrate_energy_export
+    description: Integrate exported energy (Wh) from total active power (W).
+    call: $in(energy_export_total_wh) + max(0.0, -$in(active_power_total_w)) * $in(_cycle_time_s) / 3600.0
+
+communication:
+  - modbus_slave:
+      host: 0.0.0.0
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
+      zero_fill: true
+      mapping:
+        # Voltages (V) Float32
+        k__voltage_l1_n_v:   { address: [1,2], group: h_r, type: float }
+        k__voltage_l2_n_v:   { address: [3,4], group: h_r, type: float }
+        k__voltage_l3_n_v:   { address: [5,6], group: h_r, type: float }
+        voltage_l1_l2_v:     { address: [7,8], group: h_r, type: float }
+        voltage_l2_l3_v:     { address: [9,10], group: h_r, type: float }
+        voltage_l3_l1_v:     { address: [11,12], group: h_r, type: float }
+        voltage_ln_avg_v:    { address: [57,58], group: h_r, type: float }
+        voltage_ll_avg_v:    { address: [59,60], group: h_r, type: float }
+
+        # Currents (A) Float32
+        k__current_l1_a:     { address: [13,14], group: h_r, type: float }
+        k__current_l2_a:     { address: [15,16], group: h_r, type: float }
+        k__current_l3_a:     { address: [17,18], group: h_r, type: float }
+        current_avg_a:       { address: [61,62], group: h_r, type: float }
+
+        # Frequency (Hz) Float32
+        k__frequency_hz:     { address: [55,56], group: h_r, type: float }
+
+        # Power (W/var/VA) Float32
+        apparent_power_l1_va:    { address: [19,20], group: h_r, type: float }
+        apparent_power_l2_va:    { address: [21,22], group: h_r, type: float }
+        apparent_power_l3_va:    { address: [23,24], group: h_r, type: float }
+        active_power_l1_w:       { address: [25,26], group: h_r, type: float }
+        active_power_l2_w:       { address: [27,28], group: h_r, type: float }
+        active_power_l3_w:       { address: [29,30], group: h_r, type: float }
+        reactive_power_l1_var:   { address: [31,32], group: h_r, type: float }
+        reactive_power_l2_var:   { address: [33,34], group: h_r, type: float }
+        reactive_power_l3_var:   { address: [35,36], group: h_r, type: float }
+        power_factor_l1:         { address: [37,38], group: h_r, type: float }
+        power_factor_l2:         { address: [39,40], group: h_r, type: float }
+        power_factor_l3:         { address: [41,42], group: h_r, type: float }
+        apparent_power_total_va: { address: [63,64], group: h_r, type: float }
+        active_power_total_w:    { address: [65,66], group: h_r, type: float }
+        reactive_power_total_var: { address: [67,68], group: h_r, type: float }
+        k__power_factor:         { address: [69,70], group: h_r, type: float }
+
+scenarios:
+  peak_demand:
+    description: High load with balanced phases and near-unity power factor.
+    duration: 30.0
+    overrides:
+      $in(k__current_l1_a): 45.0
+      $in(k__current_l2_a): 44.0
+      $in(k__current_l3_a): 46.0
+      $in(k__power_factor): 0.98
+      $in(power_factor_leading): 0
+
+  pv_export:
+    description: Simulated PV export using negative phase currents.
+    duration: 30.0
+    overrides:
+      $in(k__current_l1_a): -8.0
+      $in(k__current_l2_a): -7.5
+      $in(k__current_l3_a): -7.8
+      $in(k__power_factor): 0.99
+      $in(power_factor_leading): 1
+
+  low_power_factor_lagging:
+    description: Inductive load with low power factor.
+    duration: 45.0
+    overrides:
+      $in(k__power_factor): 0.65
+      $in(power_factor_leading): 0
+
+  voltage_sag:
+    description: Phase-to-neutral voltage sag across all phases.
+    duration: 30.0
+    overrides:
+      $in(k__voltage_l1_n_v): 205.0
+      $in(k__voltage_l2_n_v): 208.0
+      $in(k__voltage_l3_n_v): 210.0
+
+  frequency_drift:
+    description: Off-nominal grid frequency condition.
+    duration: 20.0
+    overrides:
+      $in(k__frequency_hz): 49.2

--- a/library/domains/iot/siemens/siemens_pac3200__modbus.yaml
+++ b/library/domains/iot/siemens/siemens_pac3200__modbus.yaml
@@ -4,9 +4,8 @@ name: siemens_pac3200__modbus
 description: |
   Minimal Modbus TCP (slave) simulation of the Siemens SENTRON PAC3200 power meter.
   Register mapping follows the PAC3200 measured-variable table (Float32) for voltages,
-  currents, frequency, total power and power factor. Energy counters are simulated
-  internally but not exposed via Modbus because the PAC3200 uses 64-bit registers for
-  energy totals.
+  currents, frequency, and power values. Energy counters are simulated internally but
+  not exposed via Modbus in this minimal model.
 
 meta_parameters:
   modbus_port:

--- a/library/industries/smart_building_pack/README.md
+++ b/library/industries/smart_building_pack/README.md
@@ -17,6 +17,7 @@ to validate multi-protocol integrations, test gateways, or build demo dashboards
   - Flexit Nordic HVAC (BACnet): `library/domains/iot/generic/hvac_flexit_nordic__bacnet.yaml`
   - Thermal controller (Modbus): `library/domains/thermal_controllers/generic/thermal_controller__modbus.yaml`
   - Energy meter iEM3000 (Modbus): `library/domains/iot/generic/energy_meter_iem3000__modbus.yaml`
+  - Siemens PAC3200 power meter (Modbus): `library/domains/iot/siemens/siemens_pac3200__modbus.yaml`
 - Lighting
   - Lighting panel (OPC UA): `library/domains/iot/generic/lighting_panel__opcua.yaml`
   - Lighting zone (KNX): `library/domains/iot/generic/lighting_zone__knx.yaml`

--- a/profiles/smart_building_pack/bms_quickstart.yaml
+++ b/profiles/smart_building_pack/bms_quickstart.yaml
@@ -9,6 +9,7 @@ models:
   - library/domains/thermal_controllers/generic/thermal_controller__modbus.yaml
   - library/domains/iot/generic/hvac_flexit_nordic__bacnet.yaml
   - library/domains/iot/generic/energy_meter_iem3000__modbus.yaml
+  - library/domains/iot/siemens/siemens_pac3200__modbus.yaml
   - library/domains/weather/weather_forecast__http.yaml
   - library/domains/weather/weather_gateway_wago_pfc200__vaisala_wxt530__mqtt.yaml
   - library/domains/iot/generic/bms_controller__opcua.yaml

--- a/tests/packs/smart_building_pack/integration/test_modbus_pac3200_smoke.py
+++ b/tests/packs/smart_building_pack/integration/test_modbus_pac3200_smoke.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MIT
+
+import os
+import struct
+import unittest
+
+from tests.common.modbus_utils import wait_for_modbus_endpoint
+from tests.common.spx_utils import require_existing_instance, wait_for_condition
+from tests.devices.modbus_sut_base import ModbusTcpClient
+
+
+SPX_BASE_URL = os.environ.get("SPX_BASE_URL", "http://localhost:8000")
+INSTANCE_KEY = "spx_energy_meter_pac3200_modbus"
+MODEL_ID = "Energy.EnergyMeterPac3200.Modbus"
+
+
+def _decode_float(registers):
+    if not registers or len(registers) != 2:
+        raise ValueError(f"Expected 2 registers, got {registers}")
+    packed = struct.pack(">HH", int(registers[0]) & 0xFFFF, int(registers[1]) & 0xFFFF
+    )
+    return struct.unpack(">f", packed)[0]
+
+
+class TestModbusPac3200Smoke(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if ModbusTcpClient is None:  # pragma: no cover - dependency missing
+            raise unittest.SkipTest(
+                "pymodbus is not available. Install pymodbus to run Modbus integration tests."
+            )
+
+        try:
+            import spx_python  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise unittest.SkipTest(f"spx_python not available: {exc}") from exc
+
+        product_key = os.environ.get("SPX_PRODUCT_KEY")
+        if not product_key:
+            raise unittest.SkipTest("SPX_PRODUCT_KEY must be set to run integration tests.")
+
+        cls._client = spx_python.init(address=SPX_BASE_URL, product_key=product_key)
+        cls._instance = require_existing_instance(
+            cls._client,
+            INSTANCE_KEY,
+            expected_model_id=MODEL_ID,
+            ensure_running=False,
+        )
+
+        cls._model_changed = False
+        try:
+            cls._instance.stop()
+        except Exception:
+            pass
+        try:
+            cls._instance.reset()
+        except Exception:
+            pass
+        try:
+            cls._instance.start()
+        except Exception:
+            pass
+
+    def setUp(self):
+        instance = getattr(self.__class__, "_instance", None)
+        if instance is None:  # pragma: no cover - defensive
+            self.skipTest("PAC3200 instance not initialised")
+
+        comms = instance["communication"]
+        preferred_comm_key = "modbus_slave" if "modbus_slave" in comms else "modbus_tcp"
+        try:
+            self._modbus_port, self._modbus_unit_id = wait_for_modbus_endpoint(
+                instance,
+                comm_keys=(
+                    preferred_comm_key,
+                    "modbus_slave" if preferred_comm_key == "modbus_tcp" else "modbus_tcp",
+                ),
+                timeout=10.0,
+                interval=0.2,
+            )
+        except TimeoutError as exc:
+            self.skipTest(str(exc))
+
+    def _read_float(self, client, address: int) -> float:
+        try:
+            result = client.read_holding_registers(address, count=2, slave=self._modbus_unit_id)
+        except TypeError:
+            result = client.read_holding_registers(address, count=2, unit=self._modbus_unit_id)
+        if result is None:
+            raise RuntimeError(f"No response at address {address}")
+        if result.isError():  # pragma: no cover - delegated to pymodbus
+            raise RuntimeError(f"Modbus read failed at address {address}")
+        return float(_decode_float(result.registers))
+
+    def test_pac3200_registers_are_readable(self):
+        client = ModbusTcpClient(host="127.0.0.1", port=self._modbus_port)
+        try:
+            ready = wait_for_condition(client.connect, timeout=5.0, interval=0.2)
+            if not ready:
+                self.skipTest(f"Modbus server not reachable at 127.0.0.1:{self._modbus_port}")
+
+            voltage_l1 = self._read_float(client, 1)
+            current_l1 = self._read_float(client, 13)
+            frequency = self._read_float(client, 55)
+            power_factor = self._read_float(client, 69)
+            apparent_power = self._read_float(client, 63)
+            active_power = self._read_float(client, 65)
+
+            self.assertGreater(voltage_l1, 150.0)
+            self.assertLess(voltage_l1, 270.0)
+            self.assertGreater(current_l1, -200.0)
+            self.assertLess(current_l1, 200.0)
+            self.assertGreater(frequency, 45.0)
+            self.assertLess(frequency, 65.0)
+            self.assertGreater(power_factor, -1.1)
+            self.assertLess(power_factor, 1.1)
+
+            expected_power = power_factor * apparent_power
+            self.assertAlmostEqual(active_power, expected_power, delta=max(50.0, abs(expected_power) * 0.2))
+        finally:
+            client.close()


### PR DESCRIPTION
## Summary\n- add Siemens SENTRON PAC3200 Modbus TCP model with realistic power-meter simulation\n- register model in catalogs and smart_building_pack profile/default instances\n- add smart_building_pack Modbus smoke integration test for PAC3200\n\n## Validation\n- poetry run python tools/validate_models.py\n- poetry run pytest\n\n## Source docs (first-party)\n- Siemens product page: https://mall.industry.siemens.com/mall/en/WW/Catalog/Product/7KM2112-0BA00-3AA0\n- Siemens PAC3200 Modbus docs: https://support.industry.siemens.com/cs/document/109739487/