### PR TITLE
Add Prevac M600DC-PS Modbus model

### DIFF
--- a/library/catalog/industries.yaml
+++ b/library/catalog/industries.yaml
@@ -89,6 +89,8 @@ industries:
         instance: spx_env_sensor_lwm2m
       - model: Lab.Multimeter.Scpi
         instance: spx_lab_multimeter
+      - model: Lab.MagnetronPowerSupply.PrevacM600DCPS.Modbus
+        instance: spx_prevac_m600dc_ps
       - model: Process.VacuumGauge.Modbus
         instance: spx_vacuum_gauge
       - model: Process.VacuumGaugeMultichannel.Modbus

--- a/library/catalog/models.yaml
+++ b/library/catalog/models.yaml
@@ -214,6 +214,15 @@ models:
       - id: modbus_tcp_gateway
     packages: [embedded_lab_pack, industrial_iiot_pack]
     profiles: []
+  - id: Lab.MagnetronPowerSupply.PrevacM600DCPS.Modbus
+    name: Prevac M600DC-PS Magnetron Power Supply (Modbus TCP)
+    path: library/domains/iot/prevac/prevac_m600dc_ps__modbus.yaml
+    domain: iot
+    protocols: [modbus]
+    services:
+      - id: modbus_tcp_gateway
+    packages: [embedded_lab_pack]
+    profiles: [scpi_lab]
   - id: Lab.Multimeter.Scpi
     name: SCPI Multimeter
     path: library/domains/measurement_instruments/generic/multimeter__scpi.yaml

--- a/library/domains/iot/prevac/prevac_m600dc_ps__modbus.yaml
+++ b/library/domains/iot/prevac/prevac_m600dc_ps__modbus.yaml
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: MIT
+
+name: prevac_m600dc_ps__modbus
+description: |
+  Prevac M600DC-PS magnetron power supply with Modbus TCP register map.
+  The mapping follows the user manual register table (rev. 03 / 1.4.4),
+  exposing key measurements, setpoints, and control commands.
+
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 502
+  modbus_unit_id:
+    type: int
+    default: 1
+
+attributes:
+  device_state: 0
+  status_word_1: 0
+  status_word_2: 0
+  switch_to_operate_allowed: 17
+
+  magnetron_power_w: 0.0
+  magnetron_voltage_v: 0.0
+  magnetron_current_ma: 0.0
+  arc_value: 0
+  thickness_nm: 0.0
+  rate_nm_s: 0.0
+  flow_sccm: 0.0
+
+  cmd__go_to_operate: 0
+  cmd__go_to_standby: 0
+
+  k__power_set_w: 100.0
+  k__voltage_set_v: 500.0
+  k__current_set_ma: 100.0
+  k__flow_set_sccm: 10.0
+
+  cmd__shutter_1_open: 0
+  cmd__shutter_1_close: 0
+  cmd__shutter_2_open: 0
+  cmd__shutter_2_close: 0
+  cmd__shutter_3_open: 0
+  cmd__shutter_3_close: 0
+
+  cmd__valve_open: 0
+  cmd__valve_close: 0
+  cmd__clear_thickness: 0
+
+  k__power_limit_output_1_w: 600
+  k__power_limit_output_2_w: 600
+  k__power_limit_output_3_w: 600
+  k__voltage_limit_output_1_v: 1200
+  k__voltage_limit_output_2_v: 1200
+  k__voltage_limit_output_3_v: 1200
+  k__current_limit_output_1_ma: 1200
+  k__current_limit_output_2_ma: 1200
+  k__current_limit_output_3_ma: 1200
+
+  k__power_ramp_w_s: 200
+  k__voltage_ramp_v_s: 200
+  k__current_ramp_ma_s: 200
+
+  k__vacuum_interlock_mode: 0
+  k__arc_detect_enabled: 1
+  k__arc_detect_time_us: 50
+  k__arc_off_time_ms: 100
+  k__arc_limit_enabled: 0
+  k__arc_limit_value: 1000
+
+  k__shutter_control_internal: 1
+  k__shutter_1_mode: 1
+  k__shutter_1_thickness_setpoint_nm: 0.0
+  k__shutter_1_time_setpoint_s: 0
+  shutter_1_remaining_time_s: 0
+  k__shutter_2_mode: 1
+  k__shutter_2_thickness_setpoint_nm: 0.0
+  k__shutter_2_time_setpoint_s: 0
+  shutter_2_remaining_time_s: 0
+  k__shutter_3_mode: 1
+  k__shutter_3_thickness_setpoint_nm: 0.0
+  k__shutter_3_time_setpoint_s: 0
+  shutter_3_remaining_time_s: 0
+
+  k__flow_sensor_enabled: 1
+  k__flow_sensor_range: 3
+  flow_controller_temp_raw: 0
+  flow_controller_drive_level_raw: 0
+  k__parallel_mode_enabled: 0
+  extension_module_count: 0
+
+  output_1_work_time_s: 0
+  output_2_work_time_s: 0
+  output_3_work_time_s: 0
+  k__active_output: 1
+  active_output: 1
+  k__timer_direction: 1
+  operate_time_s: 0
+  k__operate_time_setpoint_s: 0
+
+communication:
+  - modbus_slave:
+      host: 0.0.0.0
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
+      zero_fill: true
+      mapping:
+        device_state: { address: [0,0], group: h_r, type: uint_16 }
+        status_word_1: { address: [1,1], group: h_r, type: uint_16 }
+        status_word_2: { address: [2,2], group: h_r, type: uint_16 }
+        switch_to_operate_allowed: { address: [3,3], group: h_r, type: uint_16 }
+
+        magnetron_power_w: { address: [4,5], group: h_r, type: float }
+        magnetron_voltage_v: { address: [6,7], group: h_r, type: float }
+        magnetron_current_ma: { address: [8,9], group: h_r, type: float }
+        arc_value: { address: [10,10], group: h_r, type: uint_16 }
+        thickness_nm: { address: [11,12], group: h_r, type: float }
+        rate_nm_s: { address: [13,14], group: h_r, type: float }
+        flow_sccm: { address: [15,16], group: h_r, type: float }
+
+        cmd__go_to_operate: { address: [17,17], group: h_r, type: uint_16 }
+        cmd__go_to_standby: { address: [18,18], group: h_r, type: uint_16 }
+
+        k__power_set_w: { address: [19,20], group: h_r, type: float }
+        k__voltage_set_v: { address: [21,22], group: h_r, type: float }
+        k__current_set_ma: { address: [23,24], group: h_r, type: float }
+        k__flow_set_sccm: { address: [25,26], group: h_r, type: float }
+
+        cmd__shutter_1_open: { address: [27,27], group: h_r, type: uint_16 }
+        cmd__shutter_1_close: { address: [28,28], group: h_r, type: uint_16 }
+        cmd__shutter_2_open: { address: [29,29], group: h_r, type: uint_16 }
+        cmd__shutter_2_close: { address: [30,30], group: h_r, type: uint_16 }
+        cmd__shutter_3_open: { address: [31,31], group: h_r, type: uint_16 }
+        cmd__shutter_3_close: { address: [32,32], group: h_r, type: uint_16 }
+
+        cmd__valve_open: { address: [33,33], group: h_r, type: uint_16 }
+        cmd__valve_close: { address: [34,34], group: h_r, type: uint_16 }
+        cmd__clear_thickness: { address: [35,35], group: h_r, type: uint_16 }
+
+        k__power_limit_output_1_w: { address: [36,36], group: h_r, type: uint_16 }
+        k__power_limit_output_2_w: { address: [37,37], group: h_r, type: uint_16 }
+        k__power_limit_output_3_w: { address: [38,38], group: h_r, type: uint_16 }
+        k__voltage_limit_output_1_v: { address: [39,39], group: h_r, type: uint_16 }
+        k__voltage_limit_output_2_v: { address: [40,40], group: h_r, type: uint_16 }
+        k__voltage_limit_output_3_v: { address: [41,41], group: h_r, type: uint_16 }
+        k__current_limit_output_1_ma: { address: [42,42], group: h_r, type: uint_16 }
+        k__current_limit_output_2_ma: { address: [43,43], group: h_r, type: uint_16 }
+        k__current_limit_output_3_ma: { address: [44,44], group: h_r, type: uint_16 }
+
+        k__power_ramp_w_s: { address: [45,45], group: h_r, type: uint_16 }
+        k__voltage_ramp_v_s: { address: [46,46], group: h_r, type: uint_16 }
+        k__current_ramp_ma_s: { address: [47,47], group: h_r, type: uint_16 }
+
+        k__vacuum_interlock_mode: { address: [48,48], group: h_r, type: uint_16 }
+        k__arc_detect_enabled: { address: [49,49], group: h_r, type: uint_16 }
+        k__arc_detect_time_us: { address: [50,50], group: h_r, type: uint_16 }
+        k__arc_off_time_ms: { address: [51,51], group: h_r, type: uint_16 }
+        k__arc_limit_enabled: { address: [52,52], group: h_r, type: uint_16 }
+        k__arc_limit_value: { address: [53,54], group: h_r, type: uint_32 }
+
+        k__shutter_control_internal: { address: [55,55], group: h_r, type: uint_16 }
+        k__shutter_1_mode: { address: [56,56], group: h_r, type: uint_16 }
+        k__shutter_1_thickness_setpoint_nm: { address: [57,58], group: h_r, type: float }
+        k__shutter_1_time_setpoint_s: { address: [59,60], group: h_r, type: uint_32 }
+        shutter_1_remaining_time_s: { address: [61,62], group: h_r, type: uint_32 }
+        k__shutter_2_mode: { address: [63,63], group: h_r, type: uint_16 }
+        k__shutter_2_thickness_setpoint_nm: { address: [64,65], group: h_r, type: float }
+        k__shutter_2_time_setpoint_s: { address: [66,67], group: h_r, type: uint_32 }
+        shutter_2_remaining_time_s: { address: [68,69], group: h_r, type: uint_32 }
+        k__shutter_3_mode: { address: [70,70], group: h_r, type: uint_16 }
+        k__shutter_3_thickness_setpoint_nm: { address: [71,72], group: h_r, type: float }
+        k__shutter_3_time_setpoint_s: { address: [73,74], group: h_r, type: uint_32 }
+        shutter_3_remaining_time_s: { address: [75,76], group: h_r, type: uint_32 }
+
+        k__flow_sensor_enabled: { address: [77,77], group: h_r, type: uint_16 }
+        k__flow_sensor_range: { address: [78,78], group: h_r, type: uint_16 }
+        flow_controller_temp_raw: { address: [79,79], group: h_r, type: uint_16 }
+        flow_controller_drive_level_raw: { address: [80,80], group: h_r, type: uint_16 }
+        k__parallel_mode_enabled: { address: [81,81], group: h_r, type: uint_16 }
+        extension_module_count: { address: [82,82], group: h_r, type: uint_16 }
+
+        output_1_work_time_s: { address: [83,84], group: h_r, type: uint_32 }
+        output_2_work_time_s: { address: [85,86], group: h_r, type: uint_32 }
+        output_3_work_time_s: { address: [87,88], group: h_r, type: uint_32 }
+        k__active_output: { address: [89,89], group: h_r, type: uint_16 }
+        active_output: { address: [90,90], group: h_r, type: uint_16 }
+        k__timer_direction: { address: [91,91], group: h_r, type: uint_16 }
+        operate_time_s: { address: [92,93], group: h_r, type: uint_32 }
+        k__operate_time_setpoint_s: { address: [94,95], group: h_r, type: uint_32 }

--- a/library/industries/embedded_lab_pack/README.md
+++ b/library/industries/embedded_lab_pack/README.md
@@ -4,5 +4,5 @@ Bundle of BLE/LwM2M/MQTT edge nodes and SCPI/modbus instruments for CI pipelines
 and firmware validation labs.
 
 - **Protocols**: BLE GATT, MQTT, LwM2M/CoAP, SCPI (ASCII/TCP), Modbus TCP.
-- **Models**: health wearables, temperature sensors, multimeter, vacuum gauge.
+- **Models**: health wearables, temperature sensors, multimeter, vacuum gauge, magnetron power supply.
 - **Quickstarts**: `profiles/embedded_lab_pack/mhealth_ci.yaml`, `profiles/embedded_lab_pack/scpi_lab.yaml`.

--- a/profiles/embedded_lab_pack/scpi_lab.yaml
+++ b/profiles/embedded_lab_pack/scpi_lab.yaml
@@ -5,6 +5,7 @@ description: |
 models:
   - library/domains/measurement_instruments/generic/multimeter__scpi.yaml
   - library/domains/vacuum_systems/generic/vacuum_gauge__modbus.yaml
+  - library/domains/iot/prevac/prevac_m600dc_ps__modbus.yaml
 services:
   - scpi_tcp_stack
   - modbus_tcp_gateway

--- a/tests/devices/modbus_prevac_m600dc_ps_sut_example.py
+++ b/tests/devices/modbus_prevac_m600dc_ps_sut_example.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Hammerheads Engineers Sp. z o.o.
+# See the accompanying LICENSE file for terms.
+
+"""Example SUT implementation: Modbus Prevac M600DC-PS client used in integration tests."""
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence
+
+from .modbus_sut_base import (
+    ModbusMap,
+    ModbusSUTBase,
+    ModbusTcpClient,
+    RegisterDecoder,
+)
+
+DEFAULT_MODBUS_MAP: ModbusMap = {
+    "device_state": {"address": 0, "decoder": "u16"},
+    "magnetron_power_w": {"address": 4, "decoder": "modbus_float_be", "bit_order": "ABCD"},
+    "magnetron_voltage_v": {"address": 6, "decoder": "modbus_float_be", "bit_order": "ABCD"},
+    "magnetron_current_ma": {"address": 8, "decoder": "modbus_float_be", "bit_order": "ABCD"},
+    "power_set_w": {"address": 19, "decoder": "modbus_float_be", "bit_order": "ABCD"},
+    "voltage_set_v": {"address": 21, "decoder": "modbus_float_be", "bit_order": "ABCD"},
+    "current_set_ma": {"address": 23, "decoder": "modbus_float_be", "bit_order": "ABCD"},
+    "flow_set_sccm": {"address": 25, "decoder": "modbus_float_be", "bit_order": "ABCD"},
+}
+
+
+def _decode_u16(registers: Sequence[int]) -> int:
+    return registers[0] & 0xFFFF
+
+
+def _decode_float_abcd(registers: Sequence[int]) -> float:
+    return ModbusPrevacM600DCPSExample.modbus_to_float(registers, "ABCD")
+
+
+class ModbusPrevacM600DCPSExample(ModbusSUTBase):
+    """Thin wrapper around pymodbus representing the Prevac M600DC-PS Modbus model."""
+
+    _DECODER_REGISTRY: Dict[str, RegisterDecoder] = {
+        "u16": RegisterDecoder(count=1, fn=_decode_u16),
+        "modbus_float_be": RegisterDecoder(count=2, fn=_decode_float_abcd),
+    }
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 502,
+        unit_id: int = 1,
+        timeout: float = 2.0,
+        mapping: Optional[ModbusMap] = None,
+    ) -> None:
+        super().__init__(
+            default_map=DEFAULT_MODBUS_MAP,
+            mapping=mapping,
+            host=host,
+            port=port,
+            unit_id=unit_id,
+            timeout=timeout,
+        )
+
+    def read_u16(self, field: str) -> int:
+        return int(self._read(field))
+
+    def read_float(self, field: str) -> float:
+        return float(self._read(field))
+
+    def set_float(self, field: str, value: float) -> None:
+        config = self._get_field_config(field)
+        address = self._get_address(config, field)
+        registers = self._float_to_registers(value)
+        self._write_registers(address, registers)
+
+    def _read(self, field_name: str) -> float:
+        config = self._get_field_config(field_name)
+        address = self._get_address(config, field_name)
+        decoder_key = config.get("decoder", "u16")
+        decoder = self._DECODER_REGISTRY.get(decoder_key)
+        if decoder is None:
+            raise ValueError(f"Unsupported decoder '{decoder_key}' for field '{field_name}'")
+        registers = self._read_holding_registers(address, decoder.count)
+        return decoder.decode(registers)
+
+
+__all__ = ["ModbusPrevacM600DCPSExample", "ModbusTcpClient"]

--- a/tests/packs/embedded_lab_pack/integration/test_modbus_prevac_m600dc_ps_sut_example.py
+++ b/tests/packs/embedded_lab_pack/integration/test_modbus_prevac_m600dc_ps_sut_example.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+
+import os
+import unittest
+
+import tests.shared.integration.modbus_prevac_m600dc_ps_sut_example as shared_prevac
+
+from tests.common.spx_utils import require_existing_instance
+
+
+SPX_BASE_URL = os.environ.get("SPX_BASE_URL", "http://localhost:8000")
+INSTANCE_KEY = "spx_prevac_m600dc_ps"
+MODEL_ID = "Lab.MagnetronPowerSupply.PrevacM600DCPS.Modbus"
+
+
+class TestModbusPrevacM600DCPSExampleIntegration(
+    shared_prevac.TestModbusPrevacM600DCPSExampleIntegration
+):
+    """Run the shared Prevac M600DC-PS suite against the installer-created instance."""
+
+    @classmethod
+    def setUpClass(cls):
+        if shared_prevac.ModbusTcpClient is None:  # pragma: no cover - dependency missing
+            raise unittest.SkipTest(
+                "pymodbus is not available. Install pymodbus to run Modbus integration tests."
+            )
+
+        try:
+            import spx_python  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise unittest.SkipTest(f"spx_python not available: {exc}") from exc
+
+        product_key = os.environ.get("SPX_PRODUCT_KEY")
+        if not product_key:
+            raise unittest.SkipTest("SPX_PRODUCT_KEY must be set to run integration tests.")
+
+        cls._spx = spx_python
+        cls._client = spx_python.init(address=SPX_BASE_URL, product_key=product_key)
+        cls._instance = require_existing_instance(
+            cls._client,
+            INSTANCE_KEY,
+            expected_model_id=MODEL_ID,
+            ensure_running=False,
+        )
+        cls._model_changed = False
+
+        try:
+            cls._instance.stop()
+        except Exception:
+            pass
+        try:
+            cls._instance.reset()
+        except Exception:
+            pass
+        try:
+            cls._instance.start()
+        except Exception:
+            pass

--- a/tests/shared/integration/modbus_prevac_m600dc_ps_sut_example.py
+++ b/tests/shared/integration/modbus_prevac_m600dc_ps_sut_example.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Hammerheads Engineers Sp. z o.o.
+# See the accompanying LICENSE file for terms.
+
+"""Integration coverage for the example Modbus Prevac M600DC-PS SUT device implementation."""
+
+import os
+import unittest
+
+from tests.common.modbus_utils import wait_for_modbus_endpoint
+from tests.common.spx_utils import (
+    bootstrap_model_instance,
+    wait_for_condition,
+    wait_seconds,
+)
+from tests.common.repo import repo_root
+from tests.devices.modbus_prevac_m600dc_ps_sut_example import (
+    ModbusPrevacM600DCPSExample,
+    ModbusTcpClient,
+)
+
+
+ROOT = repo_root()
+MODEL_PATH = (
+    ROOT
+    / "library"
+    / "domains"
+    / "iot"
+    / "prevac"
+    / "prevac_m600dc_ps__modbus.yaml"
+)
+MODEL_KEY = "tests__prevac_m600dc_ps"
+INSTANCE_KEY = "prevac_m600dc_ps"
+SPX_BASE_URL = os.environ.get("SPX_BASE_URL", "http://localhost:8000")
+
+
+class TestModbusPrevacM600DCPSExampleIntegration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if ModbusTcpClient is None:  # pragma: no cover - dependency missing
+            raise unittest.SkipTest(
+                "pymodbus is not available. Install pymodbus to run Modbus integration tests."
+            )
+
+        try:
+            import spx_python  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise unittest.SkipTest(f"spx_python not available: {exc}") from exc
+
+        product_key = os.environ.get("SPX_PRODUCT_KEY")
+        if not product_key:
+            raise unittest.SkipTest(
+                "SPX_PRODUCT_KEY must be set to run integration tests."
+            )
+
+        cls._spx = spx_python
+        (
+            cls._client,
+            cls._instance,
+            cls._model_changed,
+        ) = bootstrap_model_instance(
+            spx_python,
+            product_key=product_key,
+            base_url=SPX_BASE_URL,
+            model_path=MODEL_PATH,
+            model_key=MODEL_KEY,
+            instance_key=INSTANCE_KEY,
+        )
+
+    def setUp(self):
+        self.model = self.__class__._instance
+        wait_seconds(0.2)
+
+        try:
+            comm = self.model["communication"]["modbus_slave"]
+            attach = getattr(comm, "attach", None)
+            if callable(attach):
+                attach()
+        except Exception:
+            pass
+
+        try:
+            port, unit_id = wait_for_modbus_endpoint(
+                self.model,
+                comm_keys=("modbus_slave", "modbus_tcp"),
+                timeout=10.0,
+                interval=0.2,
+            )
+        except TimeoutError as exc:
+            self.skipTest(str(exc))
+
+        self.sut = ModbusPrevacM600DCPSExample(
+            host="127.0.0.1",
+            port=port,
+            unit_id=unit_id,
+            timeout=1.0,
+        )
+        if not wait_for_condition(lambda: self.sut.connect(), timeout=5.0, interval=0.2):
+            self.skipTest(f"Modbus server not reachable at 127.0.0.1:{port} (unit {unit_id})")
+        wait_seconds(0.2)
+
+    def tearDown(self):
+        if hasattr(self, "sut") and self.sut:
+            self.sut.close()
+
+    def test_read_status_and_measurements(self):
+        state = self.sut.read_u16("device_state")
+        power = self.sut.read_float("magnetron_power_w")
+        voltage = self.sut.read_float("magnetron_voltage_v")
+        current = self.sut.read_float("magnetron_current_ma")
+
+        self.assertIsInstance(state, int)
+        self.assertGreaterEqual(state, 0)
+        for value in (power, voltage, current):
+            self.assertIsInstance(value, float)
+
+    def test_write_power_setpoint(self):
+        target = 150.0
+        self.sut.set_float("power_set_w", target)
+
+        def _read_back() -> bool:
+            try:
+                value = float(self.sut.read_float("power_set_w"))
+            except Exception:
+                return False
+            return abs(value - target) < 0.1
+
+        self.assertTrue(
+            wait_for_condition(_read_back, timeout=5.0, interval=0.2),
+            "Expected power setpoint to be writable and readable via Modbus",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary\n- add Prevac M600DC-PS Modbus TCP model and register mapping\n- include model in embedded_lab_pack catalog/profile/default instances\n- add Modbus SUT + integration coverage\n\n## Testing\n- poetry run python tools/validate_models.py\n- poetry run pytest\n\nRefs #20