### PR TITLE
feat(modbus): add APC Easy UPS 3M model

### DIFF
--- a/library/catalog/industries.yaml
+++ b/library/catalog/industries.yaml
@@ -19,6 +19,8 @@ industries:
         instance: spx_hvac_flexit_nordic_bacnet
       - model: Energy.EnergyMeterIem3000.Modbus
         instance: spx_energy_meter_iem3000_modbus
+      - model: Energy.UpsEasy3M.Modbus
+        instance: spx_easy_ups_3m_modbus
       - model: Weather.WeatherFeed.Http
         instance: spx_weather_feed
       - model: Weather.WeatherGateway.WagoPfc200.VaisalaWxt530.Mqtt
@@ -44,6 +46,7 @@ industries:
     start_instances:
       - spx_hvac_flexit_nordic_bacnet
       - spx_energy_meter_iem3000_modbus
+      - spx_easy_ups_3m_modbus
       - spx_weather_gateway_wago_pfc200_vaisala_wxt530_mqtt
       - spx_abb_sa_s12_16_5_1_knx
       - spx_abb_jra_s4_230_5_1_knx

--- a/library/catalog/models.yaml
+++ b/library/catalog/models.yaml
@@ -331,6 +331,15 @@ models:
       - id: modbus_tcp_gateway
     packages: [smart_building_pack]
     profiles: [bms_quickstart]
+  - id: Energy.UpsEasy3M.Modbus
+    name: APC Easy UPS 3M (Modbus)
+    path: library/domains/iot/apc/apc_easy_ups_3m__modbus.yaml
+    domain: iot
+    protocols: [modbus]
+    services:
+      - id: modbus_tcp_gateway
+    packages: [smart_building_pack]
+    profiles: [bms_quickstart]
   - id: Energy.EVSE.Ocpp
     name: EVSE / Charge Point (OCPP 1.6)
     path: library/domains/energy/emobility/evse__ocpp.yaml

--- a/library/domains/iot/apc/apc_easy_ups_3m__modbus.yaml
+++ b/library/domains/iot/apc/apc_easy_ups_3m__modbus.yaml
@@ -1,0 +1,350 @@
+# SPDX-License-Identifier: MIT
+
+name: apc_easy_ups_3m__modbus
+description: |
+  Modbus TCP (slave) simulation of APC Easy UPS 3M (E3M) telemetry registers.
+  Uses the E3M Modbus Register Map input register block (function 0x04) with
+  scaled unsigned integer values and per-point gains (0.1, 0.01, 0.001).
+
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5024
+  modbus_unit_id:
+    type: int
+    default: 1
+
+attributes:
+  # Input currents (A)
+  input_current_phase_a_a: 12.0
+  input_current_phase_b_a: 11.6
+  input_current_phase_c_a: 12.2
+  input_current_avg_a: 0.0
+
+  # Output currents (A)
+  output_current_phase_a_a: 10.8
+  output_current_phase_b_a: 10.4
+  output_current_phase_c_a: 11.1
+  output_current_avg_a: 0.0
+
+  # Frequencies (Hz)
+  input_frequency_hz: 50.0
+  output_frequency_hz: 50.0
+  bypass_frequency_hz: 50.0
+
+  # Power factor (ratio)
+  input_power_factor_phase_a: 0.98
+  input_power_factor_phase_b: 0.97
+  input_power_factor_phase_c: 0.99
+
+  # Output power
+  output_active_power_phase_a_kw: 8.2
+  output_active_power_phase_b_kw: 7.9
+  output_active_power_phase_c_kw: 8.4
+  output_active_power_total_kw: 0.0
+
+  output_apparent_power_phase_a_kva: 8.7
+  output_apparent_power_phase_b_kva: 8.3
+  output_apparent_power_phase_c_kva: 8.9
+  output_apparent_power_total_kva: 0.0
+
+  # Output load
+  output_load_pct_phase_a: 32.0
+  output_load_pct_phase_b: 30.0
+  output_load_pct_phase_c: 33.0
+
+  # Line voltages (V)
+  input_line_voltage_ab_v: 400.0
+  input_line_voltage_bc_v: 398.5
+  input_line_voltage_ca_v: 401.0
+  input_line_voltage_avg_v: 0.0
+
+  output_line_voltage_ab_v: 400.0
+  output_line_voltage_bc_v: 399.0
+  output_line_voltage_ca_v: 401.5
+  output_line_voltage_avg_v: 0.0
+
+  # Internal registers (scaled integer values for Modbus mapping)
+  _reg_input_current_phase_a: 0
+  _reg_input_current_phase_b: 0
+  _reg_input_current_phase_c: 0
+  _reg_output_current_phase_a: 0
+  _reg_output_current_phase_b: 0
+  _reg_output_current_phase_c: 0
+  _reg_input_frequency: 0
+  _reg_output_frequency: 0
+  _reg_bypass_frequency: 0
+  _reg_input_power_factor_phase_a: 0
+  _reg_input_power_factor_phase_b: 0
+  _reg_input_power_factor_phase_c: 0
+  _reg_output_active_power_phase_a: 0
+  _reg_output_active_power_phase_b: 0
+  _reg_output_active_power_phase_c: 0
+  _reg_output_apparent_power_phase_a: 0
+  _reg_output_apparent_power_phase_b: 0
+  _reg_output_apparent_power_phase_c: 0
+  _reg_output_load_pct_phase_a: 0
+  _reg_output_load_pct_phase_b: 0
+  _reg_output_load_pct_phase_c: 0
+  _reg_input_line_voltage_ab: 0
+  _reg_input_line_voltage_bc: 0
+  _reg_input_line_voltage_ca: 0
+  _reg_output_line_voltage_ab: 0
+  _reg_output_line_voltage_bc: 0
+  _reg_output_line_voltage_ca: 0
+
+actions:
+  - function: $in(input_current_avg_a)
+    name: compute_input_current_avg
+    description: Average input current.
+    call: ($in(input_current_phase_a_a) + $in(input_current_phase_b_a) + $in(input_current_phase_c_a)) / 3.0
+
+  - function: $in(output_current_avg_a)
+    name: compute_output_current_avg
+    description: Average output current.
+    call: ($in(output_current_phase_a_a) + $in(output_current_phase_b_a) + $in(output_current_phase_c_a)) / 3.0
+
+  - function: $in(output_active_power_total_kw)
+    name: compute_output_active_power_total
+    description: Total output active power.
+    call: $in(output_active_power_phase_a_kw) + $in(output_active_power_phase_b_kw) + $in(output_active_power_phase_c_kw)
+
+  - function: $in(output_apparent_power_total_kva)
+    name: compute_output_apparent_power_total
+    description: Total output apparent power.
+    call: $in(output_apparent_power_phase_a_kva) + $in(output_apparent_power_phase_b_kva) + $in(output_apparent_power_phase_c_kva)
+
+  - function: $in(input_line_voltage_avg_v)
+    name: compute_input_line_voltage_avg
+    description: Average input line voltage.
+    call: ($in(input_line_voltage_ab_v) + $in(input_line_voltage_bc_v) + $in(input_line_voltage_ca_v)) / 3.0
+
+  - function: $in(output_line_voltage_avg_v)
+    name: compute_output_line_voltage_avg
+    description: Average output line voltage.
+    call: ($in(output_line_voltage_ab_v) + $in(output_line_voltage_bc_v) + $in(output_line_voltage_ca_v)) / 3.0
+
+  - function: $in(_reg_input_current_phase_a)
+    name: pack_input_current_phase_a
+    description: Scale input current phase A (0.1 A).
+    call: max(0, min(65535, int(round($in(input_current_phase_a_a) / 0.1))))
+
+  - function: $in(_reg_input_current_phase_b)
+    name: pack_input_current_phase_b
+    description: Scale input current phase B (0.1 A).
+    call: max(0, min(65535, int(round($in(input_current_phase_b_a) / 0.1))))
+
+  - function: $in(_reg_input_current_phase_c)
+    name: pack_input_current_phase_c
+    description: Scale input current phase C (0.1 A).
+    call: max(0, min(65535, int(round($in(input_current_phase_c_a) / 0.1))))
+
+  - function: $in(_reg_output_current_phase_a)
+    name: pack_output_current_phase_a
+    description: Scale output current phase A (0.1 A).
+    call: max(0, min(65535, int(round($in(output_current_phase_a_a) / 0.1))))
+
+  - function: $in(_reg_output_current_phase_b)
+    name: pack_output_current_phase_b
+    description: Scale output current phase B (0.1 A).
+    call: max(0, min(65535, int(round($in(output_current_phase_b_a) / 0.1))))
+
+  - function: $in(_reg_output_current_phase_c)
+    name: pack_output_current_phase_c
+    description: Scale output current phase C (0.1 A).
+    call: max(0, min(65535, int(round($in(output_current_phase_c_a) / 0.1))))
+
+  - function: $in(_reg_input_frequency)
+    name: pack_input_frequency
+    description: Scale input frequency (0.1 Hz).
+    call: max(0, min(65535, int(round($in(input_frequency_hz) / 0.1))))
+
+  - function: $in(_reg_output_frequency)
+    name: pack_output_frequency
+    description: Scale output frequency (0.1 Hz).
+    call: max(0, min(65535, int(round($in(output_frequency_hz) / 0.1))))
+
+  - function: $in(_reg_bypass_frequency)
+    name: pack_bypass_frequency
+    description: Scale bypass frequency (0.1 Hz).
+    call: max(0, min(65535, int(round($in(bypass_frequency_hz) / 0.1))))
+
+  - function: $in(_reg_input_power_factor_phase_a)
+    name: pack_input_power_factor_phase_a
+    description: Scale input power factor phase A (0.001).
+    call: max(0, min(65535, int(round($in(input_power_factor_phase_a) / 0.001))))
+
+  - function: $in(_reg_input_power_factor_phase_b)
+    name: pack_input_power_factor_phase_b
+    description: Scale input power factor phase B (0.001).
+    call: max(0, min(65535, int(round($in(input_power_factor_phase_b) / 0.001))))
+
+  - function: $in(_reg_input_power_factor_phase_c)
+    name: pack_input_power_factor_phase_c
+    description: Scale input power factor phase C (0.001).
+    call: max(0, min(65535, int(round($in(input_power_factor_phase_c) / 0.001))))
+
+  - function: $in(_reg_output_active_power_phase_a)
+    name: pack_output_active_power_phase_a
+    description: Scale output active power phase A (0.1 kW).
+    call: max(0, min(65535, int(round($in(output_active_power_phase_a_kw) / 0.1))))
+
+  - function: $in(_reg_output_active_power_phase_b)
+    name: pack_output_active_power_phase_b
+    description: Scale output active power phase B (0.1 kW).
+    call: max(0, min(65535, int(round($in(output_active_power_phase_b_kw) / 0.1))))
+
+  - function: $in(_reg_output_active_power_phase_c)
+    name: pack_output_active_power_phase_c
+    description: Scale output active power phase C (0.1 kW).
+    call: max(0, min(65535, int(round($in(output_active_power_phase_c_kw) / 0.1))))
+
+  - function: $in(_reg_output_apparent_power_phase_a)
+    name: pack_output_apparent_power_phase_a
+    description: Scale output apparent power phase A (0.1 kVA).
+    call: max(0, min(65535, int(round($in(output_apparent_power_phase_a_kva) / 0.1))))
+
+  - function: $in(_reg_output_apparent_power_phase_b)
+    name: pack_output_apparent_power_phase_b
+    description: Scale output apparent power phase B (0.1 kVA).
+    call: max(0, min(65535, int(round($in(output_apparent_power_phase_b_kva) / 0.1))))
+
+  - function: $in(_reg_output_apparent_power_phase_c)
+    name: pack_output_apparent_power_phase_c
+    description: Scale output apparent power phase C (0.1 kVA).
+    call: max(0, min(65535, int(round($in(output_apparent_power_phase_c_kva) / 0.1))))
+
+  - function: $in(_reg_output_load_pct_phase_a)
+    name: pack_output_load_pct_phase_a
+    description: Scale output load percent phase A (1%).
+    call: max(0, min(65535, int(round($in(output_load_pct_phase_a)))))
+
+  - function: $in(_reg_output_load_pct_phase_b)
+    name: pack_output_load_pct_phase_b
+    description: Scale output load percent phase B (1%).
+    call: max(0, min(65535, int(round($in(output_load_pct_phase_b)))))
+
+  - function: $in(_reg_output_load_pct_phase_c)
+    name: pack_output_load_pct_phase_c
+    description: Scale output load percent phase C (1%).
+    call: max(0, min(65535, int(round($in(output_load_pct_phase_c)))))
+
+  - function: $in(_reg_input_line_voltage_ab)
+    name: pack_input_line_voltage_ab
+    description: Scale input line voltage AB (0.1 V).
+    call: max(0, min(65535, int(round($in(input_line_voltage_ab_v) / 0.1))))
+
+  - function: $in(_reg_input_line_voltage_bc)
+    name: pack_input_line_voltage_bc
+    description: Scale input line voltage BC (0.1 V).
+    call: max(0, min(65535, int(round($in(input_line_voltage_bc_v) / 0.1))))
+
+  - function: $in(_reg_input_line_voltage_ca)
+    name: pack_input_line_voltage_ca
+    description: Scale input line voltage CA (0.1 V).
+    call: max(0, min(65535, int(round($in(input_line_voltage_ca_v) / 0.1))))
+
+  - function: $in(_reg_output_line_voltage_ab)
+    name: pack_output_line_voltage_ab
+    description: Scale output line voltage AB (0.1 V).
+    call: max(0, min(65535, int(round($in(output_line_voltage_ab_v) / 0.1))))
+
+  - function: $in(_reg_output_line_voltage_bc)
+    name: pack_output_line_voltage_bc
+    description: Scale output line voltage BC (0.1 V).
+    call: max(0, min(65535, int(round($in(output_line_voltage_bc_v) / 0.1))))
+
+  - function: $in(_reg_output_line_voltage_ca)
+    name: pack_output_line_voltage_ca
+    description: Scale output line voltage CA (0.1 V).
+    call: max(0, min(65535, int(round($in(output_line_voltage_ca_v) / 0.1))))
+
+communication:
+  - modbus_slave:
+      host: 0.0.0.0
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
+      zero_fill: true
+      mapping:
+        # Input current (A) 0.1 A
+        _reg_input_current_phase_a: { address: [30005,30005], group: i_r, type: uint_16 }
+        _reg_input_current_phase_b: { address: [30006,30006], group: i_r, type: uint_16 }
+        _reg_input_current_phase_c: { address: [30007,30007], group: i_r, type: uint_16 }
+
+        # Output current (A) 0.1 A
+        _reg_output_current_phase_a: { address: [30015,30015], group: i_r, type: uint_16 }
+        _reg_output_current_phase_b: { address: [30016,30016], group: i_r, type: uint_16 }
+        _reg_output_current_phase_c: { address: [30017,30017], group: i_r, type: uint_16 }
+
+        # Frequencies (Hz) 0.1 Hz
+        _reg_input_frequency: { address: [30004,30004], group: i_r, type: uint_16 }
+        _reg_output_frequency: { address: [30014,30014], group: i_r, type: uint_16 }
+        _reg_bypass_frequency: { address: [30030,30030], group: i_r, type: uint_16 }
+
+        # Input power factor 0.001
+        _reg_input_power_factor_phase_a: { address: [30008,30008], group: i_r, type: uint_16 }
+        _reg_input_power_factor_phase_b: { address: [30009,30009], group: i_r, type: uint_16 }
+        _reg_input_power_factor_phase_c: { address: [30010,30010], group: i_r, type: uint_16 }
+
+        # Output active power (kW) 0.1 kW
+        _reg_output_active_power_phase_a: { address: [30018,30018], group: i_r, type: uint_16 }
+        _reg_output_active_power_phase_b: { address: [30019,30019], group: i_r, type: uint_16 }
+        _reg_output_active_power_phase_c: { address: [30020,30020], group: i_r, type: uint_16 }
+
+        # Output load (%) 1%
+        _reg_output_load_pct_phase_a: { address: [30021,30021], group: i_r, type: uint_16 }
+        _reg_output_load_pct_phase_b: { address: [30022,30022], group: i_r, type: uint_16 }
+        _reg_output_load_pct_phase_c: { address: [30023,30023], group: i_r, type: uint_16 }
+
+        # Output apparent power (kVA) 0.1 kVA
+        _reg_output_apparent_power_phase_a: { address: [30047,30047], group: i_r, type: uint_16 }
+        _reg_output_apparent_power_phase_b: { address: [30048,30048], group: i_r, type: uint_16 }
+        _reg_output_apparent_power_phase_c: { address: [30049,30049], group: i_r, type: uint_16 }
+
+        # Input line voltage (V) 0.1 V
+        _reg_input_line_voltage_ab: { address: [30050,30050], group: i_r, type: uint_16 }
+        _reg_input_line_voltage_bc: { address: [30051,30051], group: i_r, type: uint_16 }
+        _reg_input_line_voltage_ca: { address: [30052,30052], group: i_r, type: uint_16 }
+
+        # Output line voltage (V) 0.1 V
+        _reg_output_line_voltage_ab: { address: [30056,30056], group: i_r, type: uint_16 }
+        _reg_output_line_voltage_bc: { address: [30057,30057], group: i_r, type: uint_16 }
+        _reg_output_line_voltage_ca: { address: [30058,30058], group: i_r, type: uint_16 }
+
+scenarios:
+  normal_operation:
+    description: Balanced load with nominal frequencies and voltages.
+    duration: 30.0
+    overrides:
+      $in(input_current_phase_a_a): 12.0
+      $in(input_current_phase_b_a): 11.6
+      $in(input_current_phase_c_a): 12.2
+      $in(output_current_phase_a_a): 10.8
+      $in(output_current_phase_b_a): 10.4
+      $in(output_current_phase_c_a): 11.1
+      $in(output_active_power_phase_a_kw): 8.2
+      $in(output_active_power_phase_b_kw): 7.9
+      $in(output_active_power_phase_c_kw): 8.4
+      $in(output_apparent_power_phase_a_kva): 8.7
+      $in(output_apparent_power_phase_b_kva): 8.3
+      $in(output_apparent_power_phase_c_kva): 8.9
+      $in(output_load_pct_phase_a): 32.0
+      $in(output_load_pct_phase_b): 30.0
+      $in(output_load_pct_phase_c): 33.0
+
+  high_load:
+    description: Elevated output load and current draw.
+    duration: 30.0
+    overrides:
+      $in(output_current_phase_a_a): 19.5
+      $in(output_current_phase_b_a): 18.8
+      $in(output_current_phase_c_a): 20.1
+      $in(output_active_power_phase_a_kw): 14.2
+      $in(output_active_power_phase_b_kw): 13.7
+      $in(output_active_power_phase_c_kw): 14.8
+      $in(output_apparent_power_phase_a_kva): 15.1
+      $in(output_apparent_power_phase_b_kva): 14.6
+      $in(output_apparent_power_phase_c_kva): 15.5
+      $in(output_load_pct_phase_a): 58.0
+      $in(output_load_pct_phase_b): 55.0
+      $in(output_load_pct_phase_c): 60.0

--- a/library/industries/smart_building_pack/README.md
+++ b/library/industries/smart_building_pack/README.md
@@ -17,6 +17,7 @@ to validate multi-protocol integrations, test gateways, or build demo dashboards
   - Flexit Nordic HVAC (BACnet): `library/domains/iot/generic/hvac_flexit_nordic__bacnet.yaml`
   - Thermal controller (Modbus): `library/domains/thermal_controllers/generic/thermal_controller__modbus.yaml`
   - Energy meter iEM3000 (Modbus): `library/domains/iot/generic/energy_meter_iem3000__modbus.yaml`
+  - Easy UPS 3M (Modbus): `library/domains/iot/apc/apc_easy_ups_3m__modbus.yaml`
 - Lighting
   - Lighting panel (OPC UA): `library/domains/iot/generic/lighting_panel__opcua.yaml`
   - Lighting zone (KNX): `library/domains/iot/generic/lighting_zone__knx.yaml`

--- a/profiles/smart_building_pack/bms_quickstart.yaml
+++ b/profiles/smart_building_pack/bms_quickstart.yaml
@@ -9,6 +9,7 @@ models:
   - library/domains/thermal_controllers/generic/thermal_controller__modbus.yaml
   - library/domains/iot/generic/hvac_flexit_nordic__bacnet.yaml
   - library/domains/iot/generic/energy_meter_iem3000__modbus.yaml
+  - library/domains/iot/apc/apc_easy_ups_3m__modbus.yaml
   - library/domains/weather/weather_forecast__http.yaml
   - library/domains/weather/weather_gateway_wago_pfc200__vaisala_wxt530__mqtt.yaml
   - library/domains/iot/generic/bms_controller__opcua.yaml

--- a/tests/packs/smart_building_pack/integration/test_modbus_easy_ups_3m_smoke.py
+++ b/tests/packs/smart_building_pack/integration/test_modbus_easy_ups_3m_smoke.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Hammerheads Engineers Sp. z o.o.
+# See the accompanying LICENSE file for terms.
+
+"""Integration coverage for the APC Easy UPS 3M Modbus model."""
+
+import os
+import unittest
+
+from tests.common.modbus_utils import wait_for_modbus_endpoint
+from tests.common.spx_utils import require_existing_instance, wait_seconds
+from tests.devices.modbus_sut_base import ModbusTcpClient
+
+INSTANCE_KEY = "spx_easy_ups_3m_modbus"
+MODEL_ID = "Energy.UpsEasy3M.Modbus"
+SPX_BASE_URL = os.environ.get("SPX_BASE_URL", "http://localhost:8000")
+
+
+def _read_attr_value(instance, name):
+    try:
+        doc = instance.get()
+    except Exception:
+        doc = None
+    if isinstance(doc, dict):
+        attr = doc.get("attr")
+        if isinstance(attr, dict) and name in attr:
+            entry = attr.get(name)
+            if isinstance(entry, dict) and "value" in entry:
+                return entry.get("value")
+            return entry
+    return None
+
+
+def _call_with_unit(client, method_name, *args, unit_id=1, **kwargs):
+    method = getattr(client, method_name)
+    try:
+        return method(*args, slave=unit_id, **kwargs)
+    except TypeError as exc:
+        message = str(exc)
+        if "unexpected keyword argument" in message and "'slave'" in message:
+            return method(*args, unit=unit_id, **kwargs)
+        raise
+
+
+class TestModbusEasyUps3MSmoke(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if ModbusTcpClient is None:  # pragma: no cover - dependency missing
+            raise unittest.SkipTest(
+                "pymodbus is not available. Install pymodbus to run Modbus integration tests."
+            )
+
+        try:
+            import spx_python  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise unittest.SkipTest(f"spx_python not available: {exc}") from exc
+
+        product_key = os.environ.get("SPX_PRODUCT_KEY")
+        if not product_key:
+            raise unittest.SkipTest("SPX_PRODUCT_KEY must be set to run integration tests.")
+
+        cls._client = spx_python.init(address=SPX_BASE_URL, product_key=product_key)
+        cls._instance = require_existing_instance(
+            cls._client,
+            INSTANCE_KEY,
+            expected_model_id=MODEL_ID,
+            ensure_running=False,
+        )
+
+        try:
+            cls._instance.stop()
+        except Exception:
+            pass
+        try:
+            cls._instance.reset()
+        except Exception:
+            pass
+        try:
+            cls._instance.start()
+        except Exception:
+            pass
+
+        wait_seconds(0.2)
+        try:
+            port, unit_id = wait_for_modbus_endpoint(cls._instance, timeout=10.0, interval=0.2)
+        except TimeoutError as exc:
+            raise unittest.SkipTest(str(exc)) from exc
+
+        cls._modbus_port = port
+        cls._modbus_unit_id = unit_id
+
+    def _read_input_register(self, address, *, count=1):
+        client = ModbusTcpClient(host="127.0.0.1", port=self._modbus_port)
+        try:
+            if not client.connect():
+                self.skipTest(f"Modbus server not reachable at 127.0.0.1:{self._modbus_port}")
+            result = _call_with_unit(
+                client, "read_input_registers", address, count=count, unit_id=self._modbus_unit_id
+            )
+            if result is None or getattr(result, "isError", lambda: True)():
+                # Some stacks treat input addresses as zero-based; try address - 1 once.
+                alt_address = max(0, address - 1)
+                result = _call_with_unit(
+                    client,
+                    "read_input_registers",
+                    alt_address,
+                    count=count,
+                    unit_id=self._modbus_unit_id,
+                )
+            if result is None or getattr(result, "isError", lambda: True)():
+                self.skipTest(f"Modbus read failed at address {address}")
+            return result.registers
+        finally:
+            client.close()
+
+    def _assert_scaled_register(self, attr_name, address, gain):
+        value = _read_attr_value(self._instance, attr_name)
+        if value is None:
+            self.skipTest(f"Attribute '{attr_name}' not available on instance")
+        expected = int(round(float(value) / gain))
+        registers = self._read_input_register(address)
+        self.assertEqual(1, len(registers))
+        self.assertLessEqual(abs(registers[0] - expected), 1)
+
+    def test_input_current_phase_a_register(self):
+        self._assert_scaled_register("input_current_phase_a_a", 30005, 0.1)
+
+    def test_output_power_phase_a_register(self):
+        self._assert_scaled_register("output_active_power_phase_a_kw", 30018, 0.1)
+
+    def test_output_line_voltage_ab_register(self):
+        self._assert_scaled_register("output_line_voltage_ab_v", 30056, 0.1)
+
+    def test_input_power_factor_phase_a_register(self):
+        self._assert_scaled_register("input_power_factor_phase_a", 30008, 0.001)


### PR DESCRIPTION
## Summary\n- add APC Easy UPS 3M Modbus model (E3M register map)\n- register model in smart_building_pack catalog/profile/default instances\n- add Modbus smoke integration test for the UPS model\n\n## Testing\n- poetry run python tools/validate_models.py\n- poetry run pytest\n