### PR TITLE
Add Schneider EM4200 Modbus model

### DIFF
--- a/library/catalog/industries.yaml
+++ b/library/catalog/industries.yaml
@@ -19,6 +19,8 @@ industries:
         instance: spx_hvac_flexit_nordic_bacnet
       - model: Energy.EnergyMeterIem3000.Modbus
         instance: spx_energy_meter_iem3000_modbus
+      - model: Energy.EnergyMeterEm4200.Modbus
+        instance: spx_energy_meter_em4200_modbus
       - model: Weather.WeatherFeed.Http
         instance: spx_weather_feed
       - model: Weather.WeatherGateway.WagoPfc200.VaisalaWxt530.Mqtt

--- a/library/catalog/models.yaml
+++ b/library/catalog/models.yaml
@@ -331,6 +331,15 @@ models:
       - id: modbus_tcp_gateway
     packages: [smart_building_pack]
     profiles: [bms_quickstart]
+  - id: Energy.EnergyMeterEm4200.Modbus
+    name: Schneider Electric EM4200 Energy Meter (Modbus)
+    path: library/domains/iot/schneider/schneider_em4200__modbus.yaml
+    domain: iot
+    protocols: [modbus]
+    services:
+      - id: modbus_tcp_gateway
+    packages: [smart_building_pack]
+    profiles: [bms_quickstart]
   - id: Energy.EVSE.Ocpp
     name: EVSE / Charge Point (OCPP 1.6)
     path: library/domains/energy/emobility/evse__ocpp.yaml

--- a/library/domains/iot/schneider/schneider_em4200__modbus.yaml
+++ b/library/domains/iot/schneider/schneider_em4200__modbus.yaml
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: MIT
+
+name: schneider_em4200__modbus
+description: |
+  Minimal Modbus TCP (slave) simulation of Schneider Electric PowerLogic EM4200
+  energy meters. The exposed registers follow the EM4200 Modbus Register Map
+  float block (addresses 257+), covering totals, per-phase voltages/currents,
+  power factor, and frequency.
+
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5030
+  modbus_unit_id:
+    type: int
+    default: 1
+
+attributes:
+  # Phase currents (A)
+  k__current_l1_a: 12.0
+  k__current_l2_a: 10.5
+  k__current_l3_a: 11.2
+  current_avg_a: 0.0
+
+  # Phase-to-neutral voltages (V)
+  k__voltage_l1_n_v: 230.0
+  k__voltage_l2_n_v: 229.5
+  k__voltage_l3_n_v: 231.0
+  voltage_ln_avg_v: 0.0
+
+  # Line-to-line voltages (V) (derived from L-N; suitable for demo dashboards)
+  voltage_l1_l2_v: 0.0
+  voltage_l2_l3_v: 0.0
+  voltage_l3_l1_v: 0.0
+  voltage_ll_avg_v: 0.0
+
+  # Power (kW/kVAR/kVA)
+  k__power_factor: 0.96
+  power_factor_leading: 0
+  k__active_power_total_kw: 0.0
+  k__reactive_power_total_kvar: 0.0
+  k__apparent_power_total_kva: 0.0
+
+  # Frequency (Hz)
+  k__frequency_hz: 50.0
+
+  # Cumulative energy (kWh)
+  k__energy_total_kwh: 0.0
+
+  _cycle_time_s: 1.0
+
+actions:
+  - function: $in(current_avg_a)
+    name: compute_current_avg
+    description: Average phase current.
+    call: ($in(k__current_l1_a) + $in(k__current_l2_a) + $in(k__current_l3_a)) / 3.0
+
+  - function: $in(voltage_ln_avg_v)
+    name: compute_voltage_ln_avg
+    description: Average phase-to-neutral voltage.
+    call: ($in(k__voltage_l1_n_v) + $in(k__voltage_l2_n_v) + $in(k__voltage_l3_n_v)) / 3.0
+
+  - function: $in(voltage_l1_l2_v)
+    name: compute_voltage_l1_l2
+    description: Approximate L1-L2 voltage from phase-to-neutral values (balanced phasor assumption).
+    call: 1.7320508075688772 * (($in(k__voltage_l1_n_v) + $in(k__voltage_l2_n_v)) / 2.0)
+
+  - function: $in(voltage_l2_l3_v)
+    name: compute_voltage_l2_l3
+    description: Approximate L2-L3 voltage from phase-to-neutral values (balanced phasor assumption).
+    call: 1.7320508075688772 * (($in(k__voltage_l2_n_v) + $in(k__voltage_l3_n_v)) / 2.0)
+
+  - function: $in(voltage_l3_l1_v)
+    name: compute_voltage_l3_l1
+    description: Approximate L3-L1 voltage from phase-to-neutral values (balanced phasor assumption).
+    call: 1.7320508075688772 * (($in(k__voltage_l3_n_v) + $in(k__voltage_l1_n_v)) / 2.0)
+
+  - function: $in(voltage_ll_avg_v)
+    name: compute_voltage_ll_avg
+    description: Average line-to-line voltage.
+    call: ($in(voltage_l1_l2_v) + $in(voltage_l2_l3_v) + $in(voltage_l3_l1_v)) / 3.0
+
+  - function: $in(k__apparent_power_total_kva)
+    name: compute_apparent_power
+    description: Total apparent power (sum of per-phase V*I).
+    call: 1e-3
+         * (
+             $in(k__voltage_l1_n_v) * $in(k__current_l1_a)
+             + $in(k__voltage_l2_n_v) * $in(k__current_l2_a)
+             + $in(k__voltage_l3_n_v) * $in(k__current_l3_a)
+           )
+
+  - function: $in(k__active_power_total_kw)
+    name: compute_active_power_total
+    description: Total active power (power factor applied to apparent power).
+    call: $in(k__power_factor) * $in(k__apparent_power_total_kva)
+
+  - function: $in(k__reactive_power_total_kvar)
+    name: compute_reactive_power_total
+    description: Approximate total reactive power magnitude from active/apparent power.
+    call: (
+          max(0.0, ($in(k__apparent_power_total_kva) ** 2) - ($in(k__active_power_total_kw) ** 2)) ** 0.5
+        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+
+  - function: $in(k__energy_total_kwh)
+    name: integrate_energy_total
+    description: Integrate consumed energy (kWh) from total active power (kW).
+    call: $in(k__energy_total_kwh) + max(0.0, $in(k__active_power_total_kw)) * $in(_cycle_time_s) / 3600.0
+
+communication:
+  - modbus_slave:
+      host: 0.0.0.0
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
+      zero_fill: true
+      mapping:
+        # Energy totals (kWh) Float32
+        k__energy_total_kwh:     { address: [257,258], group: h_r, type: float }
+
+        # Power totals (kW/kVAR/kVA) Float32
+        k__active_power_total_kw:    { address: [261,262], group: i_r, type: float }
+        k__reactive_power_total_kvar: { address: [263,264], group: i_r, type: float }
+        k__apparent_power_total_kva:  { address: [265,266], group: i_r, type: float }
+        k__power_factor:             { address: [267,268], group: i_r, type: float }
+
+        # Voltage + current averages Float32
+        voltage_ll_avg_v:        { address: [269,270], group: i_r, type: float }
+        voltage_ln_avg_v:        { address: [271,272], group: i_r, type: float }
+        current_avg_a:           { address: [273,274], group: i_r, type: float }
+
+        # Line-line voltages (V) Float32
+        voltage_l1_l2_v:         { address: [287,288], group: i_r, type: float }
+        voltage_l2_l3_v:         { address: [289,290], group: i_r, type: float }
+        voltage_l3_l1_v:         { address: [291,292], group: i_r, type: float }
+
+        # Phase-to-neutral voltages (V) Float32
+        k__voltage_l1_n_v:       { address: [293,294], group: i_r, type: float }
+        k__voltage_l2_n_v:       { address: [295,296], group: i_r, type: float }
+        k__voltage_l3_n_v:       { address: [297,298], group: i_r, type: float }
+
+        # Frequency (Hz) Float32
+        k__frequency_hz:         { address: [1557,1558], group: i_r, type: float }
+
+        # Phase currents (A) Float32
+        k__current_l1_a:         { address: [2705,2706], group: i_r, type: float }
+        k__current_l2_a:         { address: [2707,2708], group: i_r, type: float }
+        k__current_l3_a:         { address: [2709,2710], group: i_r, type: float }
+
+scenarios:
+  peak_demand:
+    description: High load with balanced phases and near-unity power factor.
+    duration: 30.0
+    overrides:
+      $in(k__current_l1_a): 48.0
+      $in(k__current_l2_a): 46.5
+      $in(k__current_l3_a): 49.0
+      $in(k__power_factor): 0.99
+      $in(power_factor_leading): 0
+
+  pv_export:
+    description: Simulated PV export using negative phase currents.
+    duration: 30.0
+    overrides:
+      $in(k__current_l1_a): -7.5
+      $in(k__current_l2_a): -6.8
+      $in(k__current_l3_a): -7.1
+      $in(k__power_factor): 0.98
+      $in(power_factor_leading): 1
+
+  low_power_factor_lagging:
+    description: Inductive load with low power factor.
+    duration: 45.0
+    overrides:
+      $in(k__current_l1_a): 24.0
+      $in(k__current_l2_a): 23.5
+      $in(k__current_l3_a): 24.2
+      $in(k__power_factor): 0.72
+      $in(power_factor_leading): 0

--- a/library/industries/smart_building_pack/README.md
+++ b/library/industries/smart_building_pack/README.md
@@ -17,6 +17,7 @@ to validate multi-protocol integrations, test gateways, or build demo dashboards
   - Flexit Nordic HVAC (BACnet): `library/domains/iot/generic/hvac_flexit_nordic__bacnet.yaml`
   - Thermal controller (Modbus): `library/domains/thermal_controllers/generic/thermal_controller__modbus.yaml`
   - Energy meter iEM3000 (Modbus): `library/domains/iot/generic/energy_meter_iem3000__modbus.yaml`
+  - Energy meter EM4200 (Modbus): `library/domains/iot/schneider/schneider_em4200__modbus.yaml`
 - Lighting
   - Lighting panel (OPC UA): `library/domains/iot/generic/lighting_panel__opcua.yaml`
   - Lighting zone (KNX): `library/domains/iot/generic/lighting_zone__knx.yaml`

--- a/profiles/smart_building_pack/bms_quickstart.yaml
+++ b/profiles/smart_building_pack/bms_quickstart.yaml
@@ -9,6 +9,7 @@ models:
   - library/domains/thermal_controllers/generic/thermal_controller__modbus.yaml
   - library/domains/iot/generic/hvac_flexit_nordic__bacnet.yaml
   - library/domains/iot/generic/energy_meter_iem3000__modbus.yaml
+  - library/domains/iot/schneider/schneider_em4200__modbus.yaml
   - library/domains/weather/weather_forecast__http.yaml
   - library/domains/weather/weather_gateway_wago_pfc200__vaisala_wxt530__mqtt.yaml
   - library/domains/iot/generic/bms_controller__opcua.yaml

--- a/tests/packs/smart_building_pack/integration/test_modbus_schneider_em4200_smoke.py
+++ b/tests/packs/smart_building_pack/integration/test_modbus_schneider_em4200_smoke.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Hammerheads Engineers Sp. z o.o.
+# See the accompanying LICENSE file for terms.
+
+"""Integration smoke coverage for the Schneider Electric EM4200 Modbus model."""
+
+from __future__ import annotations
+
+import math
+import os
+import struct
+import unittest
+
+from tests.common.modbus_utils import wait_for_modbus_endpoint
+from tests.common.spx_utils import require_existing_instance, wait_for_condition, wait_seconds
+from tests.devices.modbus_sut_base import ModbusTcpClient
+
+
+INSTANCE_KEY = "spx_energy_meter_em4200_modbus"
+MODEL_ID = "Energy.EnergyMeterEm4200.Modbus"
+SPX_BASE_URL = os.environ.get("SPX_BASE_URL", "http://localhost:8000")
+
+
+def _decode_float(registers: list[int]) -> float:
+    if len(registers) != 2:
+        raise ValueError(f"Expected 2 registers, got {len(registers)}")
+    packed = struct.pack(">HH", registers[0], registers[1])
+    return struct.unpack(">f", packed)[0]
+
+
+class TestModbusSchneiderEm4200Smoke(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if ModbusTcpClient is None:  # pragma: no cover - dependency missing
+            raise unittest.SkipTest(
+                "pymodbus is not available. Install pymodbus to run Modbus integration tests."
+            )
+
+        try:
+            import spx_python  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise unittest.SkipTest(f"spx_python not available: {exc}") from exc
+
+        product_key = os.environ.get("SPX_PRODUCT_KEY")
+        if not product_key:
+            raise unittest.SkipTest("SPX_PRODUCT_KEY must be set to run integration tests.")
+
+        cls._client = spx_python.init(address=SPX_BASE_URL, product_key=product_key)
+        cls._instance = require_existing_instance(
+            cls._client,
+            INSTANCE_KEY,
+            expected_model_id=MODEL_ID,
+            ensure_running=False,
+        )
+
+        try:
+            cls._instance.stop()
+        except Exception:
+            pass
+        try:
+            cls._instance.reset()
+        except Exception:
+            pass
+        try:
+            cls._instance.start()
+        except Exception:
+            pass
+
+        wait_seconds(0.2)
+
+        try:
+            comms = cls._instance["communication"]
+        except Exception:
+            comms = {}
+        for comm_name in ("modbus_slave", "modbus_tcp"):
+            comm = comms.get(comm_name) if isinstance(comms, dict) else None
+            if comm is None:
+                continue
+            attach = getattr(comm, "attach", None)
+            if callable(attach):
+                try:
+                    attach()
+                except Exception:
+                    pass
+
+        try:
+            port, unit_id = wait_for_modbus_endpoint(
+                cls._instance,
+                comm_keys=("modbus_slave", "modbus_tcp"),
+                timeout=10.0,
+                interval=0.2,
+            )
+        except TimeoutError as exc:
+            raise unittest.SkipTest(str(exc)) from exc
+
+        cls._modbus_port = port
+        cls._modbus_unit_id = unit_id
+        cls._modbus = ModbusTcpClient(host="127.0.0.1", port=port, timeout=2.0)
+
+        connected = wait_for_condition(
+            lambda: bool(cls._modbus.connect()),
+            timeout=5.0,
+            interval=0.2,
+        )
+        if not connected:
+            raise unittest.SkipTest(
+                f"Unable to connect to Modbus endpoint at 127.0.0.1:{port} (unit {unit_id})"
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        modbus = getattr(cls, "_modbus", None)
+        if modbus is not None:
+            try:
+                modbus.close()
+            except Exception:
+                pass
+
+    def _call_with_unit(self, method_name: str, *args, **kwargs):
+        method = getattr(self._modbus, method_name)
+        try:
+            return method(*args, slave=self._modbus_unit_id, **kwargs)
+        except TypeError as exc:
+            if "slave" in str(exc) and "unexpected keyword argument" in str(exc):
+                return method(*args, unit=self._modbus_unit_id, **kwargs)
+            raise
+
+    def _read_input_float(self, address: int) -> float:
+        result = self._call_with_unit("read_input_registers", address, count=2)
+        if result is None or getattr(result, "isError", lambda: False)():
+            self.skipTest(f"Modbus input register read failed at address {address}")
+        return _decode_float(result.registers)
+
+    def _read_holding_float(self, address: int) -> float:
+        result = self._call_with_unit("read_holding_registers", address, count=2)
+        if result is None or getattr(result, "isError", lambda: False)():
+            self.skipTest(f"Modbus holding register read failed at address {address}")
+        return _decode_float(result.registers)
+
+    def test_read_key_registers(self):
+        energy_kwh = self._read_holding_float(257)
+        voltage_l1_n = self._read_input_float(293)
+        current_l1 = self._read_input_float(2705)
+        frequency = self._read_input_float(1557)
+
+        for value, label in [
+            (energy_kwh, "energy_kwh"),
+            (voltage_l1_n, "voltage_l1_n"),
+            (current_l1, "current_l1"),
+            (frequency, "frequency"),
+        ]:
+            self.assertTrue(math.isfinite(value), f"{label} should be finite, got {value!r}")
+
+        self.assertGreater(voltage_l1_n, 0.0)
+        self.assertGreater(current_l1, -2000.0)
+        self.assertGreater(frequency, 0.0)


### PR DESCRIPTION
## Summary
- add Schneider Electric EM4200 Modbus energy meter model using float register map block
- update smart_building_pack catalog, profile, and README + default instance
- add Modbus smoke integration test for EM4200

## Testing
- poetry run python tools/validate_models.py
- poetry run pytest

## Sources
- EM4200 Modbus Register Map (Version 1, Date Jan 30 2019): https://www.se.com/us/en/download/document/EM4200_Modbus_Register_Map/
- EM4200 documentation FAQ (Published 1/29/2016, last modified 2/4/2023): https://www.se.com/us/en/faqs/FA279387/
- EM4200 specification sheet: https://www.se.com/us/en/download/document/13656969/