### PR TITLE
Add Schneider PowerLogic PM8000 Modbus meter

### DIFF
--- a/library/catalog/industries.yaml
+++ b/library/catalog/industries.yaml
@@ -19,6 +19,8 @@ industries:
         instance: spx_hvac_flexit_nordic_bacnet
       - model: Energy.EnergyMeterIem3000.Modbus
         instance: spx_energy_meter_iem3000_modbus
+      - model: Energy.EnergyMeterPm8000.Modbus
+        instance: spx_energy_meter_pm8000_modbus
       - model: Weather.WeatherFeed.Http
         instance: spx_weather_feed
       - model: Weather.WeatherGateway.WagoPfc200.VaisalaWxt530.Mqtt

--- a/library/catalog/models.yaml
+++ b/library/catalog/models.yaml
@@ -331,6 +331,15 @@ models:
       - id: modbus_tcp_gateway
     packages: [smart_building_pack]
     profiles: [bms_quickstart]
+  - id: Energy.EnergyMeterPm8000.Modbus
+    name: Schneider Electric PowerLogic PM8000 Meter (Modbus)
+    path: library/domains/iot/schneider_electric/schneider_powerlogic_pm8000__modbus.yaml
+    domain: iot
+    protocols: [modbus]
+    services:
+      - id: modbus_tcp_gateway
+    packages: [smart_building_pack]
+    profiles: [bms_quickstart]
   - id: Energy.EVSE.Ocpp
     name: EVSE / Charge Point (OCPP 1.6)
     path: library/domains/energy/emobility/evse__ocpp.yaml

--- a/library/domains/iot/schneider_electric/schneider_powerlogic_pm8000__modbus.yaml
+++ b/library/domains/iot/schneider_electric/schneider_powerlogic_pm8000__modbus.yaml
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: MIT
+
+name: schneider_powerlogic_pm8000__modbus
+description: |
+  Modbus TCP (slave) simulation of a Schneider Electric PowerLogic PM8000
+  power/energy meter. The register mapping follows the PM8000 Modbus Map
+  (float32 quantities for average currents/voltages, total powers, frequency,
+  and energy totals).
+
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5025
+  modbus_unit_id:
+    type: int
+    default: 1
+
+attributes:
+  # Averaged electrical measurements
+  k__current_avg_a: 12.0
+  k__voltage_ll_avg_v: 400.0
+  k__voltage_ln_avg_v: 230.0
+  k__power_factor: 0.97
+  power_factor_leading: 0
+  k__frequency_hz: 50.0
+
+  # Derived totals (W/VAR/VA)
+  active_power_total_w: 0.0
+  reactive_power_total_var: 0.0
+  apparent_power_total_va: 0.0
+
+  # Cumulative energy (kWh)
+  energy_import_total_kwh: 0.0
+  energy_export_total_kwh: 0.0
+
+  _cycle_time_s: 1.0
+
+actions:
+  - function: $in(apparent_power_total_va)
+    name: compute_apparent_power
+    description: Total apparent power from average VLL and current.
+    call: |
+      (lambda s: abs(s))(
+        1.7320508075688772 * $in(k__voltage_ll_avg_v) * $in(k__current_avg_a)
+      )
+
+  - function: $in(active_power_total_w)
+    name: compute_active_power
+    description: Total active power from apparent power and power factor.
+    call: |
+      1.7320508075688772
+      * $in(k__voltage_ll_avg_v)
+      * $in(k__current_avg_a)
+      * $in(k__power_factor)
+
+  - function: $in(reactive_power_total_var)
+    name: compute_reactive_power
+    description: Reactive power magnitude with leading/lagging sign.
+    call: |
+      (max(0.0, ($in(apparent_power_total_va) ** 2) - ($in(active_power_total_w) ** 2)) ** 0.5)
+      * (-1.0 if $in(power_factor_leading) else 1.0)
+
+  - function: $in(energy_import_total_kwh)
+    name: integrate_energy_import
+    description: Integrate imported energy (kWh) from active power (W).
+    call: |
+      $in(energy_import_total_kwh)
+      + max(0.0, $in(active_power_total_w)) * $in(_cycle_time_s) / 3600000.0
+
+  - function: $in(energy_export_total_kwh)
+    name: integrate_energy_export
+    description: Integrate exported energy (kWh) from active power (W).
+    call: |
+      $in(energy_export_total_kwh)
+      + max(0.0, -$in(active_power_total_w)) * $in(_cycle_time_s) / 3600000.0
+
+communication:
+  - modbus_slave:
+      host: 0.0.0.0
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
+      zero_fill: true
+      mapping:
+        # Averages (Float32 input registers)
+        k__current_avg_a:     { address: [3010, 3011], group: i_r, type: float }
+        k__voltage_ll_avg_v:  { address: [3026, 3027], group: i_r, type: float }
+        k__voltage_ln_avg_v:  { address: [3036, 3037], group: i_r, type: float }
+
+        # Power totals (Float32 input registers)
+        active_power_total_w:    { address: [3060, 3061], group: i_r, type: float }
+        reactive_power_total_var: { address: [3068, 3069], group: i_r, type: float }
+        apparent_power_total_va: { address: [3076, 3077], group: i_r, type: float }
+
+        # Power factor + frequency (Float32 input registers)
+        k__power_factor:      { address: [3150, 3151], group: i_r, type: float }
+        k__frequency_hz:      { address: [3110, 3111], group: i_r, type: float }
+
+        # Energy totals (Float32 input registers)
+        energy_import_total_kwh: { address: [2700, 2701], group: i_r, type: float }
+        energy_export_total_kwh: { address: [2702, 2703], group: i_r, type: float }
+
+scenarios:
+  peak_demand:
+    description: High load, lagging power factor.
+    duration: 30.0
+    overrides:
+      $in(k__current_avg_a): 80.0
+      $in(k__power_factor): 0.92
+      $in(power_factor_leading): 0
+
+  pv_export:
+    description: Simulated PV export with leading power factor.
+    duration: 30.0
+    overrides:
+      $in(k__current_avg_a): -20.0
+      $in(k__power_factor): 0.98
+      $in(power_factor_leading): 1

--- a/library/industries/smart_building_pack/README.md
+++ b/library/industries/smart_building_pack/README.md
@@ -17,6 +17,7 @@ to validate multi-protocol integrations, test gateways, or build demo dashboards
   - Flexit Nordic HVAC (BACnet): `library/domains/iot/generic/hvac_flexit_nordic__bacnet.yaml`
   - Thermal controller (Modbus): `library/domains/thermal_controllers/generic/thermal_controller__modbus.yaml`
   - Energy meter iEM3000 (Modbus): `library/domains/iot/generic/energy_meter_iem3000__modbus.yaml`
+  - PowerLogic PM8000 meter (Modbus): `library/domains/iot/schneider_electric/schneider_powerlogic_pm8000__modbus.yaml`
 - Lighting
   - Lighting panel (OPC UA): `library/domains/iot/generic/lighting_panel__opcua.yaml`
   - Lighting zone (KNX): `library/domains/iot/generic/lighting_zone__knx.yaml`

--- a/profiles/smart_building_pack/bms_quickstart.yaml
+++ b/profiles/smart_building_pack/bms_quickstart.yaml
@@ -9,6 +9,7 @@ models:
   - library/domains/thermal_controllers/generic/thermal_controller__modbus.yaml
   - library/domains/iot/generic/hvac_flexit_nordic__bacnet.yaml
   - library/domains/iot/generic/energy_meter_iem3000__modbus.yaml
+  - library/domains/iot/schneider_electric/schneider_powerlogic_pm8000__modbus.yaml
   - library/domains/weather/weather_forecast__http.yaml
   - library/domains/weather/weather_gateway_wago_pfc200__vaisala_wxt530__mqtt.yaml
   - library/domains/iot/generic/bms_controller__opcua.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "spx-examples"
-version = "1.1.0-rc.7"
+version = "1.1.0-alpha.5"
 description = "Runnable SPX examples and smoke tests using the Python client against SPX Server."
 authors = ["Aleksander Stanik <aleksander.stanik@hammerheadsengineers.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "spx-examples"
-version = "1.1.0-rc.2"
+version = "1.1.0-alpha.4"
 description = "Runnable SPX examples and smoke tests using the Python client against SPX Server."
 authors = ["Aleksander Stanik <aleksander.stanik@hammerheadsengineers.com>"]
 license = "MIT"

--- a/tests/packs/smart_building_pack/integration/test_modbus_pm8000_smoke.py
+++ b/tests/packs/smart_building_pack/integration/test_modbus_pm8000_smoke.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+
+"""Smoke test for the Schneider Electric PowerLogic PM8000 Modbus model."""
+
+from __future__ import annotations
+
+import os
+import struct
+import unittest
+
+from tests.common.modbus_utils import wait_for_modbus_endpoint
+from tests.common.spx_utils import require_existing_instance, wait_for_condition
+from tests.devices.modbus_sut_base import ModbusTcpClient
+
+INSTANCE_KEY = "spx_energy_meter_pm8000_modbus"
+MODEL_ID = "Energy.EnergyMeterPm8000.Modbus"
+SPX_BASE_URL = os.environ.get("SPX_BASE_URL", "http://localhost:8000")
+
+
+def _decode_float_abcd(registers: list[int]) -> float:
+    if len(registers) < 2:
+        raise ValueError(f"Expected 2 registers, got {len(registers)}")
+    return struct.unpack(">f", struct.pack(">HH", registers[0], registers[1])
+    )[0]
+
+
+def _call_with_unit_kwarg(client, method_name: str, *args, unit_id: int, **kwargs):
+    method = getattr(client, method_name)
+    try:
+        return method(*args, slave=unit_id, **kwargs)
+    except TypeError as exc:
+        if "unexpected keyword argument" in str(exc) and "'slave'" in str(exc):
+            return method(*args, unit=unit_id, **kwargs)
+        raise
+
+
+class TestModbusPm8000Smoke(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if ModbusTcpClient is None:  # pragma: no cover - dependency missing
+            raise unittest.SkipTest(
+                "pymodbus is not available. Install pymodbus to run Modbus integration tests."
+            )
+
+        try:
+            import spx_python  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise unittest.SkipTest(f"spx_python not available: {exc}") from exc
+
+        product_key = os.environ.get("SPX_PRODUCT_KEY")
+        if not product_key:
+            raise unittest.SkipTest("SPX_PRODUCT_KEY must be set to run integration tests.")
+
+        cls._client = spx_python.init(address=SPX_BASE_URL, product_key=product_key)
+        cls._instance = require_existing_instance(
+            cls._client,
+            INSTANCE_KEY,
+            expected_model_id=MODEL_ID,
+            ensure_running=False,
+        )
+
+        try:
+            cls._instance.stop()
+        except Exception:
+            pass
+        try:
+            cls._instance.reset()
+        except Exception:
+            pass
+        try:
+            cls._instance.start()
+        except Exception:
+            pass
+
+    def setUp(self):
+        instance = getattr(self.__class__, "_instance", None)
+        if instance is None:  # pragma: no cover - defensive
+            self.skipTest("PM8000 instance not initialised")
+
+        try:
+            port, unit_id = wait_for_modbus_endpoint(instance, timeout=10.0, interval=0.2)
+        except TimeoutError as exc:
+            self.skipTest(str(exc))
+
+        self._modbus_port = port
+        self._modbus_unit_id = unit_id
+
+    def _connect_client(self):
+        client = ModbusTcpClient(host="127.0.0.1", port=self._modbus_port)
+        if not wait_for_condition(client.connect, timeout=5.0, interval=0.2):
+            self.skipTest(
+                f"Modbus server not reachable at 127.0.0.1:{self._modbus_port} (unit {self._modbus_unit_id})"
+            )
+        return client
+
+    def test_reads_current_avg_register(self):
+        client = self._connect_client()
+        try:
+            result = _call_with_unit_kwarg(
+                client,
+                "read_input_registers",
+                3010,
+                count=2,
+                unit_id=self._modbus_unit_id,
+            )
+            if result is None or getattr(result, "isError", lambda: True)():
+                self.fail("Modbus read_input_registers failed for PM8000 current_avg")
+            value = _decode_float_abcd(result.registers)
+            self.assertTrue(
+                value == value,  # NaN check
+                "Decoded current_avg value is NaN",
+            )
+        finally:
+            client.close()


### PR DESCRIPTION
## Summary
- add Schneider Electric PowerLogic PM8000 Modbus meter model and mapping
- register PM8000 in smart_building_pack catalog/profile/default instances
- add Modbus PM8000 smoke integration test

## Testing
- poetry run python tools/validate_models.py
- poetry run pytest