### PR TITLE
Add Prevac BCU14 Modbus model

### DIFF
--- a/library/catalog/industries.yaml
+++ b/library/catalog/industries.yaml
@@ -93,6 +93,8 @@ industries:
         instance: spx_vacuum_gauge
       - model: Process.VacuumGaugeMultichannel.Modbus
         instance: spx_vacuum_gauge_multichannel
+      - model: Process.ThermalController.PrevacBcu14.Modbus
+        instance: spx_prevac_bcu14
     start_instances:
       - spx_health_monitor_ble
       - spx_temp_sensor_ble

--- a/library/catalog/models.yaml
+++ b/library/catalog/models.yaml
@@ -179,6 +179,15 @@ models:
       - id: modbus_tcp_gateway
     packages: [industrial_iiot_pack]
     profiles: []
+  - id: Process.ThermalController.PrevacBcu14.Modbus
+    name: Prevac BCU14 Bakeout Controller (Modbus TCP)
+    path: library/domains/thermal_controllers/prevac/prevac_bcu14__modbus.yaml
+    domain: thermal_controllers
+    protocols: [modbus]
+    services:
+      - id: modbus_tcp_gateway
+    packages: [embedded_lab_pack]
+    profiles: [scpi_lab]
   - id: Process.ThermalController.Advanced
     name: Thermal Controller (Advanced)
     path: library/domains/thermal_controllers/generic/thermal_controller_advanced.yaml

--- a/library/domains/thermal_controllers/prevac/prevac_bcu14__modbus.yaml
+++ b/library/domains/thermal_controllers/prevac/prevac_bcu14__modbus.yaml
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Hammerheads Engineers Sp. z o.o.
+# See the accompanying LICENSE file for terms.
+
+name: prevac_bcu14__modbus
+description: |
+  Prevac BCU14 bakeout controller with two independent heating zones.
+  Modbus register map based on BCU14 User Manual rev. 1 (Nov 2025), firmware 3.7.3.
+
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5031
+  modbus_unit_id:
+    type: int
+    default: 1
+
+attributes:
+  # Zone 1 controls/status.
+  cmd__zone1_go_operate: 0
+  cmd__zone1_go_standby: 0
+  zone1_status_bits: 0
+  k__zone1_timer_direction: 0
+  zone1_remaining_reg_time_s: 0
+  k__zone1_reg_bakeout_time_s: 3600
+  zone1_remaining_cont_time_s: 0
+  k__zone1_cont_bakeout_time_s: 0
+  zone1_actual_temp_c: 25
+  k__zone1_temp_unit: 0
+  k__zone1_target_temp_c: 120
+  zone1_actual_target_temp_c: 120
+  k__zone1_fan_start_temp_c: 80
+  k__zone1_ramp_rate_c_per_unit: 5
+  k__zone1_ramp_rate_unit: 1
+  k__zone1_controlled_cooling: 1
+  k__zone1_autostart_interlock: 0
+  k__zone1_power_fail_signal: 0
+
+  # Zone 2 controls/status.
+  cmd__zone2_go_operate: 0
+  cmd__zone2_go_standby: 0
+  zone2_status_bits: 0
+  k__zone2_timer_direction: 0
+  zone2_remaining_reg_time_s: 0
+  k__zone2_reg_bakeout_time_s: 3600
+  zone2_remaining_cont_time_s: 0
+  k__zone2_cont_bakeout_time_s: 0
+  zone2_actual_temp_c: 25
+  k__zone2_temp_unit: 0
+  k__zone2_target_temp_c: 120
+  zone2_actual_target_temp_c: 120
+  k__zone2_fan_start_temp_c: 80
+  k__zone2_ramp_rate_c_per_unit: 5
+  k__zone2_ramp_rate_unit: 1
+  k__zone2_controlled_cooling: 1
+  k__zone2_autostart_interlock: 0
+  k__zone2_power_fail_signal: 0
+
+  # Global device settings.
+  cmd__release_remote_control: 0
+  remote_control_enabled: 0
+
+  # Internal helpers.
+  _zone1_temp_min_c: 0
+  _zone1_temp_max_c: 1200
+  _zone1_temp_response_gain: 0.08
+  _zone2_temp_min_c: 0
+  _zone2_temp_max_c: 1200
+  _zone2_temp_response_gain: 0.08
+
+actions:
+  - function: $in(zone1_actual_target_temp_c)
+    name: sync_zone1_target
+    description: Keep actual target temperature aligned with the zone 1 target.
+    call: $in(k__zone1_target_temp_c)
+
+  - function: $in(zone2_actual_target_temp_c)
+    name: sync_zone2_target
+    description: Keep actual target temperature aligned with the zone 2 target.
+    call: $in(k__zone2_target_temp_c)
+
+  - function: $in(zone1_actual_temp_c)
+    name: zone1_temperature_follow
+    description: Simple first-order response for zone 1 bakeout temperature.
+    call: max(
+          $in(_zone1_temp_min_c),
+          min(
+            $in(_zone1_temp_max_c),
+            $in(zone1_actual_temp_c)
+            + $in(_zone1_temp_response_gain)
+              * ($in(zone1_actual_target_temp_c) - $in(zone1_actual_temp_c))
+          )
+        )
+
+  - function: $in(zone2_actual_temp_c)
+    name: zone2_temperature_follow
+    description: Simple first-order response for zone 2 bakeout temperature.
+    call: max(
+          $in(_zone2_temp_min_c),
+          min(
+            $in(_zone2_temp_max_c),
+            $in(zone2_actual_temp_c)
+            + $in(_zone2_temp_response_gain)
+              * ($in(zone2_actual_target_temp_c) - $in(zone2_actual_temp_c))
+          )
+        )
+
+communication:
+  - modbus_slave:
+      host: 0.0.0.0
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
+      zero_fill: true
+      mapping:
+        cmd__zone1_go_operate: { address: [0,0], group: h_r, type: uint_16 }
+        cmd__zone1_go_standby: { address: [1,1], group: h_r, type: uint_16 }
+        zone1_status_bits: { address: [2,2], group: h_r, type: uint_16 }
+        k__zone1_timer_direction: { address: [3,3], group: h_r, type: uint_16 }
+        zone1_remaining_reg_time_s: { address: [4,5], group: h_r, type: uint_32 }
+        k__zone1_reg_bakeout_time_s: { address: [6,7], group: h_r, type: uint_32 }
+        zone1_remaining_cont_time_s: { address: [8,9], group: h_r, type: uint_32 }
+        k__zone1_cont_bakeout_time_s: { address: [10,11], group: h_r, type: uint_32 }
+        zone1_actual_temp_c: { address: [12,12], group: h_r, type: uint_16 }
+        k__zone1_temp_unit: { address: [13,13], group: h_r, type: uint_16 }
+        k__zone1_target_temp_c: { address: [14,14], group: h_r, type: uint_16 }
+        zone1_actual_target_temp_c: { address: [15,15], group: h_r, type: uint_16 }
+        k__zone1_fan_start_temp_c: { address: [16,16], group: h_r, type: uint_16 }
+        k__zone1_ramp_rate_c_per_unit: { address: [17,17], group: h_r, type: uint_16 }
+        k__zone1_ramp_rate_unit: { address: [18,18], group: h_r, type: uint_16 }
+        k__zone1_controlled_cooling: { address: [19,19], group: h_r, type: uint_16 }
+        k__zone1_autostart_interlock: { address: [20,20], group: h_r, type: uint_16 }
+        k__zone1_power_fail_signal: { address: [21,21], group: h_r, type: uint_16 }
+
+        cmd__zone2_go_operate: { address: [27,27], group: h_r, type: uint_16 }
+        cmd__zone2_go_standby: { address: [28,28], group: h_r, type: uint_16 }
+        zone2_status_bits: { address: [29,29], group: h_r, type: uint_16 }
+        k__zone2_timer_direction: { address: [30,30], group: h_r, type: uint_16 }
+        zone2_remaining_reg_time_s: { address: [31,32], group: h_r, type: uint_32 }
+        k__zone2_reg_bakeout_time_s: { address: [33,34], group: h_r, type: uint_32 }
+        zone2_remaining_cont_time_s: { address: [35,36], group: h_r, type: uint_32 }
+        k__zone2_cont_bakeout_time_s: { address: [37,38], group: h_r, type: uint_32 }
+        zone2_actual_temp_c: { address: [39,39], group: h_r, type: uint_16 }
+        k__zone2_temp_unit: { address: [40,40], group: h_r, type: uint_16 }
+        k__zone2_target_temp_c: { address: [41,41], group: h_r, type: uint_16 }
+        zone2_actual_target_temp_c: { address: [42,42], group: h_r, type: uint_16 }
+        k__zone2_fan_start_temp_c: { address: [43,43], group: h_r, type: uint_16 }
+        k__zone2_ramp_rate_c_per_unit: { address: [44,44], group: h_r, type: uint_16 }
+        k__zone2_ramp_rate_unit: { address: [45,45], group: h_r, type: uint_16 }
+        k__zone2_controlled_cooling: { address: [46,46], group: h_r, type: uint_16 }
+        k__zone2_autostart_interlock: { address: [47,47], group: h_r, type: uint_16 }
+        k__zone2_power_fail_signal: { address: [48,48], group: h_r, type: uint_16 }
+
+        cmd__release_remote_control: { address: [1000,1000], group: h_r, type: uint_16 }
+        remote_control_enabled: { address: [1151,1151], group: h_r, type: uint_16 }
+
+scenarios:
+  zone1_bakeout:
+    description: Drive zone 1 to a higher bakeout target.
+    duration: 20.0
+    overrides:
+      $in(k__zone1_target_temp_c): 200
+      $in(k__zone1_fan_start_temp_c): 120
+
+  zone2_bakeout:
+    description: Drive zone 2 to a higher bakeout target.
+    duration: 20.0
+    overrides:
+      $in(k__zone2_target_temp_c): 220
+      $in(k__zone2_fan_start_temp_c): 130

--- a/library/industries/embedded_lab_pack/README.md
+++ b/library/industries/embedded_lab_pack/README.md
@@ -4,5 +4,5 @@ Bundle of BLE/LwM2M/MQTT edge nodes and SCPI/modbus instruments for CI pipelines
 and firmware validation labs.
 
 - **Protocols**: BLE GATT, MQTT, LwM2M/CoAP, SCPI (ASCII/TCP), Modbus TCP.
-- **Models**: health wearables, temperature sensors, multimeter, vacuum gauge.
+- **Models**: health wearables, temperature sensors, multimeter, vacuum gauge, Prevac BCU14 bakeout controller.
 - **Quickstarts**: `profiles/embedded_lab_pack/mhealth_ci.yaml`, `profiles/embedded_lab_pack/scpi_lab.yaml`.

--- a/profiles/embedded_lab_pack/scpi_lab.yaml
+++ b/profiles/embedded_lab_pack/scpi_lab.yaml
@@ -5,6 +5,7 @@ description: |
 models:
   - library/domains/measurement_instruments/generic/multimeter__scpi.yaml
   - library/domains/vacuum_systems/generic/vacuum_gauge__modbus.yaml
+  - library/domains/thermal_controllers/prevac/prevac_bcu14__modbus.yaml
 services:
   - scpi_tcp_stack
   - modbus_tcp_gateway

--- a/tests/devices/modbus_prevac_bcu14_sut_example.py
+++ b/tests/devices/modbus_prevac_bcu14_sut_example.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Hammerheads Engineers Sp. z o.o.
+# See the accompanying LICENSE file for terms.
+
+"""Example SUT implementation: Modbus Prevac BCU14 client used in integration tests."""
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence
+
+from .modbus_sut_base import (
+    ModbusMap,
+    ModbusSUTBase,
+    ModbusTcpClient,
+    RegisterDecoder,
+)
+
+DEFAULT_MODBUS_MAP: ModbusMap = {
+    "zone1_actual_temp_c": {"address": 12, "decoder": "u16"},
+    "zone1_target_temp_c": {"address": 14, "decoder": "u16"},
+    "zone2_actual_temp_c": {"address": 39, "decoder": "u16"},
+    "zone2_target_temp_c": {"address": 41, "decoder": "u16"},
+}
+
+
+def _decode_u16(registers: Sequence[int]) -> int:
+    return registers[0] & 0xFFFF
+
+
+class ModbusPrevacBCU14SUTExample(ModbusSUTBase):
+    """Thin wrapper around pymodbus representing the BCU14 Modbus bakeout controller."""
+
+    _DECODER_REGISTRY: Dict[str, RegisterDecoder] = {
+        "u16": RegisterDecoder(count=1, fn=_decode_u16),
+    }
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 502,
+        unit_id: int = 1,
+        timeout: float = 2.0,
+        mapping: Optional[ModbusMap] = None,
+    ) -> None:
+        super().__init__(
+            default_map=DEFAULT_MODBUS_MAP,
+            mapping=mapping,
+            host=host,
+            port=port,
+            unit_id=unit_id,
+            timeout=timeout,
+        )
+
+    def _read(self, field_name: str) -> int:
+        config = self._get_field_config(field_name)
+        address = self._get_address(config, field_name)
+        decoder_key = config.get("decoder", "u16")
+        decoder = self._DECODER_REGISTRY.get(decoder_key)
+        if decoder is None:
+            raise ValueError(f"Unsupported decoder '{decoder_key}' for field '{field_name}'")
+        registers = self._read_holding_registers(address, decoder.count)
+        return int(decoder.decode(registers))
+
+    def read_u16(self, field_name: str) -> int:
+        return self._read(field_name)
+
+    def write_u16(self, field_name: str, value: int) -> None:
+        config = self._get_field_config(field_name)
+        address = self._get_address(config, field_name)
+        self._write_registers(address, [int(value) & 0xFFFF])
+
+    def read_zone1_actual_temp(self) -> int:
+        return self.read_u16("zone1_actual_temp_c")
+
+    def read_zone1_target_temp(self) -> int:
+        return self.read_u16("zone1_target_temp_c")
+
+    def read_zone2_actual_temp(self) -> int:
+        return self.read_u16("zone2_actual_temp_c")
+
+    def read_zone2_target_temp(self) -> int:
+        return self.read_u16("zone2_target_temp_c")
+
+    def set_zone1_target_temp(self, value: int) -> None:
+        self.write_u16("zone1_target_temp_c", value)
+
+    def set_zone2_target_temp(self, value: int) -> None:
+        self.write_u16("zone2_target_temp_c", value)
+
+
+__all__ = ["ModbusPrevacBCU14SUTExample", "ModbusTcpClient"]

--- a/tests/packs/embedded_lab_pack/integration/test_modbus_prevac_bcu14_smoke.py
+++ b/tests/packs/embedded_lab_pack/integration/test_modbus_prevac_bcu14_smoke.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: MIT
+
+import os
+import unittest
+
+from tests.common.modbus_utils import wait_for_modbus_endpoint
+from tests.common.spx_utils import require_existing_instance, wait_for_condition, wait_seconds
+from tests.devices.modbus_prevac_bcu14_sut_example import (
+    ModbusPrevacBCU14SUTExample,
+    ModbusTcpClient,
+)
+
+
+SPX_BASE_URL = os.environ.get("SPX_BASE_URL", "http://localhost:8000")
+INSTANCE_KEY = "spx_prevac_bcu14"
+MODEL_ID = "Process.ThermalController.PrevacBcu14.Modbus"
+
+
+class TestModbusPrevacBCU14Smoke(unittest.TestCase):
+    """Smoke coverage for the Prevac BCU14 Modbus TCP bakeout controller."""
+
+    @classmethod
+    def setUpClass(cls):
+        if ModbusTcpClient is None:  # pragma: no cover - dependency missing
+            raise unittest.SkipTest(
+                "pymodbus is not available. Install pymodbus to run Modbus integration tests."
+            )
+
+        try:
+            import spx_python  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise unittest.SkipTest(f"spx_python not available: {exc}") from exc
+
+        product_key = os.environ.get("SPX_PRODUCT_KEY")
+        if not product_key:
+            raise unittest.SkipTest("SPX_PRODUCT_KEY must be set to run integration tests.")
+
+        cls._spx = spx_python
+        cls._client = spx_python.init(address=SPX_BASE_URL, product_key=product_key)
+        cls._instance = require_existing_instance(
+            cls._client,
+            INSTANCE_KEY,
+            expected_model_id=MODEL_ID,
+            ensure_running=False,
+        )
+
+        for action in (cls._instance.stop, cls._instance.reset, cls._instance.start):
+            try:
+                action()
+            except Exception:
+                pass
+
+    def setUp(self):
+        for comm_key in ("modbus_slave", "modbus_tcp"):
+            try:
+                comm = self._instance["communication"][comm_key]
+            except Exception:
+                continue
+            attach = getattr(comm, "attach", None)
+            if callable(attach):
+                try:
+                    attach()
+                except Exception:
+                    pass
+
+        try:
+            port, unit_id = wait_for_modbus_endpoint(self._instance, timeout=10.0, interval=0.2)
+        except TimeoutError as exc:
+            self.skipTest(str(exc))
+
+        self._modbus_port = port
+        self._modbus_unit_id = unit_id
+        self.sut = ModbusPrevacBCU14SUTExample(
+            host="127.0.0.1",
+            port=port,
+            unit_id=unit_id,
+            timeout=1.0,
+        )
+        if not self.sut.connect():
+            self.skipTest(f"Modbus server not reachable at 127.0.0.1:{port} (unit {unit_id})")
+
+    def tearDown(self):
+        if hasattr(self, "sut") and self.sut:
+            self.sut.close()
+
+    def test_zone1_target_write_and_temperature_response(self):
+        baseline = self.sut.read_zone1_actual_temp()
+        target = min(1200, baseline + 25)
+
+        self.sut.set_zone1_target_temp(target)
+        wait_seconds(0.2)
+        self.assertEqual(self.sut.read_zone1_target_temp(), target)
+
+        self.assertTrue(
+            wait_for_condition(
+                lambda: self.sut.read_zone1_actual_temp() >= baseline + 1,
+                timeout=20.0,
+                interval=0.5,
+            ),
+            "Expected zone 1 temperature to begin moving toward the target",
+        )


### PR DESCRIPTION
## Summary
- add Prevac BCU14 Modbus TCP model (two-zone bakeout controller)
- register model in embedded_lab_pack catalog/profile/default instances
- add Modbus smoke integration test + SUT helper

## Testing
- poetry run python tools/validate_models.py
- poetry run pytest