### PR TITLE
fix(thermal_controllers): align eurotherm 3216 modbus attrs with repo…

### DIFF
--- a/examples/packs/industrial_iiot_pack/industrial_pack_eurotherm_setpoints.ipynb
+++ b/examples/packs/industrial_iiot_pack/industrial_pack_eurotherm_setpoints.ipynb
@@ -91,10 +91,10 @@
           "output_type": "stream",
           "text": [
             "Before update:\n",
-            "  Eurotherm 3216 setpoint_c = 30\n",
+            "  Eurotherm 3216 k__setpoint_c = 30\n",
             "  Eurotherm 3504 pressure_sp_bar = 10.0\n",
             "After update:\n",
-            "  Eurotherm 3216 setpoint_c = 60\n",
+            "  Eurotherm 3216 k__setpoint_c = 60\n",
             "  Eurotherm 3504 pressure_sp_bar = 10.0\n"
           ]
         }
@@ -103,22 +103,22 @@
         "attrs_3216 = euro_3216[\"attributes\"]\n",
         "attrs_3504 = euro_3504[\"attributes\"]\n",
         "\n",
-        "temp_sp = attrs_3216[\"target_sp_raw\"]\n",
+        "temp_sp = attrs_3216[\"k__setpoint_c\"]\n",
         "pressure_sp = attrs_3504[\"pressure_sp_bar\"]\n",
         "\n",
         "# Ensure auto mode (0 = auto, 1 = manual)\n",
-        "attrs_3216[\"auto_man_raw\"].internal_value = 0\n",
+        "attrs_3216[\"k__auto_man\"].internal_value = 0\n",
         "attrs_3504[\"auto_man_raw\"].internal_value = 0\n",
         "\n",
         "print(\"Before update:\")\n",
-        "print(\"  Eurotherm 3216 setpoint_c =\", temp_sp.external_value)\n",
+        "print(\"  Eurotherm 3216 k__setpoint_c =\", temp_sp.external_value)\n",
         "print(\"  Eurotherm 3504 pressure_sp_bar =\", pressure_sp.external_value)\n",
         "\n",
         "temp_sp.internal_value = 60.0\n",
         "pressure_sp.internal_value = 2.5\n",
         "\n",
         "print(\"After update:\")\n",
-        "print(\"  Eurotherm 3216 setpoint_c =\", temp_sp.external_value)\n",
+        "print(\"  Eurotherm 3216 k__setpoint_c =\", temp_sp.external_value)\n",
         "print(\"  Eurotherm 3504 pressure_sp_bar =\", pressure_sp.external_value)\n"
       ]
     }

--- a/library/domains/thermal_controllers/eurotherm/eurotherm_3216__modbus.yaml
+++ b/library/domains/thermal_controllers/eurotherm/eurotherm_3216__modbus.yaml
@@ -15,24 +15,33 @@ description: |
     - 5   WKG.SP  (Working setpoint)
     - 273 A-M     (Mode of the loop: 0=Auto, 1=Manual)
 
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5029
+  modbus_unit_id:
+    type: int
+    default: 1
+
 attributes:
+  # Key control inputs written by external clients or scenarios.
+  k__setpoint_c: 30.0
+  k__manual_out_pct: 0.0
+  k__auto_man: 0
+
+  # Observable process state.
   temperature_c: 25.0
-  setpoint_c: 30.0
   working_setpoint_c: 30.0
   output_pct: 0.0
-  manual_out_pct: 0.0
-  auto_man: 0
 
+  # Environment, tuning, and limits.
   ambient_c: 22.0
   heat_coeff: 0.25
   cool_coeff: 0.03
   power_gain: 1.5
-  power_integral: 0.0
   power_integral_gain: 0.2
   power_integral_leak: 0.05
-  power_derivative: 0.0
   power_derivative_gain: 0.8
-  power_error_prev: 0.0
 
   temp_min_c: 0.0
   temp_max_c: 200.0
@@ -40,58 +49,73 @@ attributes:
   sp_max_c: 200.0
   out_min: 0.0
   out_max: 100.0
-  scale_0p1: 10.0
 
-  pv_raw: 250
-  target_sp_raw: 300
-  manual_out_raw: 0
-  working_out_raw: 0
-  working_sp_raw: 300
-  auto_man_raw: 0
+  # Hidden controller state.
+  _power_integral: 0.0
+  _power_derivative: 0.0
+  _power_error_prev: 0.0
+  _scale_0p1: 10.0
+
+  # Hidden Modbus transport payloads.
+  _pv_raw: 250
+  _target_sp_raw: 300
+  _manual_out_raw: 0
+  _working_out_raw: 0
+  _working_sp_raw: 300
+  _auto_man_raw: 0
+  _target_sp_raw_prev: 300
+  _manual_out_raw_prev: 0
+  _auto_man_raw_prev: 0
+  _setpoint_c_prev: 30.0
+  _manual_out_pct_prev: 0.0
+  _auto_man_prev: 0
 
 actions:
-  - function: $in(auto_man)
+  - function: $in(k__auto_man)
     name: sync_auto_man
     description: Resolve auto/manual mode from the Modbus register.
-    call: 1 if $in(auto_man_raw) else 0
+    call: $in(k__auto_man) if $in(_auto_man_raw) == $in(_auto_man_raw_prev)
+          else (1 if $in(_auto_man_raw) else 0)
 
-  - function: $in(setpoint_c)
+  - function: $in(k__setpoint_c)
     name: sync_target_sp
     description: Decode Target SP (0.1 resolution scaled integer).
-    call: max($in(sp_min_c), min($in(sp_max_c), $in(target_sp_raw) / $in(scale_0p1)))
+    call: $in(k__setpoint_c) if $in(_target_sp_raw) == $in(_target_sp_raw_prev)
+          else max($in(sp_min_c), min($in(sp_max_c), $in(_target_sp_raw) / $in(_scale_0p1)))
 
-  - function: $in(manual_out_pct)
+  - function: $in(k__manual_out_pct)
     name: sync_manual_out
     description: Decode Manual Output (0.1 resolution scaled integer).
-    call: max($in(out_min), min($in(out_max), $in(manual_out_raw) / $in(scale_0p1)))
+    call: $in(k__manual_out_pct) if $in(_manual_out_raw) == $in(_manual_out_raw_prev)
+          else max($in(out_min), min($in(out_max), $in(_manual_out_raw) / $in(_scale_0p1)))
 
   - function: $in(working_setpoint_c)
     name: sync_working_sp
     description: Use Target SP as Working SP for the minimal simulation.
-    call: $in(setpoint_c)
+    call: $in(k__setpoint_c)
 
-  - function: $in(power_derivative)
+  - function: $in(_power_derivative)
     name: update_derivative
     description: Derivative contribution based on PV error slope.
-    call: 0.0 if $in(auto_man) == 1
-          else $in(power_derivative_gain) * (($in(setpoint_c) - $in(temperature_c)) - $in(power_error_prev))
+    call: 0.0 if $in(k__auto_man) == 1
+          else $in(power_derivative_gain) * (($in(k__setpoint_c) - $in(temperature_c)) - $in(_power_error_prev))
 
-  - function: $in(power_error_prev)
+  - function: $in(_power_error_prev)
     name: update_error_prev
-    call: 0.0 if $in(auto_man) == 1 else ($in(setpoint_c) - $in(temperature_c))
+    call: 0.0 if $in(k__auto_man) == 1 else ($in(k__setpoint_c) - $in(temperature_c))
 
-  - function: $in(power_integral)
+  - function: $in(_power_integral)
     name: update_integral
     description: Integrator bias to offset steady-state error.
-    call: 0.0 if $in(auto_man) == 1
+    call: 0.0 if $in(k__auto_man) == 1
           else (
-            max(0, $in(power_integral) * (1 - $in(power_integral_leak)))
-            if ($in(setpoint_c) - $in(temperature_c) <= 0)
+            max(0, $in(_power_integral) * (1 - $in(power_integral_leak)))
+            if ($in(k__setpoint_c) - $in(temperature_c) <= 0)
             else max(
               0,
               min(
                 $in(out_max),
-                $in(power_integral) + $in(power_integral_gain) * ($in(setpoint_c) - $in(temperature_c))
+                $in(_power_integral) + $in(power_integral_gain) * ($in(k__setpoint_c) - $in(temperature_c))
               )
             )
           )
@@ -104,11 +128,11 @@ actions:
             $in(out_min),
             min(
               $in(out_max),
-              $in(power_gain) * ($in(setpoint_c) - $in(temperature_c)) + $in(power_integral) + $in(power_derivative)
+              $in(power_gain) * ($in(k__setpoint_c) - $in(temperature_c)) + $in(_power_integral) + $in(_power_derivative)
             )
           )
-          if $in(auto_man) == 0
-          else max($in(out_min), min($in(out_max), $in(manual_out_pct)))
+          if $in(k__auto_man) == 0
+          else max($in(out_min), min($in(out_max), $in(k__manual_out_pct)))
         )
 
   - function: $in(temperature_c)
@@ -127,66 +151,157 @@ actions:
           )
         )
 
-  - function: $in(pv_raw)
+  - function: $in(_pv_raw)
     name: encode_pv_raw
     description: Encode PV into 0.1 resolution register.
-    call: int(round($in(temperature_c) * $in(scale_0p1)))
+    call: int(round(max($in(temp_min_c), min($in(temp_max_c), $in(temperature_c))) * $in(_scale_0p1)))
 
-  - function: $in(target_sp_raw)
+  - function: $in(_target_sp_raw)
     name: encode_target_sp_raw
     description: Clamp and encode Target SP.
-    call: int(round($in(setpoint_c) * $in(scale_0p1)))
+    call: $in(_target_sp_raw) if abs($in(k__setpoint_c) - $in(_setpoint_c_prev)) < 1e-9
+          else int(round(max($in(sp_min_c), min($in(sp_max_c), $in(k__setpoint_c))) * $in(_scale_0p1)))
 
-  - function: $in(working_out_raw)
+  - function: $in(_working_out_raw)
     name: encode_working_out_raw
-    call: int(round($in(output_pct) * $in(scale_0p1)))
+    call: int(round(max($in(out_min), min($in(out_max), $in(output_pct))) * $in(_scale_0p1)))
 
-  - function: $in(working_sp_raw)
+  - function: $in(_working_sp_raw)
     name: encode_working_sp_raw
-    call: int(round($in(working_setpoint_c) * $in(scale_0p1)))
+    call: int(round(max($in(sp_min_c), min($in(sp_max_c), $in(working_setpoint_c))) * $in(_scale_0p1)))
 
-  - function: $in(manual_out_raw)
+  - function: $in(_manual_out_raw)
     name: encode_manual_out_raw
-    call: int(round($in(manual_out_pct) * $in(scale_0p1)))
+    call: $in(_manual_out_raw) if abs($in(k__manual_out_pct) - $in(_manual_out_pct_prev)) < 1e-9
+          else int(round(max($in(out_min), min($in(out_max), $in(k__manual_out_pct))) * $in(_scale_0p1)))
 
-  - function: $in(auto_man_raw)
+  - function: $in(_auto_man_raw)
     name: encode_auto_man_raw
-    call: 1 if $in(auto_man) == 1 else 0
+    call: $in(_auto_man_raw) if $in(k__auto_man) == $in(_auto_man_prev)
+          else (1 if $in(k__auto_man) == 1 else 0)
+
+  - function: $in(_target_sp_raw_prev)
+    name: remember_target_sp_raw
+    call: $in(_target_sp_raw)
+
+  - function: $in(_manual_out_raw_prev)
+    name: remember_manual_out_raw
+    call: $in(_manual_out_raw)
+
+  - function: $in(_auto_man_raw_prev)
+    name: remember_auto_man_raw
+    call: $in(_auto_man_raw)
+
+  - function: $in(_setpoint_c_prev)
+    name: remember_setpoint_c
+    call: $in(k__setpoint_c)
+
+  - function: $in(_manual_out_pct_prev)
+    name: remember_manual_out_pct
+    call: $in(k__manual_out_pct)
+
+  - function: $in(_auto_man_prev)
+    name: remember_auto_man
+    call: $in(k__auto_man)
 
 communication:
   - modbus_slave:
       host: 0.0.0.0
-      port: 5029
-      unit_id: 1
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
       zero_fill: true
       mapping:
-        pv_raw:          { address: [1,1], group: h_r, type: uint_16 }
-        target_sp_raw:   { address: [2,2], group: h_r, type: uint_16 }
-        manual_out_raw:  { address: [3,3], group: h_r, type: uint_16 }
-        working_out_raw: { address: [4,4], group: h_r, type: uint_16 }
-        working_sp_raw:  { address: [5,5], group: h_r, type: uint_16 }
-        auto_man_raw:    { address: [273,273], group: h_r, type: uint_16 }
+        _pv_raw:          { address: [1,1], group: h_r, type: uint_16 }
+        _target_sp_raw:   { address: [2,2], group: h_r, type: uint_16 }
+        _manual_out_raw:  { address: [3,3], group: h_r, type: uint_16 }
+        _working_out_raw: { address: [4,4], group: h_r, type: uint_16 }
+        _working_sp_raw:  { address: [5,5], group: h_r, type: uint_16 }
+        _auto_man_raw:    { address: [273,273], group: h_r, type: uint_16 }
 
 scenarios:
   auto_heat_step:
-    enabled: true
+    display_name: "Auto Heat Step"
+    description: Raise the temperature setpoint while keeping the controller in auto mode.
     duration: 20.0
     overrides:
-      $in(auto_man_raw): 0
-      $in(target_sp_raw): 600
-      $in(manual_out_raw): 0
+      $in(k__auto_man): 0
+      $in(k__setpoint_c): 60.0
+      $in(k__manual_out_pct): 0.0
 
   auto_cool_step:
-    enabled: true
+    display_name: "Auto Cool Step"
+    description: Drop the requested setpoint back toward ambient while staying in auto mode.
     duration: 20.0
     overrides:
-      $in(auto_man_raw): 0
-      $in(target_sp_raw): 250
+      $in(k__auto_man): 0
+      $in(k__setpoint_c): 25.0
 
   manual_hold_35:
-    enabled: true
+    display_name: "Manual Hold 35%"
+    description: Hold a fixed manual output and keep the loop in manual mode.
     duration: 15.0
     overrides:
-      $in(auto_man_raw): 1
-      $in(manual_out_raw): 350
-      $in(target_sp_raw): 350
+      $in(k__auto_man): 1
+      $in(k__manual_out_pct): 35.0
+      $in(k__setpoint_c): 35.0
+
+  setpoint_ramp_up:
+    display_name: "Setpoint Ramp Up"
+    description: Ramp the temperature setpoint from 30 C to 75 C in auto mode.
+    duration: 24.0
+    actions:
+      - function: $in(k__auto_man)
+        params: {mode_auto: 0}
+        call: mode_auto
+      - function: $in(k__manual_out_pct)
+        params: {manual_out: 0.0}
+        call: manual_out
+      - function: $in(k__setpoint_c)
+        params:
+          start_sp: 30.0
+          target_sp: 75.0
+          ramp_duration: 18.0
+        call: start_sp + (target_sp - start_sp) * min(1.0, $attr(timer.time) / ramp_duration)
+
+  manual_to_auto_transfer:
+    display_name: "Manual To Auto Transfer"
+    description: Start in manual mode, then hand control back to the automatic loop.
+    duration: 24.0
+    conditions:
+      - if: $attr(timer.time) < 8.0
+        actions:
+          - set: $in(k__auto_man)
+            value: 1
+          - set: $in(k__manual_out_pct)
+            value: 35.0
+          - set: $in(k__setpoint_c)
+            value: 35.0
+      - if: $attr(timer.time) >= 8.0
+        actions:
+          - set: $in(k__auto_man)
+            value: 0
+          - set: $in(k__manual_out_pct)
+            value: 0.0
+          - set: $in(k__setpoint_c)
+            value: 55.0
+
+  ambient_disturbance:
+    display_name: "Ambient Disturbance"
+    description: Alternate ambient temperature every 5 s to exercise controller compensation.
+    duration: 30.0
+    actions:
+      - function: $in(k__auto_man)
+        params: {mode_auto: 0}
+        call: mode_auto
+      - function: $in(k__manual_out_pct)
+        params: {manual_out: 0.0}
+        call: manual_out
+      - function: $in(k__setpoint_c)
+        params: {target_sp: 55.0}
+        call: target_sp
+      - function: $in(ambient_c)
+        params:
+          ambient_base: 22.0
+          ambient_amp: 3.0
+          toggle_period: 5.0
+        call: ambient_base + (ambient_amp if (int($attr(timer.time) / toggle_period) % 2 == 0) else -ambient_amp)

--- a/tests/packs/industrial_iiot_pack/integration/test_pack_instances_running.py
+++ b/tests/packs/industrial_iiot_pack/integration/test_pack_instances_running.py
@@ -102,11 +102,11 @@ class TestIndustrialPackInstancesRunning(unittest.TestCase):
         baseline_pressure = _float_attr(attrs_3504["pressure_sp_bar"])
         self.assertIsNotNone(baseline_pressure, "Unable to read Eurotherm 3504 pressure setpoint.")
 
-        attrs_3216["auto_man_raw"].internal_value = 0
-        attrs_3216["target_sp_raw"].internal_value = 600
+        attrs_3216["k__auto_man"].internal_value = 0
+        attrs_3216["k__setpoint_c"].internal_value = 60.0
 
         temp_ready = wait_for_condition(
-            lambda: abs((_float_attr(attrs_3216["setpoint_c"]) or 0.0) - 60.0) <= 0.1,
+            lambda: abs((_float_attr(attrs_3216["k__setpoint_c"]) or 0.0) - 60.0) <= 0.1,
             timeout=5.0,
             interval=0.2,
         )
@@ -119,7 +119,7 @@ class TestIndustrialPackInstancesRunning(unittest.TestCase):
             "Eurotherm 3504 setpoint changed while updating Eurotherm 3216.",
         )
 
-        baseline_temp = _float_attr(attrs_3216["setpoint_c"])
+        baseline_temp = _float_attr(attrs_3216["k__setpoint_c"])
         self.assertIsNotNone(baseline_temp, "Unable to read Eurotherm 3216 temperature setpoint.")
 
         attrs_3504["auto_man_raw"].internal_value = 0
@@ -132,7 +132,7 @@ class TestIndustrialPackInstancesRunning(unittest.TestCase):
         )
         self.assertTrue(pressure_ready, "Eurotherm 3504 setpoint did not reach 2.5 bar.")
 
-        temp_after_pressure = _float_attr(attrs_3216["setpoint_c"])
+        temp_after_pressure = _float_attr(attrs_3216["k__setpoint_c"])
         self.assertIsNotNone(temp_after_pressure, "Unable to read Eurotherm 3216 temperature setpoint.")
         self.assertTrue(
             abs(temp_after_pressure - baseline_temp) <= 0.1,

--- a/tests/packs/industrial_iiot_pack/unit/test_eurotherm_3216_modbus_model.py
+++ b/tests/packs/industrial_iiot_pack/unit/test_eurotherm_3216_modbus_model.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import yaml
+
+from tests.common.repo import repo_root
+
+ROOT = repo_root()
+MODEL_PATH = (
+    ROOT
+    / "library"
+    / "domains"
+    / "thermal_controllers"
+    / "eurotherm"
+    / "eurotherm_3216__modbus.yaml"
+)
+
+
+def test_eurotherm_3216_modbus_model_uses_key_and_hidden_attributes() -> None:
+    doc = yaml.safe_load(MODEL_PATH.read_text(encoding="utf-8"))
+
+    assert isinstance(doc, dict)
+    assert doc.get("name") == "eurotherm_3216__modbus"
+
+    meta_parameters = doc.get("meta_parameters")
+    assert isinstance(meta_parameters, dict)
+    assert meta_parameters["modbus_port"]["default"] == 5029
+    assert meta_parameters["modbus_unit_id"]["default"] == 1
+
+    attributes = doc.get("attributes")
+    assert isinstance(attributes, dict)
+
+    for key_attr in ("k__setpoint_c", "k__manual_out_pct", "k__auto_man"):
+        assert key_attr in attributes
+
+    for observed_attr in ("temperature_c", "working_setpoint_c", "output_pct"):
+        assert observed_attr in attributes
+
+    for hidden_attr in (
+        "_power_integral",
+        "_power_derivative",
+        "_power_error_prev",
+        "_scale_0p1",
+        "_pv_raw",
+        "_target_sp_raw",
+        "_manual_out_raw",
+        "_working_out_raw",
+        "_working_sp_raw",
+        "_auto_man_raw",
+    ):
+        assert hidden_attr in attributes
+
+    for legacy_public_attr in (
+        "setpoint_c",
+        "manual_out_pct",
+        "auto_man",
+        "pv_raw",
+        "target_sp_raw",
+        "manual_out_raw",
+        "working_out_raw",
+        "working_sp_raw",
+        "auto_man_raw",
+    ):
+        assert legacy_public_attr not in attributes
+
+
+def test_eurotherm_3216_modbus_model_maps_hidden_raw_registers_and_documents_scenarios() -> None:
+    doc = yaml.safe_load(MODEL_PATH.read_text(encoding="utf-8"))
+
+    assert isinstance(doc, dict)
+    communication = doc.get("communication")
+    assert isinstance(communication, list) and communication
+
+    modbus = communication[0].get("modbus_slave")
+    assert isinstance(modbus, dict)
+    mapping = modbus.get("mapping")
+    assert isinstance(mapping, dict)
+
+    assert mapping["_pv_raw"]["address"] == [1, 1]
+    assert mapping["_target_sp_raw"]["address"] == [2, 2]
+    assert mapping["_manual_out_raw"]["address"] == [3, 3]
+    assert mapping["_working_out_raw"]["address"] == [4, 4]
+    assert mapping["_working_sp_raw"]["address"] == [5, 5]
+    assert mapping["_auto_man_raw"]["address"] == [273, 273]
+
+    scenarios = doc.get("scenarios")
+    assert isinstance(scenarios, dict)
+    assert "manual_to_auto_transfer" in scenarios
+    assert "setpoint_ramp_up" in scenarios
+    assert "ambient_disturbance" in scenarios
+
+    for name, scenario in scenarios.items():
+        assert isinstance(scenario, dict), f"Scenario {name!r} must be a mapping"
+        assert isinstance(scenario.get("display_name"), str) and scenario["display_name"]
+        assert isinstance(scenario.get("description"), str) and scenario["description"]
+        assert scenario.get("enabled") is not True
+
+
+def test_eurotherm_3216_modbus_model_is_in_catalog() -> None:
+    catalog_path = ROOT / "library" / "catalog" / "models.yaml"
+    catalog = yaml.safe_load(catalog_path.read_text(encoding="utf-8"))
+
+    assert isinstance(catalog, dict)
+    models = catalog.get("models")
+    assert isinstance(models, list)
+
+    matches = [
+        model
+        for model in models
+        if isinstance(model, dict)
+        and model.get("path")
+        == "library/domains/thermal_controllers/eurotherm/eurotherm_3216__modbus.yaml"
+    ]
+    assert matches, "Model is missing from library/catalog/models.yaml"


### PR DESCRIPTION
This pull request makes significant improvements to the Eurotherm 3216 Modbus model and its related tests, notebook examples, and integration logic. The main focus is on introducing clear separation between key control attributes, observable state, and hidden/internal attributes, and updating all relevant code to use the new naming conventions and structure. Additionally, new scenarios have been added for richer simulation and testing, and comprehensive unit tests now verify the model's structure and catalog inclusion.

**Eurotherm 3216 Modbus model refactor and enhancements:**

* Introduced explicit key control attributes (`k__setpoint_c`, `k__manual_out_pct`, `k__auto_man`), hidden/internal attributes (prefixed with `_`), and updated actions to use these new attributes for control logic, replacing legacy public attributes. [[1]](diffhunk://#diff-2999109a8e947ba6780bf407a9834f2e8ada03493ea8ccd3b6a7e7d020fcc595R18-R118) [[2]](diffhunk://#diff-2999109a8e947ba6780bf407a9834f2e8ada03493ea8ccd3b6a7e7d020fcc595L107-R135) [[3]](diffhunk://#diff-2999109a8e947ba6780bf407a9834f2e8ada03493ea8ccd3b6a7e7d020fcc595L130-R307)
* Modbus communication mapping now uses hidden attributes for register access, and meta-parameters for port and unit ID are added for configurability.
* Added new and improved scenarios for simulation, such as "Setpoint Ramp Up", "Manual To Auto Transfer", and "Ambient Disturbance", each with descriptive names and documentation.

**Code and test updates for new attribute structure:**

* Updated notebook example and integration tests to use new key control attributes, ensuring test and output consistency with the refactored model. [[1]](diffhunk://#diff-a7770f9464e3cbc4873a9b87d1a62cdce6b52416abe04dbe44e4ffefcc57cf8aL94-R97) [[2]](diffhunk://#diff-a7770f9464e3cbc4873a9b87d1a62cdce6b52416abe04dbe44e4ffefcc57cf8aL106-R121) [[3]](diffhunk://#diff-280c768cbb52c035322390c3e427064e82ad3551c298bae6499acdcb385743d4L105-R109) [[4]](diffhunk://#diff-280c768cbb52c035322390c3e427064e82ad3551c298bae6499acdcb385743d4L122-R122) [[5]](diffhunk://#diff-280c768cbb52c035322390c3e427064e82ad3551c298bae6499acdcb385743d4L135-R135)
* Added a new unit test file `test_eurotherm_3216_modbus_model.py` to verify the model's attribute structure, communication mapping, scenario documentation, and catalog inclusion.

These changes improve clarity, maintainability, and extensibility of the Eurotherm 3216 Modbus model and its integration in the codebase.… standard