### PR TITLE
feat(installer): add macOS app packaging flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,41 @@ This creates `dist/spx-installer/` and `dist/spx-installer.tgz` containing:
 
 Hand the `.tgz` to teammates; they can extract it anywhere and run the platform launcher (`spx-setup.command`, `spx-setup.desktop`, `spx-setup.sh`, or `spx-setup.bat`) to go through the wizard locally.
 
+### 6. Build a trusted macOS installer (Developer ID + notarization)
+
+For a macOS-native distribution, build a signed `.pkg` that installs a single
+`SPX Setup.app` into `/Applications`. The app embeds the full installer payload
+inside the bundle, opens Terminal, and runs the existing terminal-based wizard
+without asking the user to trust a loose downloaded `.command` file.
+
+1. Confirm both Developer ID certificates are present in your keychain:
+
+```bash
+security find-identity -v -p basic | grep "Developer ID"
+```
+
+2. Store notarization credentials once in the keychain:
+
+```bash
+xcrun notarytool store-credentials spx-notary \
+  --apple-id "YOUR_APPLE_ID" \
+  --team-id "YOUR_TEAM_ID"
+```
+
+3. Build, sign, notarize, and staple the macOS installer package:
+
+```bash
+scripts/build_macos_pkg.sh \
+  --app-sign "Developer ID Application: Your Company (TEAMID1234)" \
+  --sign "Developer ID Installer: Your Company (TEAMID1234)" \
+  --notarytool-profile spx-notary
+```
+
+The output package is written to `dist/spx-installer-macos-<version>.pkg`. After
+installation, users launch `SPX Setup.app` from `/Applications`; the installer
+defaults to a user-writable output directory when it is running from a packaged
+location such as `/Applications`.
+
 ### 5. Produce single-file installers (optional)
 
 Convert the package into self-extracting files so users run a single artifact per platform:

--- a/installer/generator.py
+++ b/installer/generator.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import stat
 import json
+import re
 import shutil
 from pathlib import Path
 from typing import Dict, List, Set
@@ -33,6 +34,7 @@ class DeploymentGenerator:
 
     def generate(self, selection, output_dir: Path) -> None:
         output_dir.mkdir(parents=True, exist_ok=True)
+        spx_python_requirement = self._resolve_spx_python_requirement()
 
         assets_root = output_dir / "assets"
         assets_root.mkdir(parents=True, exist_ok=True)
@@ -57,17 +59,6 @@ class DeploymentGenerator:
 
         start_script = """
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -z "${PYTHON_BIN:-}" ]; then
-  if command -v python3 >/dev/null 2>&1; then
-    PYTHON_BIN=python3
-  elif command -v python >/dev/null 2>&1; then
-    PYTHON_BIN=python
-  else
-    echo "[spx-start] Missing required command: python3 or python" >&2
-    exit 1
-  fi
-fi
-REQUIRED_MODULES=(requests:requests spx_python:spx-python yaml:pyyaml)
 BLE_ADAPTER_PORT=${BLE_ADAPTER_PORT:-8085}
 BLE_ADAPTER_PID=""
 
@@ -91,33 +82,51 @@ need_cmd() {
   fi
 }
 
-check_python_modules() {
-  local missing=()
-  local packages=()
-  for entry in "${REQUIRED_MODULES[@]}"; do
-    local module="${entry%%:*}"
-    local package="${entry##*:}"
-    if ! "$PYTHON_BIN" -c "import ${module}" >/dev/null 2>&1; then
-      missing+=("$module")
-      packages+=("$package")
-    fi
-  done
-  if [ ${#missing[@]} -eq 0 ]; then
+resolve_system_python() {
+  if [ -n "${PYTHON_BIN:-}" ]; then
+    printf '%s\n' "${PYTHON_BIN}"
     return
   fi
-  echo "[spx-start] Missing Python modules: ${missing[*]}. Installing via pip..."
-  "$PYTHON_BIN" -m pip install --user "${packages[@]}"
-  for module in "${missing[@]}"; do
-    if ! "$PYTHON_BIN" -c "import ${module}" >/dev/null 2>&1; then
-      echo "[spx-start] Unable to import module '${module}' even after pip install." >&2
-      exit 1
-    fi
-  done
+
+  if command -v python3 >/dev/null 2>&1; then
+    printf 'python3\n'
+    return
+  fi
+
+  if command -v python >/dev/null 2>&1; then
+    printf 'python\n'
+    return
+  fi
+
+  echo "[spx-start] Missing required command: python3 or python" >&2
+  exit 1
 }
 
+bootstrap_python_runtime() {
+  local system_python="$1"
+  local runtime_bootstrap="$SCRIPT_DIR/runtime_bootstrap.py"
+
+  if [ ! -f "$runtime_bootstrap" ]; then
+    echo "[spx-start] Missing runtime bootstrap helper: $runtime_bootstrap" >&2
+    exit 1
+  fi
+
+  "$system_python" "$runtime_bootstrap" \
+    --venv-dir "$SCRIPT_DIR/.spx-runtime" \
+    --package requests \
+    --package "__SPX_PYTHON_REQUIREMENT__" \
+    --package pyyaml
+}
+
+SYSTEM_PYTHON_BIN="$(resolve_system_python)"
 need_cmd docker
-need_cmd "$PYTHON_BIN"
-check_python_modules
+need_cmd "$SYSTEM_PYTHON_BIN"
+PYTHON_BIN="$(bootstrap_python_runtime "$SYSTEM_PYTHON_BIN")"
+if [ ! -x "$PYTHON_BIN" ]; then
+  echo "[spx-start] Python runtime bootstrap did not return an executable interpreter." >&2
+  exit 1
+fi
+export PYTHON_BIN
 
 # Optional BLE adapter (NodeJS) support
 HAS_BLE=$(
@@ -158,6 +167,9 @@ echo "[spx-start] SPX started successfully."
 echo "[spx-start] UI: http://localhost:3000 (if enabled), API: http://localhost:8000"
 echo "[spx-start] You can now open the available services and start playing with SPX :)"
 """
+        start_script = start_script.replace(
+            "__SPX_PYTHON_REQUIREMENT__", spx_python_requirement
+        )
         start_script = start_script.replace("__BOOTSTRAP_CMD_SH__", bootstrap_cmd_sh).strip("\n")
         start_script_ps1 = r"""
 $ErrorActionPreference = "Stop"
@@ -196,12 +208,6 @@ function Resolve-Python {
     throw "[spx-start] Missing required command: python (3.x). Install Python 3 or set PYTHON_BIN."
 }
 
-$PythonBin = Resolve-Python
-$RequiredModules = @(
-    @{ Module = "requests"; Package = "requests" },
-    @{ Module = "spx_python"; Package = "spx-python" },
-    @{ Module = "yaml"; Package = "pyyaml" }
-)
 $BleAdapterPort = if ($Env:BLE_ADAPTER_PORT) { $Env:BLE_ADAPTER_PORT } else { 8085 }
 $bleProcess = $null
 
@@ -212,39 +218,34 @@ function Need-Command {
     }
 }
 
-function Check-PythonModules {
-    function Test-PythonModule {
-        param([string]$Module)
-        $checkCmd = "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('$Module') else 1)"
-        try {
-            & $PythonBin -c $checkCmd 2>$null | Out-Null
-        } catch {
-            return $false
-        }
-        return ($LASTEXITCODE -eq 0)
+function Bootstrap-PythonRuntime {
+    param([string]$SystemPython)
+
+    $runtimeBootstrap = Join-Path $ScriptDir "runtime_bootstrap.py"
+    if (-not (Test-Path $runtimeBootstrap)) {
+        throw "[spx-start] Missing runtime bootstrap helper: $runtimeBootstrap"
     }
 
-    $missing = @()
-    foreach ($entry in $RequiredModules) {
-        if (-not (Test-PythonModule $entry.Module)) {
-            $missing += $entry
-        }
-    }
-    if ($missing.Count -eq 0) {
-        return
-    }
-    $moduleNames = $missing | ForEach-Object { $_.Module }
-    $packages = $missing | ForEach-Object { $_.Package }
-    Write-Host "[spx-start] Missing Python modules: $($moduleNames -join ', '). Installing via pip..."
-    & $PythonBin -m pip install --user @($packages)
+    $pythonPath = & $SystemPython $runtimeBootstrap `
+        --venv-dir (Join-Path $ScriptDir ".spx-runtime") `
+        --package "requests" `
+        --package "__SPX_PYTHON_REQUIREMENT__" `
+        --package "pyyaml"
+
     if ($LASTEXITCODE -ne 0) {
-        throw "[spx-start] pip install failed"
+        throw "[spx-start] Failed to prepare the local Python runtime."
     }
-    foreach ($entry in $missing) {
-        if (-not (Test-PythonModule $entry.Module)) {
-            throw "[spx-start] Unable to import module '$($entry.Module)' even after pip install."
-        }
+
+    $pythonPath = "$pythonPath".Trim()
+    if (-not $pythonPath) {
+        throw "[spx-start] Local Python runtime bootstrap returned an empty interpreter path."
     }
+
+    if (-not (Test-Path $pythonPath)) {
+        throw "[spx-start] Local Python runtime bootstrap returned a missing interpreter: $pythonPath"
+    }
+
+    return $pythonPath
 }
 
 function Cleanup-OnFailure {
@@ -260,8 +261,9 @@ function Cleanup-OnFailure {
 
 try {
     Need-Command "docker"
-    Need-Command $PythonBin
-    Check-PythonModules
+    $SystemPython = Resolve-Python
+    Need-Command $SystemPython
+    $PythonBin = Bootstrap-PythonRuntime $SystemPython
 
     $bundlePath = Join-Path $ScriptDir "bundle.json"
     $hasBle = $false
@@ -307,6 +309,9 @@ catch {
     Cleanup-OnFailure 1
 }
 """
+        start_script_ps1 = start_script_ps1.replace(
+            "__SPX_PYTHON_REQUIREMENT__", spx_python_requirement
+        )
         start_script_ps1 = start_script_ps1.replace("__BOOTSTRAP_CMD_PS__", bootstrap_cmd_ps)
         self._write_script(output_dir / "spx-start.sh", start_script.strip() + "\n")
         self._write_ps_script(output_dir / "spx-start.ps1", start_script_ps1.strip() + "\n")
@@ -336,6 +341,7 @@ exit /b %EXITCODE%
         self._write_text_script(output_dir / "spx-start.command", start_command.strip() + "\n", executable=True)
         self._write_text_script(output_dir / "spx-start.bat", start_bat.strip() + "\n")
         self._write_bootstrap_runner(output_dir)
+        self._write_runtime_bootstrap(output_dir)
         stop_script = """
 pkill -f spx-ble-adapter >/dev/null 2>&1 || true
 docker compose -f "$(dirname "$0")/docker-compose.generated.yml" --env-file "$(dirname "$0")/.env" down
@@ -620,6 +626,21 @@ exit /b %EXITCODE%
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dest)
 
+    def _resolve_spx_python_requirement(self) -> str:
+        pyproject = self.repo_root / "pyproject.toml"
+        if not pyproject.exists():
+            return "spx-python"
+
+        content = pyproject.read_text(encoding="utf-8")
+        match = re.search(r'^\s*spx-python\s*=\s*"([^"]+)"', content, flags=re.MULTILINE)
+        if not match:
+            return "spx-python"
+
+        spec = match.group(1).strip()
+        if not spec or any(char in spec for char in "^~<>*,[]"):
+            return "spx-python"
+        return f"spx-python=={spec}"
+
     def _write_bootstrap_runner(self, output_dir: Path) -> None:
         runner = """#!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
@@ -819,3 +840,15 @@ if __name__ == "__main__":  # pragma: no cover
 """
         path = output_dir / "bootstrap_runner.py"
         path.write_text(runner, encoding="utf-8")
+
+    def _write_runtime_bootstrap(self, output_dir: Path) -> None:
+        src = self.repo_root / "installer" / "runtime_bootstrap.py"
+        if not src.exists():
+            src = Path(__file__).with_name("runtime_bootstrap.py")
+        if not src.exists():
+            raise FileNotFoundError(f"Missing runtime bootstrap helper: {src}")
+
+        dest = output_dir / "runtime_bootstrap.py"
+        shutil.copy2(src, dest)
+        mode = os.stat(dest).st_mode
+        os.chmod(dest, mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)

--- a/installer/macos/spx_setup_launcher.applescript
+++ b/installer/macos/spx_setup_launcher.applescript
@@ -1,0 +1,23 @@
+property appTitle : "SPX Setup"
+property payloadDirName : "spx-installer"
+property launcherName : "spx-setup.command"
+
+on run
+  set appBundlePath to POSIX path of (path to me)
+  set launcherPath to appBundlePath & "Contents/Resources/" & payloadDirName & "/" & launcherName
+
+  try
+    set launcherAlias to POSIX file launcherPath as alias
+  on error
+    activate
+    display dialog appTitle & " could not find the embedded installer launcher." buttons {"OK"} default button "OK" with icon stop
+    return
+  end try
+
+  try
+    do shell script "/usr/bin/open -a Terminal " & quoted form of (POSIX path of launcherAlias)
+  on error errMsg number errNum
+    activate
+    display dialog "Unable to launch the SPX installer in Terminal." & return & return & errMsg & " (" & errNum & ")" buttons {"OK"} default button "OK" with icon stop
+  end try
+end run

--- a/installer/runtime_bootstrap.py
+++ b/installer/runtime_bootstrap.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Create or reuse a local virtualenv and print its Python interpreter path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prepare a local Python runtime for the SPX installer."
+    )
+    parser.add_argument(
+        "--venv-dir",
+        required=True,
+        help="Directory where the virtual environment should live.",
+    )
+    parser.add_argument(
+        "--package",
+        action="append",
+        default=[],
+        help="Package requirement to install into the virtual environment.",
+    )
+    return parser.parse_args(argv)
+
+
+def venv_python_path(venv_dir: Path) -> Path:
+    if sys.platform == "win32":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def read_stamp(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError:
+        return None
+
+
+def write_stamp(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def run_command(argv: list[str]) -> None:
+    subprocess.run(argv, check=True, stdout=sys.stderr, stderr=sys.stderr)
+
+
+def normalize_packages(packages: list[str]) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for package in packages:
+        item = package.strip()
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        normalized.append(item)
+    return normalized
+
+
+def ensure_runtime(venv_dir: Path, packages: list[str]) -> Path:
+    venv_dir.mkdir(parents=True, exist_ok=True)
+    python_bin = venv_python_path(venv_dir)
+    stamp_path = venv_dir / ".spx-runtime.json"
+    desired_state = {
+        "packages": packages,
+        "python_version": sys.version,
+    }
+
+    if not python_bin.exists():
+        print(
+            f"[runtime] Creating Python virtual environment at {venv_dir}",
+            file=sys.stderr,
+        )
+        run_command([sys.executable, "-m", "venv", str(venv_dir)])
+
+    current_state = read_stamp(stamp_path)
+    if current_state != desired_state:
+        if packages:
+            print(
+                f"[runtime] Installing Python packages into {venv_dir}",
+                file=sys.stderr,
+            )
+            run_command(
+                [
+                    str(python_bin),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--disable-pip-version-check",
+                    *packages,
+                ]
+            )
+        write_stamp(stamp_path, desired_state)
+
+    return python_bin
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    packages = normalize_packages(args.package)
+    python_bin = ensure_runtime(Path(args.venv_dir).expanduser().resolve(), packages)
+    print(str(python_bin))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/installer/wizard.py
+++ b/installer/wizard.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import getpass
 import os
 from dataclasses import dataclass
 from shutil import get_terminal_size
@@ -369,12 +370,13 @@ class InstallerWizard:
     def _prompt_license_key(self) -> str:
         env_value = os.environ.get("SPX_PRODUCT_KEY", "").strip()
         if env_value:
-            print(ui.accent(f"\nDetected SPX_PRODUCT_KEY in environment: {env_value}"))
+            masked = self._mask_secret(env_value)
+            print(ui.accent(f"\nDetected SPX_PRODUCT_KEY in environment: {masked}"))
             return env_value
 
         print(ui.heading("\nSPX Product Key"))
         while True:
-            raw = input("Enter SPX product key (required, q to quit): ").strip()
+            raw = getpass.getpass("Enter SPX product key (required, q to quit): ").strip()
             self._check_quit(raw)
             if raw:
                 return raw
@@ -384,6 +386,14 @@ class InstallerWizard:
         if raw.lower() in {"q", "quit"}:
             print(ui.warn("Exiting wizard."))
             raise SystemExit(0)
+
+    def _mask_secret(self, value: str, *, visible_tail: int = 4) -> str:
+        clean = value.strip()
+        if not clean:
+            return "N/A"
+        if len(clean) <= visible_tail:
+            return "*" * len(clean)
+        return f"{'*' * (len(clean) - visible_tail)}{clean[-visible_tail:]}"
 
     def _prompt_indices(
         self,
@@ -452,7 +462,7 @@ class InstallerWizard:
         print(f"Install instances: {ui.success('yes') if install_instances else ui.warn('no')}")
         print(f"Include SPX UI: {ui.success('yes') if install_spx_ui else ui.warn('no')}")
         print(f"Offline bundle: {ui.success('yes') if offline_bundle else ui.warn('no')}")
-        print(f"SPX product key: {ui.heading(license_key or 'N/A')}")
+        print(f"SPX product key: {ui.heading(self._mask_secret(license_key))}")
         print("\nModels:")
         for model_id in model_ids:
             manifest = index.models[model_id]

--- a/scripts/build_macos_pkg.sh
+++ b/scripts/build_macos_pkg.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build_macos_pkg.sh [options]
+
+Builds a macOS flat installer package (.pkg) that installs SPX Setup.app into
+/Applications. The app contains the full installer payload inside its bundle,
+so the user gets a Finder-clickable launcher rather than a loose .command file.
+
+Options:
+  --output-dir DIR              Directory for the final .pkg (default: dist)
+  --staging-dir DIR             Directory for intermediate app/pkg files (default: build/macos-pkg)
+  --pkg-name NAME               Output package stem without version/ext (default: spx-installer-macos)
+  --identifier ID               macOS package identifier (default: com.hammerheadsengineers.spx.installer)
+  --version VERSION             Package version (default: pyproject.toml version or dev)
+  --install-location PATH       Install destination on macOS (default: /Applications)
+  --app-name NAME               Installed launcher app name without extension (default: SPX Setup)
+  --app-bundle-id ID            CFBundleIdentifier for the launcher app (default: com.hammerheadsengineers.spx.setup)
+  --app-sign IDENTITY           Sign the launcher app with this Developer ID Application identity
+  --sign IDENTITY               Sign the .pkg with this Developer ID Installer identity
+  --keychain PATH               Optional keychain for pkg signing / notarytool profile lookup
+  --notarytool-profile PROFILE  Submit the signed .pkg with this notarytool keychain profile
+  -h, --help                    Show this help
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+resolve_version() {
+  local version
+  version="$(sed -n 's/^version = "\(.*\)"$/\1/p' "${REPO_ROOT}/pyproject.toml" | head -n 1)"
+  if [[ -n "${version}" ]]; then
+    printf '%s\n' "${version}"
+    return
+  fi
+  printf 'dev\n'
+}
+
+OUTPUT_DIR="dist"
+STAGING_DIR="build/macos-pkg"
+PKG_NAME="spx-installer-macos"
+IDENTIFIER="com.hammerheadsengineers.spx.installer"
+VERSION=""
+INSTALL_LOCATION="/Applications"
+APP_NAME="SPX Setup"
+APP_BUNDLE_ID="com.hammerheadsengineers.spx.setup"
+APP_SIGN_IDENTITY=""
+SIGN_IDENTITY=""
+KEYCHAIN_PATH=""
+NOTARYTOOL_PROFILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --staging-dir)
+      STAGING_DIR="$2"
+      shift 2
+      ;;
+    --pkg-name)
+      PKG_NAME="$2"
+      shift 2
+      ;;
+    --identifier)
+      IDENTIFIER="$2"
+      shift 2
+      ;;
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --install-location)
+      INSTALL_LOCATION="$2"
+      shift 2
+      ;;
+    --app-name)
+      APP_NAME="$2"
+      shift 2
+      ;;
+    --app-bundle-id)
+      APP_BUNDLE_ID="$2"
+      shift 2
+      ;;
+    --app-sign)
+      APP_SIGN_IDENTITY="$2"
+      shift 2
+      ;;
+    --sign)
+      SIGN_IDENTITY="$2"
+      shift 2
+      ;;
+    --keychain)
+      KEYCHAIN_PATH="$2"
+      shift 2
+      ;;
+    --notarytool-profile)
+      NOTARYTOOL_PROFILE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "scripts/build_macos_pkg.sh must be run on macOS." >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST_DIR="${REPO_ROOT}/${OUTPUT_DIR}"
+STAGING_ROOT="${REPO_ROOT}/${STAGING_DIR}"
+APP_ROOT="${STAGING_ROOT}/root"
+
+if [[ -z "${VERSION}" ]]; then
+  VERSION="$(resolve_version)"
+fi
+
+if [[ -n "${NOTARYTOOL_PROFILE}" && -z "${SIGN_IDENTITY}" ]]; then
+  echo "--notarytool-profile requires --sign with a Developer ID Installer identity." >&2
+  exit 1
+fi
+
+if [[ -n "${NOTARYTOOL_PROFILE}" && -z "${APP_SIGN_IDENTITY}" ]]; then
+  echo "--notarytool-profile requires --app-sign with a Developer ID Application identity." >&2
+  exit 1
+fi
+
+if [[ -n "${SIGN_IDENTITY}" && "${SIGN_IDENTITY}" != Developer\ ID\ Installer:* ]]; then
+  echo "Warning: pkg signing normally uses a 'Developer ID Installer' identity." >&2
+fi
+
+require_command pkgbuild
+require_command pkgutil
+require_command sed
+require_command /usr/libexec/PlistBuddy
+
+mkdir -p "${DEST_DIR}"
+rm -rf "${APP_ROOT}"
+mkdir -p "${APP_ROOT}"
+
+build_app_args=(
+  --output-dir "${STAGING_DIR}/root"
+  --staging-dir "${STAGING_DIR}/payload"
+  --app-name "${APP_NAME}"
+  --bundle-id "${APP_BUNDLE_ID}"
+  --version "${VERSION}"
+)
+
+if [[ -n "${APP_SIGN_IDENTITY}" ]]; then
+  build_app_args+=(--sign "${APP_SIGN_IDENTITY}")
+fi
+
+"${REPO_ROOT}/scripts/build_macos_setup_app.sh" "${build_app_args[@]}"
+
+PKG_PATH="${DEST_DIR}/${PKG_NAME}-${VERSION}.pkg"
+COMPONENT_PLIST="${STAGING_ROOT}/component.plist"
+rm -f "${PKG_PATH}"
+rm -f "${COMPONENT_PLIST}"
+
+pkgbuild --analyze --root "${APP_ROOT}" "${COMPONENT_PLIST}"
+/usr/libexec/PlistBuddy -c "Set :0:BundleIsRelocatable false" "${COMPONENT_PLIST}"
+
+pkgbuild_args=(
+  --root "${APP_ROOT}"
+  --component-plist "${COMPONENT_PLIST}"
+  --identifier "${IDENTIFIER}"
+  --version "${VERSION}"
+  --install-location "${INSTALL_LOCATION}"
+  --ownership recommended
+)
+
+if [[ -n "${SIGN_IDENTITY}" ]]; then
+  pkgbuild_args+=(--sign "${SIGN_IDENTITY}")
+  if [[ -n "${KEYCHAIN_PATH}" ]]; then
+    pkgbuild_args+=(--keychain "${KEYCHAIN_PATH}")
+  fi
+fi
+
+pkgbuild "${pkgbuild_args[@]}" "${PKG_PATH}"
+
+echo "Created macOS package: ${PKG_PATH}"
+
+if [[ -n "${SIGN_IDENTITY}" ]]; then
+  echo ""
+  echo "Package signature:"
+  pkgutil --check-signature "${PKG_PATH}"
+fi
+
+if [[ -n "${NOTARYTOOL_PROFILE}" ]]; then
+  require_command xcrun
+
+  notarytool_args=(
+    notarytool
+    submit
+    "${PKG_PATH}"
+    --keychain-profile "${NOTARYTOOL_PROFILE}"
+    --wait
+  )
+
+  if [[ -n "${KEYCHAIN_PATH}" ]]; then
+    notarytool_args+=(--keychain "${KEYCHAIN_PATH}")
+  fi
+
+  echo ""
+  echo "Submitting package for notarization..."
+  xcrun "${notarytool_args[@]}"
+
+  echo ""
+  echo "Stapling notarization ticket..."
+  xcrun stapler staple "${PKG_PATH}"
+
+  echo ""
+  echo "Validating stapled ticket..."
+  xcrun stapler validate -v "${PKG_PATH}"
+
+  echo ""
+  echo "Gatekeeper assessment:"
+  spctl -a -vv -t install "${PKG_PATH}"
+elif [[ -z "${SIGN_IDENTITY}" ]]; then
+  echo ""
+  echo "Package is unsigned. Gatekeeper will reject it until you rebuild with:"
+  echo "  --app-sign \"Developer ID Application: Your Company (TEAMID1234)\""
+  echo "  --sign \"Developer ID Installer: Your Company (TEAMID1234)\""
+else
+  echo ""
+  if [[ -z "${APP_SIGN_IDENTITY}" ]]; then
+    echo "Launcher app is unsigned. Rebuild with --app-sign before notarized distribution."
+  fi
+  echo "Package is signed but not notarized."
+  echo "Re-run with --notarytool-profile PROFILE to submit and staple the package."
+fi

--- a/scripts/build_macos_setup_app.sh
+++ b/scripts/build_macos_setup_app.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build_macos_setup_app.sh [options]
+
+Builds a macOS launcher app bundle that embeds the full SPX installer payload.
+The resulting app can be installed into /Applications and launched from Finder;
+it opens Terminal and starts the existing terminal-based installer flow from the
+bundle's Resources directory.
+
+Options:
+  --output-dir DIR    Directory where the app bundle will be created (default: dist)
+  --staging-dir DIR   Directory for intermediate payload files (default: build/macos-app)
+  --app-name NAME     App bundle name without extension (default: SPX Setup)
+  --bundle-id ID      CFBundleIdentifier for the app (default: com.hammerheadsengineers.spx.setup)
+  --version VERSION   App version (default: pyproject.toml version or dev)
+  --sign IDENTITY     Sign with this Developer ID Application identity
+  -h, --help          Show this help
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+resolve_version() {
+  local version
+  version="$(sed -n 's/^version = "\(.*\)"$/\1/p' "${REPO_ROOT}/pyproject.toml" | head -n 1)"
+  if [[ -n "${version}" ]]; then
+    printf '%s\n' "${version}"
+    return
+  fi
+  printf 'dev\n'
+}
+
+OUTPUT_DIR="dist"
+STAGING_DIR="build/macos-app"
+APP_NAME="SPX Setup"
+BUNDLE_ID="com.hammerheadsengineers.spx.setup"
+VERSION=""
+SIGN_IDENTITY=""
+PAYLOAD_NAME="spx-installer"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --staging-dir)
+      STAGING_DIR="$2"
+      shift 2
+      ;;
+    --app-name)
+      APP_NAME="$2"
+      shift 2
+      ;;
+    --bundle-id)
+      BUNDLE_ID="$2"
+      shift 2
+      ;;
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --sign)
+      SIGN_IDENTITY="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "scripts/build_macos_setup_app.sh must be run on macOS." >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST_DIR="${REPO_ROOT}/${OUTPUT_DIR}"
+STAGING_ROOT="${REPO_ROOT}/${STAGING_DIR}"
+PAYLOAD_DIR="${STAGING_ROOT}/${PAYLOAD_NAME}"
+SCRIPT_SOURCE="${REPO_ROOT}/installer/macos/spx_setup_launcher.applescript"
+APP_PATH="${DEST_DIR}/${APP_NAME}.app"
+
+if [[ -z "${VERSION}" ]]; then
+  VERSION="$(resolve_version)"
+fi
+
+require_command xcrun
+require_command rsync
+require_command sed
+require_command /usr/libexec/PlistBuddy
+require_command codesign
+
+mkdir -p "${DEST_DIR}"
+mkdir -p "${STAGING_ROOT}"
+rm -rf "${APP_PATH}"
+
+"${REPO_ROOT}/scripts/build_installer_package.sh" \
+  --output-dir "${STAGING_DIR}" \
+  --package-name "${PAYLOAD_NAME}"
+
+xcrun osacompile -o "${APP_PATH}" "${SCRIPT_SOURCE}"
+
+RESOURCE_PAYLOAD_DIR="${APP_PATH}/Contents/Resources/${PAYLOAD_NAME}"
+mkdir -p "${RESOURCE_PAYLOAD_DIR}"
+rsync -a --delete "${PAYLOAD_DIR}/" "${RESOURCE_PAYLOAD_DIR}/"
+
+plist="${APP_PATH}/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string '${BUNDLE_ID}'" "${plist}" 2>/dev/null || \
+  /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier '${BUNDLE_ID}'" "${plist}"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName '${APP_NAME}'" "${plist}"
+/usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string '${APP_NAME}'" "${plist}" 2>/dev/null || \
+  /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName '${APP_NAME}'" "${plist}"
+/usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string '${VERSION}'" "${plist}" 2>/dev/null || \
+  /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString '${VERSION}'" "${plist}"
+/usr/libexec/PlistBuddy -c "Add :CFBundleVersion string '${VERSION}'" "${plist}" 2>/dev/null || \
+  /usr/libexec/PlistBuddy -c "Set :CFBundleVersion '${VERSION}'" "${plist}"
+/usr/libexec/PlistBuddy -c "Add :LSApplicationCategoryType string 'public.app-category.developer-tools'" "${plist}" 2>/dev/null || \
+  /usr/libexec/PlistBuddy -c "Set :LSApplicationCategoryType 'public.app-category.developer-tools'" "${plist}"
+
+privacy_keys=(
+  NSAppleEventsUsageDescription
+  NSAppleMusicUsageDescription
+  NSCalendarsUsageDescription
+  NSCameraUsageDescription
+  NSContactsUsageDescription
+  NSHomeKitUsageDescription
+  NSMicrophoneUsageDescription
+  NSPhotoLibraryUsageDescription
+  NSRemindersUsageDescription
+  NSSiriUsageDescription
+  NSSystemAdministrationUsageDescription
+)
+
+for key in "${privacy_keys[@]}"; do
+  /usr/libexec/PlistBuddy -c "Delete :${key}" "${plist}" >/dev/null 2>&1 || true
+done
+
+if [[ -n "${SIGN_IDENTITY}" ]]; then
+  if [[ "${SIGN_IDENTITY}" != Developer\ ID\ Application:* ]]; then
+    echo "Warning: app signing normally uses a 'Developer ID Application' identity." >&2
+  fi
+
+  codesign --force --sign "${SIGN_IDENTITY}" --timestamp --options runtime "${APP_PATH}"
+
+  echo ""
+  echo "App signature:"
+  codesign --verify --verbose=2 "${APP_PATH}"
+  echo ""
+  echo "Gatekeeper assessment:"
+  spctl -a -vv "${APP_PATH}" || true
+else
+  codesign --force --sign - "${APP_PATH}"
+
+  echo ""
+  echo "App bundle refreshed with an ad-hoc signature for local use."
+  echo "Sign it with --sign \"Developer ID Application: Your Company (TEAMID1234)\" for notarized distribution."
+fi
+
+echo "Created macOS launcher app: ${APP_PATH}"

--- a/spx-install.sh
+++ b/spx-install.sh
@@ -2,20 +2,7 @@
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -z "${PYTHON_BIN:-}" ]; then
-  if command -v python3 >/dev/null 2>&1; then
-    PYTHON_BIN=python3
-  elif command -v python >/dev/null 2>&1; then
-    PYTHON_BIN=python
-  else
-    echo "[spx-install] Missing required command: python3 or python" >&2
-    exit 1
-  fi
-fi
-REQUIRED_MODULES=(
-  "yaml:pyyaml"
-  "colorama:colorama"
-)
+RUNTIME_BOOTSTRAP="${REPO_DIR}/installer/runtime_bootstrap.py"
 
 need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -24,30 +11,81 @@ need_cmd() {
   fi
 }
 
-check_python_modules() {
-  local missing_modules=()
-  local install_packages=()
-  for entry in "${REQUIRED_MODULES[@]}"; do
-    local module="${entry%%:*}"
-    local package="${entry##*:}"
-    if ! "$PYTHON_BIN" -c "import ${module}" >/dev/null 2>&1; then
-      missing_modules+=("$module")
-      install_packages+=("$package")
-    fi
-  done
-  if [ ${#missing_modules[@]} -eq 0 ]; then
+resolve_system_python() {
+  if [ -n "${PYTHON_BIN:-}" ]; then
+    printf '%s\n' "${PYTHON_BIN}"
     return
   fi
 
-  echo "[spx-install] Missing Python modules: ${missing_modules[*]}. Installing via pip..."
-  "$PYTHON_BIN" -m pip install --user "${install_packages[@]}"
+  if command -v python3 >/dev/null 2>&1; then
+    printf 'python3\n'
+    return
+  fi
 
-  for module in "${missing_modules[@]}"; do
-    if ! "$PYTHON_BIN" -c "import ${module}" >/dev/null 2>&1; then
-      echo "[spx-install] Unable to import module '${module}' even after pip install." >&2
-      exit 1
-    fi
-  done
+  if command -v python >/dev/null 2>&1; then
+    printf 'python\n'
+    return
+  fi
+
+  echo "[spx-install] Missing required command: python3 or python" >&2
+  exit 1
+}
+
+resolve_runtime_root() {
+  if [ -n "${SPX_RUNTIME_HOME:-}" ]; then
+    printf '%s\n' "${SPX_RUNTIME_HOME}"
+    return
+  fi
+
+  if [ -w "${REPO_DIR}" ]; then
+    printf '%s\n' "${REPO_DIR}/.spx-runtime"
+    return
+  fi
+
+  case "$(uname -s)" in
+    Darwin)
+      printf '%s\n' "${HOME}/Library/Application Support/SPX/runtime"
+      ;;
+    *)
+      printf '%s\n' "${HOME}/.local/share/spx/runtime"
+      ;;
+  esac
+}
+
+resolve_default_output() {
+  if [ -n "${SPX_INSTALLER_OUTPUT_DIR:-}" ]; then
+    printf '%s\n' "${SPX_INSTALLER_OUTPUT_DIR}"
+    return
+  fi
+
+  if [ -w "${REPO_DIR}" ]; then
+    printf '%s\n' "${REPO_DIR}/build/spx-generated"
+    return
+  fi
+
+  case "$(uname -s)" in
+    Darwin)
+      printf '%s\n' "${HOME}/Library/Application Support/SPX/generated"
+      ;;
+    *)
+      printf '%s\n' "${HOME}/.local/share/spx/generated"
+      ;;
+  esac
+}
+
+bootstrap_python_runtime() {
+  local system_python="$1"
+  local runtime_root="$2"
+
+  if [ ! -f "${RUNTIME_BOOTSTRAP}" ]; then
+    echo "[spx-install] Missing runtime bootstrap helper: ${RUNTIME_BOOTSTRAP}" >&2
+    exit 1
+  fi
+
+  "$system_python" "${RUNTIME_BOOTSTRAP}" \
+    --venv-dir "${runtime_root}/installer" \
+    --package pyyaml \
+    --package colorama
 }
 
 check_docker() {
@@ -66,14 +104,22 @@ check_docker() {
   fi
 }
 
-need_cmd "$PYTHON_BIN"
+SYSTEM_PYTHON_BIN="$(resolve_system_python)"
+need_cmd "$SYSTEM_PYTHON_BIN"
 check_docker
-check_python_modules
+PYTHON_BIN="$(bootstrap_python_runtime "$SYSTEM_PYTHON_BIN" "$(resolve_runtime_root)")"
+if [ ! -x "${PYTHON_BIN}" ]; then
+  echo "[spx-install] Python runtime bootstrap did not return an executable interpreter." >&2
+  exit 1
+fi
+export PYTHON_BIN
 
 cd "$REPO_DIR"
 
 if [ $# -eq 0 ]; then
-  set -- generate --output build/spx-generated
+  DEFAULT_OUTPUT_DIR="$(resolve_default_output)"
+  echo "[spx-install] Using output directory: ${DEFAULT_OUTPUT_DIR}"
+  set -- generate --output "${DEFAULT_OUTPUT_DIR}"
 fi
 
 echo "[spx-install] Running installer CLI: $PYTHON_BIN -m installer $*"

--- a/tests/installer/test_cli_generate.py
+++ b/tests/installer/test_cli_generate.py
@@ -172,6 +172,7 @@ def test_generate_noninteractive_packages_prints_json_and_creates_artifacts(
     assert (output_dir / "spx-start.ps1").exists()
     assert (output_dir / "spx-stop.ps1").exists()
     assert (output_dir / "bootstrap_runner.py").exists()
+    assert (output_dir / "runtime_bootstrap.py").exists()
 
 
 def test_generate_allows_missing_product_key_when_flag_set(

--- a/tests/installer/test_generator.py
+++ b/tests/installer/test_generator.py
@@ -174,7 +174,9 @@ def test_generator_creates_compose(tmp_path: Path) -> None:
     assert start_path.exists()
     assert stop_path.exists()
     runner_path = output_dir / "bootstrap_runner.py"
+    runtime_path = output_dir / "runtime_bootstrap.py"
     assert runner_path.exists()
+    assert runtime_path.exists()
     start_content = start_path.read_text(encoding="utf-8")
     stop_content = stop_path.read_text(encoding="utf-8")
     assert "BLE_ADAPTER_PID" in start_content
@@ -182,6 +184,8 @@ def test_generator_creates_compose(tmp_path: Path) -> None:
     assert "down --remove-orphans" in start_content
     assert "docker compose" in start_content
     assert "bootstrap_runner.py" in start_content
+    assert "runtime_bootstrap.py" in start_content
+    assert "pip install --user" not in start_content
     assert "pkill -f spx-ble-adapter" in stop_content
     start_ps_path = output_dir / "spx-start.ps1"
     stop_ps_path = output_dir / "spx-stop.ps1"
@@ -196,6 +200,8 @@ def test_generator_creates_compose(tmp_path: Path) -> None:
         in start_ps_content
     )
     assert "bootstrap_runner.py" in start_ps_content
+    assert "runtime_bootstrap.py" in start_ps_content
+    assert "pip install --user" not in start_ps_content
     assert "Get-CimInstance Win32_Process" in stop_ps_content
 
 

--- a/tests/installer/test_wizard.py
+++ b/tests/installer/test_wizard.py
@@ -132,3 +132,51 @@ def test_wizard_protocol_selection(
     assert selection.license_key == "TEST-KEY"
     assert selection.model_ids == []
     assert selection.service_ids == ["mqtt_broker"]
+
+
+def test_wizard_masks_product_key_in_output(
+    monkeypatch: pytest.MonkeyPatch, manifest_index: manifest.ManifestIndex, capsys
+) -> None:
+    monkeypatch.delenv("SPX_PRODUCT_KEY", raising=False)
+
+    class FakeLoader:
+        def load(self):
+            return manifest_index
+
+    wizard = InstallerWizard(loader=FakeLoader())
+
+    inputs = iter(["1", "", "", "n", "n"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    monkeypatch.setattr(
+        "getpass.getpass",
+        lambda _: "COAUA-AAGRC-RWIUB-MRKIB-UMSHS-H7ZCU",
+    )
+
+    selection = wizard.run()
+    captured = capsys.readouterr()
+
+    assert selection.license_key == "COAUA-AAGRC-RWIUB-MRKIB-UMSHS-H7ZCU"
+    assert "COAUA-AAGRC-RWIUB-MRKIB-UMSHS-H7ZCU" not in captured.out
+    assert "SPX product key:" in captured.out
+    assert "*******************************7ZCU" in captured.out
+
+
+def test_wizard_masks_env_product_key_in_output(
+    monkeypatch: pytest.MonkeyPatch, manifest_index: manifest.ManifestIndex, capsys
+) -> None:
+    class FakeLoader:
+        def load(self):
+            return manifest_index
+
+    wizard = InstallerWizard(loader=FakeLoader())
+
+    inputs = iter(["1", "", "", "n", "n"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    selection = wizard.run()
+    captured = capsys.readouterr()
+
+    assert selection.license_key == "TEST-KEY"
+    assert "Detected SPX_PRODUCT_KEY in environment:" in captured.out
+    assert "TEST-KEY" not in captured.out
+    assert "****-KEY" in captured.out


### PR DESCRIPTION
## Summary
- add a macOS packaging flow that builds an embedded `SPX Setup.app` and wraps it in a signed `.pkg`
- switch installer/runtime bootstrap to a local virtualenv instead of `pip install --user`, so packaged macOS runs work from `/Applications`
- mask `SPX_PRODUCT_KEY` in the wizard UI and installer summary

## Validation
- `pytest` (`123 passed, 262 skipped`)
- manual macOS smoke test: install `.pkg`, launch `/Applications/SPX Setup.app`, generate bundle, start stack, confirm UI/API come up
- smoke test from current HEAD: build `SPX Setup.app` and run embedded `spx-install.sh generate --packages industrial_iiot_pack --allow-missing-product-key --with-ui --no-start --print-selection json`

## Notes
- signed packaging works locally with `Developer ID Application` + `Developer ID Installer`
- notarization is still a release/distribution step and is not required for this code PR