### PR TITLE
feat(installer): add macOS runtime launcher apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,10 +211,13 @@ Hand the `.tgz` to teammates; they can extract it anywhere and run the platform 
 
 ### 6. Build a trusted macOS installer (Developer ID + notarization)
 
-For a macOS-native distribution, build a signed `.pkg` that installs a single
-`SPX Setup.app` into `/Applications`. The app embeds the full installer payload
-inside the bundle, opens Terminal, and runs the existing terminal-based wizard
-without asking the user to trust a loose downloaded `.command` file.
+For a macOS-native distribution, build a signed `.pkg` that installs
+`SPX Setup.app`, `SPX Start.app`, `SPX Stop.app`, and `SPX Cleanup.app` into
+`/Applications`. `SPX Setup.app` embeds the full installer payload inside the
+bundle, opens Terminal, and runs the existing terminal-based wizard without
+asking the user to trust a loose downloaded `.command` file. The other
+launchers operate on the generated environment in
+`~/Library/Application Support/SPX/generated`.
 
 1. Confirm both Developer ID certificates are present in your keychain:
 
@@ -242,7 +245,15 @@ scripts/build_macos_pkg.sh \
 The output package is written to `dist/spx-installer-macos-<version>.pkg`. After
 installation, users launch `SPX Setup.app` from `/Applications`; the installer
 defaults to a user-writable output directory when it is running from a packaged
-location such as `/Applications`.
+location such as `/Applications`. Once they have generated a local environment,
+they can later manage it via the companion launchers in the same Applications
+folder:
+
+- `SPX Start.app` opens the generated `spx-start.command`.
+- `SPX Stop.app` opens the generated `spx-stop.command`.
+- `SPX Cleanup.app` stops the generated stack, asks Docker to remove the
+  generated environment's containers, images, and volumes, then deletes the
+  local generated/runtime directories without uninstalling the macOS apps.
 
 ### 5. Produce single-file installers (optional)
 

--- a/installer/macos/spx_cleanup_launcher.applescript
+++ b/installer/macos/spx_cleanup_launcher.applescript
@@ -1,0 +1,66 @@
+property appTitle : "SPX Cleanup"
+property generatedDirRelativePath : "Library/Application Support/SPX/generated"
+property runtimeDirRelativePath : "Library/Application Support/SPX/runtime"
+
+on run
+  set homePath to POSIX path of (path to home folder)
+  set generatedDir to homePath & generatedDirRelativePath
+  set runtimeDir to homePath & runtimeDirRelativePath
+
+  if not my fileOrDirExists(generatedDir) and not my fileOrDirExists(runtimeDir) then
+    activate
+    display dialog appTitle & " did not find any local SPX runtime files to remove." & return & return & "Expected locations:" & return & generatedDir & return & runtimeDir buttons {"OK"} default button "OK" with icon note
+    return
+  end if
+
+  activate
+  display dialog "SPX Cleanup will stop the local stack, remove generated files, remove the installer runtime, and ask Docker to delete containers, volumes, and images referenced by the generated environment." buttons {"Cancel", "Clean Up"} default button "Clean Up" cancel button "Cancel" with icon caution
+
+  set commandText to "/bin/bash -lc " & quoted form of my cleanupShell(generatedDir, runtimeDir)
+
+  try
+    tell application "Terminal"
+      activate
+      do script commandText
+    end tell
+  on error errMsg number errNum
+    activate
+    display dialog "Unable to launch the SPX cleanup command in Terminal." & return & return & errMsg & " (" & errNum & ")" buttons {"OK"} default button "OK" with icon stop
+  end try
+end run
+
+on cleanupShell(generatedDir, runtimeDir)
+  set commandLines to {}
+  set end of commandLines to "set -euo pipefail"
+  set end of commandLines to "GENERATED_DIR=" & quoted form of generatedDir
+  set end of commandLines to "RUNTIME_DIR=" & quoted form of runtimeDir
+  set end of commandLines to "echo \"[spx-cleanup] Generated directory: $GENERATED_DIR\""
+  set end of commandLines to "echo \"[spx-cleanup] Runtime directory: $RUNTIME_DIR\""
+  set end of commandLines to "pkill -f spx-ble-adapter >/dev/null 2>&1 || true"
+  set end of commandLines to "if [ -f \"$GENERATED_DIR/docker-compose.generated.yml\" ] && command -v docker >/dev/null 2>&1; then"
+  set end of commandLines to "  echo \"[spx-cleanup] Removing Docker resources from generated environment...\""
+  set end of commandLines to "  docker compose -f \"$GENERATED_DIR/docker-compose.generated.yml\" --env-file \"$GENERATED_DIR/.env\" down --remove-orphans --volumes --rmi all || true"
+  set end of commandLines to "elif [ -f \"$GENERATED_DIR/docker-compose.generated.yml\" ]; then"
+  set end of commandLines to "  echo \"[spx-cleanup] Docker CLI not found; skipping Docker cleanup.\""
+  set end of commandLines to "fi"
+  set end of commandLines to "rm -rf \"$GENERATED_DIR\" \"$RUNTIME_DIR\""
+  set end of commandLines to "echo \"[spx-cleanup] Removed local SPX generated and runtime directories.\""
+  return my joinLines(commandLines, linefeed)
+end cleanupShell
+
+on fileOrDirExists(targetPath)
+  try
+    do shell script "test -e " & quoted form of targetPath
+    return true
+  on error
+    return false
+  end try
+end fileOrDirExists
+
+on joinLines(itemsList, delimiter)
+  set previousDelimiters to AppleScript's text item delimiters
+  set AppleScript's text item delimiters to delimiter
+  set joinedText to itemsList as text
+  set AppleScript's text item delimiters to previousDelimiters
+  return joinedText
+end joinLines

--- a/installer/macos/spx_start_launcher.applescript
+++ b/installer/macos/spx_start_launcher.applescript
@@ -1,0 +1,22 @@
+property appTitle : "SPX Start"
+property generatedLauncherRelativePath : "Library/Application Support/SPX/generated/spx-start.command"
+
+on run
+  set homePath to POSIX path of (path to home folder)
+  set launcherPath to homePath & generatedLauncherRelativePath
+
+  try
+    set launcherAlias to POSIX file launcherPath as alias
+  on error
+    activate
+    display dialog appTitle & " could not find a generated SPX environment." & return & return & "Expected launcher: " & launcherPath & return & return & "Run SPX Setup.app first to generate an environment." buttons {"OK"} default button "OK" with icon stop
+    return
+  end try
+
+  try
+    do shell script "/usr/bin/open -a Terminal " & quoted form of (POSIX path of launcherAlias)
+  on error errMsg number errNum
+    activate
+    display dialog "Unable to launch the SPX start command in Terminal." & return & return & errMsg & " (" & errNum & ")" buttons {"OK"} default button "OK" with icon stop
+  end try
+end run

--- a/installer/macos/spx_stop_launcher.applescript
+++ b/installer/macos/spx_stop_launcher.applescript
@@ -1,0 +1,22 @@
+property appTitle : "SPX Stop"
+property generatedLauncherRelativePath : "Library/Application Support/SPX/generated/spx-stop.command"
+
+on run
+  set homePath to POSIX path of (path to home folder)
+  set launcherPath to homePath & generatedLauncherRelativePath
+
+  try
+    set launcherAlias to POSIX file launcherPath as alias
+  on error
+    activate
+    display dialog appTitle & " could not find a generated SPX environment." & return & return & "Expected launcher: " & launcherPath & return & return & "Run SPX Setup.app first to generate an environment." buttons {"OK"} default button "OK" with icon stop
+    return
+  end try
+
+  try
+    do shell script "/usr/bin/open -a Terminal " & quoted form of (POSIX path of launcherAlias)
+  on error errMsg number errNum
+    activate
+    display dialog "Unable to launch the SPX stop command in Terminal." & return & return & errMsg & " (" & errNum & ")" buttons {"OK"} default button "OK" with icon stop
+  end try
+end run

--- a/scripts/build_macos_cleanup_app.sh
+++ b/scripts/build_macos_cleanup_app.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build_macos_cleanup_app.sh [options]
+
+Builds SPX Cleanup.app, a small macOS launcher that opens Terminal and removes
+the local SPX generated environment plus related Docker resources.
+
+Options:
+  --output-dir DIR    Directory where the app bundle will be created (default: dist)
+  --app-name NAME     App bundle name without extension (default: SPX Cleanup)
+  --bundle-id ID      CFBundleIdentifier for the app (default: com.hammerheadsengineers.spx.cleanup)
+  --version VERSION   App version (default: pyproject.toml version or dev)
+  --sign IDENTITY     Sign with this Developer ID Application identity
+  -h, --help          Show this help
+EOF
+}
+
+OUTPUT_DIR="dist"
+APP_NAME="SPX Cleanup"
+BUNDLE_ID="com.hammerheadsengineers.spx.cleanup"
+VERSION=""
+SIGN_IDENTITY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --app-name)
+      APP_NAME="$2"
+      shift 2
+      ;;
+    --bundle-id)
+      BUNDLE_ID="$2"
+      shift 2
+      ;;
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --sign)
+      SIGN_IDENTITY="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+build_args=(
+  --output-dir "${OUTPUT_DIR}"
+  --app-name "${APP_NAME}"
+  --bundle-id "${BUNDLE_ID}"
+  --script-source "installer/macos/spx_cleanup_launcher.applescript"
+  --skip-payload
+)
+
+if [[ -n "${VERSION}" ]]; then
+  build_args+=(--version "${VERSION}")
+fi
+
+if [[ -n "${SIGN_IDENTITY}" ]]; then
+  build_args+=(--sign "${SIGN_IDENTITY}")
+fi
+
+"${REPO_ROOT}/scripts/build_macos_setup_app.sh" "${build_args[@]}"

--- a/scripts/build_macos_pkg.sh
+++ b/scripts/build_macos_pkg.sh
@@ -6,9 +6,10 @@ usage() {
   cat <<'EOF'
 Usage: scripts/build_macos_pkg.sh [options]
 
-Builds a macOS flat installer package (.pkg) that installs SPX Setup.app into
-/Applications. The app contains the full installer payload inside its bundle,
-so the user gets a Finder-clickable launcher rather than a loose .command file.
+ Builds a macOS flat installer package (.pkg) that installs SPX Setup.app,
+ SPX Start.app, SPX Stop.app, and SPX Cleanup.app into /Applications.
+ SPX Setup.app contains the full installer payload; the other launchers operate
+ on the generated environment in the user's Application Support directory.
 
 Options:
   --output-dir DIR              Directory for the final .pkg (default: dist)
@@ -52,6 +53,12 @@ VERSION=""
 INSTALL_LOCATION="/Applications"
 APP_NAME="SPX Setup"
 APP_BUNDLE_ID="com.hammerheadsengineers.spx.setup"
+START_APP_NAME="SPX Start"
+START_APP_BUNDLE_ID="com.hammerheadsengineers.spx.start"
+STOP_APP_NAME="SPX Stop"
+STOP_APP_BUNDLE_ID="com.hammerheadsengineers.spx.stop"
+CLEANUP_APP_NAME="SPX Cleanup"
+CLEANUP_APP_BUNDLE_ID="com.hammerheadsengineers.spx.cleanup"
 APP_SIGN_IDENTITY=""
 SIGN_IDENTITY=""
 KEYCHAIN_PATH=""
@@ -169,6 +176,45 @@ if [[ -n "${APP_SIGN_IDENTITY}" ]]; then
 fi
 
 "${REPO_ROOT}/scripts/build_macos_setup_app.sh" "${build_app_args[@]}"
+
+build_start_app_args=(
+  --output-dir "${STAGING_DIR}/root"
+  --app-name "${START_APP_NAME}"
+  --bundle-id "${START_APP_BUNDLE_ID}"
+  --version "${VERSION}"
+)
+
+if [[ -n "${APP_SIGN_IDENTITY}" ]]; then
+  build_start_app_args+=(--sign "${APP_SIGN_IDENTITY}")
+fi
+
+"${REPO_ROOT}/scripts/build_macos_start_app.sh" "${build_start_app_args[@]}"
+
+build_stop_app_args=(
+  --output-dir "${STAGING_DIR}/root"
+  --app-name "${STOP_APP_NAME}"
+  --bundle-id "${STOP_APP_BUNDLE_ID}"
+  --version "${VERSION}"
+)
+
+if [[ -n "${APP_SIGN_IDENTITY}" ]]; then
+  build_stop_app_args+=(--sign "${APP_SIGN_IDENTITY}")
+fi
+
+"${REPO_ROOT}/scripts/build_macos_stop_app.sh" "${build_stop_app_args[@]}"
+
+build_cleanup_app_args=(
+  --output-dir "${STAGING_DIR}/root"
+  --app-name "${CLEANUP_APP_NAME}"
+  --bundle-id "${CLEANUP_APP_BUNDLE_ID}"
+  --version "${VERSION}"
+)
+
+if [[ -n "${APP_SIGN_IDENTITY}" ]]; then
+  build_cleanup_app_args+=(--sign "${APP_SIGN_IDENTITY}")
+fi
+
+"${REPO_ROOT}/scripts/build_macos_cleanup_app.sh" "${build_cleanup_app_args[@]}"
 
 PKG_PATH="${DEST_DIR}/${PKG_NAME}-${VERSION}.pkg"
 COMPONENT_PLIST="${STAGING_ROOT}/component.plist"

--- a/scripts/build_macos_setup_app.sh
+++ b/scripts/build_macos_setup_app.sh
@@ -16,6 +16,8 @@ Options:
   --staging-dir DIR   Directory for intermediate payload files (default: build/macos-app)
   --app-name NAME     App bundle name without extension (default: SPX Setup)
   --bundle-id ID      CFBundleIdentifier for the app (default: com.hammerheadsengineers.spx.setup)
+  --script-source P   AppleScript source used to build the app (default: installer/macos/spx_setup_launcher.applescript)
+  --skip-payload      Build the launcher without embedding the installer payload
   --version VERSION   App version (default: pyproject.toml version or dev)
   --sign IDENTITY     Sign with this Developer ID Application identity
   -h, --help          Show this help
@@ -43,6 +45,8 @@ OUTPUT_DIR="dist"
 STAGING_DIR="build/macos-app"
 APP_NAME="SPX Setup"
 BUNDLE_ID="com.hammerheadsengineers.spx.setup"
+SCRIPT_SOURCE_REL="installer/macos/spx_setup_launcher.applescript"
+SKIP_PAYLOAD=0
 VERSION=""
 SIGN_IDENTITY=""
 PAYLOAD_NAME="spx-installer"
@@ -64,6 +68,14 @@ while [[ $# -gt 0 ]]; do
     --bundle-id)
       BUNDLE_ID="$2"
       shift 2
+      ;;
+    --script-source)
+      SCRIPT_SOURCE_REL="$2"
+      shift 2
+      ;;
+    --skip-payload)
+      SKIP_PAYLOAD=1
+      shift
       ;;
     --version)
       VERSION="$2"
@@ -94,7 +106,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST_DIR="${REPO_ROOT}/${OUTPUT_DIR}"
 STAGING_ROOT="${REPO_ROOT}/${STAGING_DIR}"
 PAYLOAD_DIR="${STAGING_ROOT}/${PAYLOAD_NAME}"
-SCRIPT_SOURCE="${REPO_ROOT}/installer/macos/spx_setup_launcher.applescript"
+SCRIPT_SOURCE="${REPO_ROOT}/${SCRIPT_SOURCE_REL}"
 APP_PATH="${DEST_DIR}/${APP_NAME}.app"
 
 if [[ -z "${VERSION}" ]]; then
@@ -111,15 +123,19 @@ mkdir -p "${DEST_DIR}"
 mkdir -p "${STAGING_ROOT}"
 rm -rf "${APP_PATH}"
 
-"${REPO_ROOT}/scripts/build_installer_package.sh" \
-  --output-dir "${STAGING_DIR}" \
-  --package-name "${PAYLOAD_NAME}"
+if [[ "${SKIP_PAYLOAD}" -eq 0 ]]; then
+  "${REPO_ROOT}/scripts/build_installer_package.sh" \
+    --output-dir "${STAGING_DIR}" \
+    --package-name "${PAYLOAD_NAME}"
+fi
 
 xcrun osacompile -o "${APP_PATH}" "${SCRIPT_SOURCE}"
 
-RESOURCE_PAYLOAD_DIR="${APP_PATH}/Contents/Resources/${PAYLOAD_NAME}"
-mkdir -p "${RESOURCE_PAYLOAD_DIR}"
-rsync -a --delete "${PAYLOAD_DIR}/" "${RESOURCE_PAYLOAD_DIR}/"
+if [[ "${SKIP_PAYLOAD}" -eq 0 ]]; then
+  RESOURCE_PAYLOAD_DIR="${APP_PATH}/Contents/Resources/${PAYLOAD_NAME}"
+  mkdir -p "${RESOURCE_PAYLOAD_DIR}"
+  rsync -a --delete "${PAYLOAD_DIR}/" "${RESOURCE_PAYLOAD_DIR}/"
+fi
 
 plist="${APP_PATH}/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string '${BUNDLE_ID}'" "${plist}" 2>/dev/null || \

--- a/scripts/build_macos_start_app.sh
+++ b/scripts/build_macos_start_app.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build_macos_start_app.sh [options]
+
+Builds SPX Start.app, a small macOS launcher that opens Terminal and runs the
+generated spx-start.command from ~/Library/Application Support/SPX/generated.
+
+Options:
+  --output-dir DIR    Directory where the app bundle will be created (default: dist)
+  --app-name NAME     App bundle name without extension (default: SPX Start)
+  --bundle-id ID      CFBundleIdentifier for the app (default: com.hammerheadsengineers.spx.start)
+  --version VERSION   App version (default: pyproject.toml version or dev)
+  --sign IDENTITY     Sign with this Developer ID Application identity
+  -h, --help          Show this help
+EOF
+}
+
+OUTPUT_DIR="dist"
+APP_NAME="SPX Start"
+BUNDLE_ID="com.hammerheadsengineers.spx.start"
+VERSION=""
+SIGN_IDENTITY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --app-name)
+      APP_NAME="$2"
+      shift 2
+      ;;
+    --bundle-id)
+      BUNDLE_ID="$2"
+      shift 2
+      ;;
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --sign)
+      SIGN_IDENTITY="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+build_args=(
+  --output-dir "${OUTPUT_DIR}"
+  --app-name "${APP_NAME}"
+  --bundle-id "${BUNDLE_ID}"
+  --script-source "installer/macos/spx_start_launcher.applescript"
+  --skip-payload
+)
+
+if [[ -n "${VERSION}" ]]; then
+  build_args+=(--version "${VERSION}")
+fi
+
+if [[ -n "${SIGN_IDENTITY}" ]]; then
+  build_args+=(--sign "${SIGN_IDENTITY}")
+fi
+
+"${REPO_ROOT}/scripts/build_macos_setup_app.sh" "${build_args[@]}"

--- a/scripts/build_macos_stop_app.sh
+++ b/scripts/build_macos_stop_app.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build_macos_stop_app.sh [options]
+
+Builds SPX Stop.app, a small macOS launcher that opens Terminal and runs the
+generated spx-stop.command from ~/Library/Application Support/SPX/generated.
+
+Options:
+  --output-dir DIR    Directory where the app bundle will be created (default: dist)
+  --app-name NAME     App bundle name without extension (default: SPX Stop)
+  --bundle-id ID      CFBundleIdentifier for the app (default: com.hammerheadsengineers.spx.stop)
+  --version VERSION   App version (default: pyproject.toml version or dev)
+  --sign IDENTITY     Sign with this Developer ID Application identity
+  -h, --help          Show this help
+EOF
+}
+
+OUTPUT_DIR="dist"
+APP_NAME="SPX Stop"
+BUNDLE_ID="com.hammerheadsengineers.spx.stop"
+VERSION=""
+SIGN_IDENTITY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --app-name)
+      APP_NAME="$2"
+      shift 2
+      ;;
+    --bundle-id)
+      BUNDLE_ID="$2"
+      shift 2
+      ;;
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --sign)
+      SIGN_IDENTITY="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+build_args=(
+  --output-dir "${OUTPUT_DIR}"
+  --app-name "${APP_NAME}"
+  --bundle-id "${BUNDLE_ID}"
+  --script-source "installer/macos/spx_stop_launcher.applescript"
+  --skip-payload
+)
+
+if [[ -n "${VERSION}" ]]; then
+  build_args+=(--version "${VERSION}")
+fi
+
+if [[ -n "${SIGN_IDENTITY}" ]]; then
+  build_args+=(--sign "${SIGN_IDENTITY}")
+fi
+
+"${REPO_ROOT}/scripts/build_macos_setup_app.sh" "${build_args[@]}"


### PR DESCRIPTION
## Summary
- add companion macOS launcher apps for generated SPX environments: `SPX Start.app`, `SPX Stop.app`, and `SPX Cleanup.app`
- extend the macOS packaging flow so `.pkg` installs all launchers into `/Applications`
- reuse the generic app builder for thin AppleScript launchers without embedding the installer payload
- document how the companion apps work for packaged macOS installs

## Testing
- `bash -n scripts/build_macos_setup_app.sh scripts/build_macos_start_app.sh scripts/build_macos_stop_app.sh scripts/build_macos_cleanup_app.sh scripts/build_macos_pkg.sh`
- `./scripts/build_macos_pkg.sh --output-dir build/pkg-launcher-prcheck`
- `codesign --verify --verbose=4 build/macos-start-test/SPX\ Start.app`
- `codesign --verify --verbose=4 build/macos-cleanup-test/SPX\ Cleanup.app`
- manual local macOS validation of reinstall flow and launcher behavior
