### PR TITLE
feat(installer): add macOS Codex MCP workspace bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ This repository includes a local MCP tool for code-oriented LLM workflows agains
 Claude Code and is aware of the repository catalog, profiles, packs, model
 validation rules, runtime logs, `communication`, and protocol bindings.
 
+If you install the macOS `.pkg`, the companion `SPX MCP Setup.app` can create an
+installer-managed Codex workspace with `.codex/config.toml` preconfigured for
+the local `spx-mcp` server. That managed workspace defaults to read-only MCP
+mode; for Git-backed write workflows, continue to use a normal repository clone.
+
 For attribute-heavy runtime workflows, prefer the batch MCP tools
 `server_get_attrs` and `server_set_attrs` to reduce round trips. For time-based
 numeric changes, use `server_ramp_attr`. For richer runtime behavior, prefer the
@@ -212,12 +217,13 @@ Hand the `.tgz` to teammates; they can extract it anywhere and run the platform 
 ### 6. Build a trusted macOS installer (Developer ID + notarization)
 
 For a macOS-native distribution, build a signed `.pkg` that installs
-`SPX Setup.app`, `SPX Start.app`, `SPX Stop.app`, and `SPX Cleanup.app` into
-`/Applications`. `SPX Setup.app` embeds the full installer payload inside the
-bundle, opens Terminal, and runs the existing terminal-based wizard without
-asking the user to trust a loose downloaded `.command` file. The other
-launchers operate on the generated environment in
-`~/Library/Application Support/SPX/generated`.
+`SPX Setup.app`, `SPX MCP Setup.app`, `SPX Start.app`, `SPX Stop.app`, and
+`SPX Cleanup.app` into `/Applications`. `SPX Setup.app` embeds the full
+installer payload inside the bundle, opens Terminal, and runs the existing
+terminal-based wizard without asking the user to trust a loose downloaded
+`.command` file. The other launchers operate on the generated environment in
+`~/Library/Application Support/SPX/generated` or bootstrap the installer-managed
+Codex MCP workspace.
 
 1. Confirm both Developer ID certificates are present in your keychain:
 
@@ -249,6 +255,9 @@ location such as `/Applications`. Once they have generated a local environment,
 they can later manage it via the companion launchers in the same Applications
 folder:
 
+- `SPX MCP Setup.app` creates `~/Documents/SPX Codex Workspace`, prepares a
+  local `.venv`, writes `.codex/config.toml`, and opens that folder for Codex.
+  The generated MCP config defaults to read-only mode.
 - `SPX Start.app` opens the generated `spx-start.command`.
 - `SPX Stop.app` opens the generated `spx-stop.command`.
 - `SPX Cleanup.app` stops the generated stack, asks Docker to remove the

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -48,6 +48,12 @@ Linux or macOS:
 sh tools/setup_codex_mcp.sh
 ```
 
+If you installed the macOS `.pkg`, you can also launch `SPX MCP Setup.app`.
+That companion app creates an installer-managed workspace at
+`~/Documents/SPX Codex Workspace`, prepares a local `.venv`, and writes
+`.codex/config.toml` for that folder in read-only mode. Open Codex in the
+generated workspace and start a fresh thread to pick up the config.
+
 Optional flags:
 
 - `--read-only` to omit `--allow-write`

--- a/installer/macos/spx_mcp_setup_launcher.applescript
+++ b/installer/macos/spx_mcp_setup_launcher.applescript
@@ -1,0 +1,25 @@
+property appTitle : "SPX MCP Setup"
+property setupAppName : "SPX Setup.app"
+property payloadDirName : "spx-installer"
+property launcherName : "spx-mcp-setup.command"
+
+on run
+  set appBundlePath to POSIX path of (path to me)
+  set appsDirPath to do shell script "/usr/bin/dirname " & quoted form of appBundlePath
+  set launcherPath to appsDirPath & "/" & setupAppName & "/Contents/Resources/" & payloadDirName & "/" & launcherName
+
+  try
+    set launcherAlias to POSIX file launcherPath as alias
+  on error
+    activate
+    display dialog appTitle & " could not find the embedded MCP setup launcher." & return & return & "Expected launcher: " & launcherPath & return & return & "Reinstall the latest SPX package if SPX Setup.app is missing." buttons {"OK"} default button "OK" with icon stop
+    return
+  end try
+
+  try
+    do shell script "/usr/bin/open -a Terminal " & quoted form of (POSIX path of launcherAlias)
+  on error errMsg number errNum
+    activate
+    display dialog "Unable to launch the SPX MCP workspace setup in Terminal." & return & return & errMsg & " (" & errNum & ")" buttons {"OK"} default button "OK" with icon stop
+  end try
+end run

--- a/installer/mcp_workspace.py
+++ b/installer/mcp_workspace.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Create or refresh an installer-managed Codex MCP workspace."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Mapping, Optional, Sequence
+
+
+DEFAULT_SERVER_NAME = "spx"
+DEFAULT_BASE_URL = "http://localhost:8000"
+DEFAULT_PRODUCT_KEY = "REPLACE_ME"
+DEFAULT_WORKSPACE_NAME = "SPX Codex Workspace"
+WORKSPACE_README_NAME = "MCP_WORKSPACE_README.md"
+WORKSPACE_MARKER_NAME = ".spx-mcp-workspace.json"
+SKIP_ENTRY_NAMES = {"__pycache__", ".pytest_cache", ".mypy_cache", ".DS_Store"}
+WORKSPACE_ENTRY_NAMES = (
+    "installer",
+    "library",
+    "profiles",
+    "extensions",
+    "spx_mcp",
+    "tools",
+    "docs",
+    "AGENTS.md",
+    "spx-setup.command",
+    "spx-setup.desktop",
+    "spx-setup.sh",
+    "spx-setup.bat",
+    "spx-mcp-setup.command",
+    "spx-mcp-setup.sh",
+    "spx-install.sh",
+    "spx-install.ps1",
+    "README.md",
+    "pyproject.toml",
+    "poetry.lock",
+    "INSTALLER_README.md",
+)
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bootstrap a local Codex workspace for the packaged SPX MCP tool.",
+    )
+    parser.add_argument(
+        "--source-root",
+        required=True,
+        help="Installer payload root that contains spx_mcp, tools, docs, and manifests.",
+    )
+    parser.add_argument(
+        "--workspace-dir",
+        required=False,
+        default=None,
+        help="Destination directory for the managed Codex workspace.",
+    )
+    parser.add_argument(
+        "--python",
+        required=False,
+        default=sys.executable,
+        help="Python 3.10+ executable used to prepare the local .venv.",
+    )
+    parser.add_argument(
+        "--seed-env",
+        required=False,
+        default=None,
+        help="Optional .env file used to seed SPX_PRODUCT_KEY / SPX_BASE_URL.",
+    )
+    parser.add_argument(
+        "--server-name",
+        default=DEFAULT_SERVER_NAME,
+        help="Codex MCP server name written into .codex/config.toml.",
+    )
+    parser.add_argument(
+        "--allow-write",
+        action="store_true",
+        help="Generate the Codex MCP config with write tools enabled.",
+    )
+    return parser.parse_args(argv)
+
+
+def default_workspace_dir(
+    home: Optional[Path] = None,
+    platform_name: Optional[str] = None,
+) -> Path:
+    home = (home or Path.home()).expanduser().resolve()
+    platform_name = platform_name or sys.platform
+    if platform_name == "darwin":
+        return home / "Documents" / DEFAULT_WORKSPACE_NAME
+    if platform_name.startswith("win"):
+        return home / "Documents" / DEFAULT_WORKSPACE_NAME
+    return home / "spx-codex-workspace"
+
+
+def read_dotenv(path: Path) -> dict[str, str]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in raw.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def normalize_base_url(value: str) -> str:
+    return str(value or DEFAULT_BASE_URL).rstrip("/")
+
+
+def build_workspace_env(
+    *,
+    existing: Optional[Mapping[str, str]] = None,
+    seeded: Optional[Mapping[str, str]] = None,
+) -> dict[str, str]:
+    merged = dict(existing or {})
+    seeded = dict(seeded or {})
+
+    if seeded.get("SPX_PRODUCT_KEY"):
+        merged["SPX_PRODUCT_KEY"] = seeded["SPX_PRODUCT_KEY"]
+    elif not merged.get("SPX_PRODUCT_KEY"):
+        merged["SPX_PRODUCT_KEY"] = DEFAULT_PRODUCT_KEY
+
+    if seeded.get("SPX_BASE_URL"):
+        merged["SPX_BASE_URL"] = normalize_base_url(seeded["SPX_BASE_URL"])
+    elif merged.get("SPX_BASE_URL"):
+        merged["SPX_BASE_URL"] = normalize_base_url(merged["SPX_BASE_URL"])
+    else:
+        merged["SPX_BASE_URL"] = DEFAULT_BASE_URL
+
+    return merged
+
+
+def write_dotenv(path: Path, values: Mapping[str, str]) -> None:
+    lines = [f"{key}={values[key]}" for key in sorted(values)]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def validate_source_root(source_root: Path) -> None:
+    required_paths = [
+        source_root / "spx_mcp",
+        source_root / "tools" / "codex_mcp_bootstrap.py",
+        source_root / "installer" / "runtime_bootstrap.py",
+        source_root / "library" / "catalog" / "models.yaml",
+        source_root / "pyproject.toml",
+    ]
+    missing = [str(path) for path in required_paths if not path.exists()]
+    if missing:
+        raise RuntimeError(
+            "Installer payload is missing MCP workspace assets:\n- "
+            + "\n- ".join(missing)
+        )
+
+
+def remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def copy_path(src: Path, dest: Path) -> None:
+    if src.is_dir():
+        shutil.copytree(
+            src,
+            dest,
+            symlinks=True,
+            ignore=shutil.ignore_patterns(*sorted(SKIP_ENTRY_NAMES)),
+        )
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)
+
+
+def sync_payload(source_root: Path, workspace_dir: Path) -> None:
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    for entry_name in WORKSPACE_ENTRY_NAMES:
+        if entry_name in SKIP_ENTRY_NAMES:
+            continue
+        entry = source_root / entry_name
+        if not entry.exists():
+            continue
+        dest = workspace_dir / entry_name
+        if dest.exists() or dest.is_symlink():
+            remove_path(dest)
+        copy_path(entry, dest)
+
+
+def run_command(
+    argv: Sequence[str],
+    *,
+    cwd: Optional[Path] = None,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        check=True,
+        cwd=str(cwd) if cwd else None,
+        text=True,
+        capture_output=capture_output,
+    )
+
+
+def bootstrap_runtime(source_root: Path, workspace_dir: Path, python_bin: str) -> Path:
+    runtime_helper = source_root / "installer" / "runtime_bootstrap.py"
+    result = run_command(
+        [
+            python_bin,
+            str(runtime_helper),
+            "--venv-dir",
+            str(workspace_dir / ".venv"),
+        ],
+        capture_output=True,
+    )
+    venv_python = Path(result.stdout.strip()).expanduser()
+    run_command(
+        [
+            str(venv_python),
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "-e",
+            str(workspace_dir),
+        ]
+    )
+    return venv_python
+
+
+def bootstrap_codex(workspace_dir: Path, python_bin: str, *, server_name: str, allow_write: bool) -> None:
+    bootstrap_script = workspace_dir / "tools" / "codex_mcp_bootstrap.py"
+    argv = [
+        python_bin,
+        str(bootstrap_script),
+        "--repo-root",
+        str(workspace_dir),
+        "--server-name",
+        server_name,
+        "--skip-git-exclude",
+    ]
+    if not allow_write:
+        argv.append("--read-only")
+    run_command(argv)
+
+
+def verify_workspace(venv_python: Path, workspace_dir: Path) -> None:
+    run_command(
+        [
+            str(venv_python),
+            "-m",
+            "spx_mcp",
+            "doctor",
+            "--repo-root",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+
+
+def write_workspace_readme(workspace_dir: Path, *, server_name: str, allow_write: bool) -> None:
+    mode_label = "read/write" if allow_write else "read-only"
+    readme = f"""# SPX Codex Workspace
+
+This folder was created by the packaged SPX installer so Codex can use the local
+`spx-mcp` server without cloning the full repository.
+
+## What is inside
+
+- a managed copy of the repo assets needed by `spx-mcp`
+- a local `.venv` prepared for the MCP server
+- `.codex/config.toml` pointing Codex at the local MCP server id `{server_name}`
+
+## How to use it
+
+1. Open this folder in Codex.
+2. Start a fresh thread so Codex reloads `.codex/config.toml`.
+3. Use the `spx` MCP server from this workspace.
+
+The generated config currently uses `{mode_label}` mode.
+If you want to regenerate it manually, run:
+
+```bash
+sh tools/setup_codex_mcp.sh{" --read-only" if not allow_write else ""}
+```
+
+If you need a Git-backed editable repository, clone `spx-examples` separately
+and bootstrap MCP there instead of editing this installer-managed copy.
+"""
+    (workspace_dir / WORKSPACE_README_NAME).write_text(readme, encoding="utf-8")
+
+
+def write_workspace_marker(
+    workspace_dir: Path,
+    *,
+    source_root: Path,
+    workspace_python: Path,
+    server_name: str,
+    allow_write: bool,
+) -> None:
+    payload = {
+        "kind": "spx-codex-mcp-workspace",
+        "source_root": str(source_root),
+        "workspace_python": str(workspace_python),
+        "server_name": server_name,
+        "allow_write": allow_write,
+    }
+    (workspace_dir / WORKSPACE_MARKER_NAME).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    source_root = Path(args.source_root).expanduser().resolve()
+    workspace_dir = (
+        Path(args.workspace_dir).expanduser().resolve()
+        if args.workspace_dir
+        else default_workspace_dir()
+    )
+    seed_env_path = (
+        Path(args.seed_env).expanduser().resolve()
+        if args.seed_env
+        else None
+    )
+
+    validate_source_root(source_root)
+    sync_payload(source_root, workspace_dir)
+
+    existing_env = read_dotenv(workspace_dir / ".env")
+    seeded_env = read_dotenv(seed_env_path) if seed_env_path else {}
+    workspace_env = build_workspace_env(existing=existing_env, seeded=seeded_env)
+    write_dotenv(workspace_dir / ".env", workspace_env)
+
+    venv_python = bootstrap_runtime(source_root, workspace_dir, args.python)
+    bootstrap_codex(
+        workspace_dir,
+        args.python,
+        server_name=args.server_name,
+        allow_write=bool(args.allow_write),
+    )
+    write_workspace_readme(
+        workspace_dir,
+        server_name=args.server_name,
+        allow_write=bool(args.allow_write),
+    )
+    write_workspace_marker(
+        workspace_dir,
+        source_root=source_root,
+        workspace_python=venv_python,
+        server_name=args.server_name,
+        allow_write=bool(args.allow_write),
+    )
+    verify_workspace(venv_python, workspace_dir)
+
+    print(f"[spx-mcp-workspace] Workspace directory: {workspace_dir}")
+    print(f"[spx-mcp-workspace] Local venv python: {venv_python}")
+    print(f"[spx-mcp-workspace] Codex config: {workspace_dir / '.codex' / 'config.toml'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_installer_package.sh
+++ b/scripts/build_installer_package.sh
@@ -54,10 +54,16 @@ copy_entries=(
   "library"
   "profiles"
   "extensions"
+  "spx_mcp"
+  "tools"
+  "docs"
+  "AGENTS.md"
   "spx-setup.command"
   "spx-setup.desktop"
   "spx-setup.sh"
   "spx-setup.bat"
+  "spx-mcp-setup.command"
+  "spx-mcp-setup.sh"
   "spx-install.sh"
   "spx-install.ps1"
   "README.md"
@@ -95,6 +101,7 @@ without cloning the full spx-examples repository.
 
 - Python 3.9+ with `pip`
 - Docker Desktop / Docker Engine with Compose V2
+- Python 3.10+ if you want to bootstrap the local Codex MCP workspace
 
 ## Usage
 
@@ -106,6 +113,17 @@ without cloning the full spx-examples repository.
    - macOS/Linux shells: `./spx-setup.sh`
 3. Follow the wizard prompts. Artifacts are written to `build/spx-generated/` by default.
 4. Inside the generated directory run `./spx-start.sh` (or `pwsh ./spx-start.ps1`) to start the stack.
+
+## Optional Codex MCP workspace
+
+If you want a repo-like workspace that Codex can open with the local `spx-mcp`
+server preconfigured, run:
+
+- macOS: `./spx-mcp-setup.command`
+- macOS/Linux shells: `./spx-mcp-setup.sh`
+
+This creates an installer-managed workspace and a local `.codex/config.toml`
+for that folder. Open Codex in the generated workspace and start a fresh thread.
 
 You can safely redistribute the extracted folder (including `build/spx-generated`) to teammates.
 EOF

--- a/scripts/build_macos_mcp_setup_app.sh
+++ b/scripts/build_macos_mcp_setup_app.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build_macos_mcp_setup_app.sh [options]
+
+Builds SPX MCP Setup.app, a thin macOS launcher that opens Terminal and runs
+the embedded spx-mcp-setup.command from SPX Setup.app.
+
+Options:
+  --output-dir DIR    Directory where the app bundle will be created (default: dist)
+  --app-name NAME     App bundle name without extension (default: SPX MCP Setup)
+  --bundle-id ID      CFBundleIdentifier for the app (default: com.hammerheadsengineers.spx.mcp.setup)
+  --version VERSION   App version (default: pyproject.toml version or dev)
+  --sign IDENTITY     Sign with this Developer ID Application identity
+  -h, --help          Show this help
+EOF
+}
+
+OUTPUT_DIR="dist"
+APP_NAME="SPX MCP Setup"
+BUNDLE_ID="com.hammerheadsengineers.spx.mcp.setup"
+VERSION=""
+SIGN_IDENTITY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --app-name)
+      APP_NAME="$2"
+      shift 2
+      ;;
+    --bundle-id)
+      BUNDLE_ID="$2"
+      shift 2
+      ;;
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --sign)
+      SIGN_IDENTITY="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+build_args=(
+  --output-dir "${OUTPUT_DIR}"
+  --app-name "${APP_NAME}"
+  --bundle-id "${BUNDLE_ID}"
+  --script-source "installer/macos/spx_mcp_setup_launcher.applescript"
+  --skip-payload
+)
+
+if [[ -n "${VERSION}" ]]; then
+  build_args+=(--version "${VERSION}")
+fi
+
+if [[ -n "${SIGN_IDENTITY}" ]]; then
+  build_args+=(--sign "${SIGN_IDENTITY}")
+fi
+
+"${REPO_ROOT}/scripts/build_macos_setup_app.sh" "${build_args[@]}"

--- a/scripts/build_macos_pkg.sh
+++ b/scripts/build_macos_pkg.sh
@@ -7,9 +7,10 @@ usage() {
 Usage: scripts/build_macos_pkg.sh [options]
 
  Builds a macOS flat installer package (.pkg) that installs SPX Setup.app,
- SPX Start.app, SPX Stop.app, and SPX Cleanup.app into /Applications.
- SPX Setup.app contains the full installer payload; the other launchers operate
- on the generated environment in the user's Application Support directory.
+ SPX MCP Setup.app, SPX Start.app, SPX Stop.app, and SPX Cleanup.app into
+ /Applications. SPX Setup.app contains the full installer payload; the other
+ launchers operate on the generated environment in the user's Application
+ Support directory or bootstrap a managed Codex MCP workspace.
 
 Options:
   --output-dir DIR              Directory for the final .pkg (default: dist)
@@ -53,6 +54,8 @@ VERSION=""
 INSTALL_LOCATION="/Applications"
 APP_NAME="SPX Setup"
 APP_BUNDLE_ID="com.hammerheadsengineers.spx.setup"
+MCP_SETUP_APP_NAME="SPX MCP Setup"
+MCP_SETUP_APP_BUNDLE_ID="com.hammerheadsengineers.spx.mcp.setup"
 START_APP_NAME="SPX Start"
 START_APP_BUNDLE_ID="com.hammerheadsengineers.spx.start"
 STOP_APP_NAME="SPX Stop"
@@ -176,6 +179,19 @@ if [[ -n "${APP_SIGN_IDENTITY}" ]]; then
 fi
 
 "${REPO_ROOT}/scripts/build_macos_setup_app.sh" "${build_app_args[@]}"
+
+build_mcp_setup_app_args=(
+  --output-dir "${STAGING_DIR}/root"
+  --app-name "${MCP_SETUP_APP_NAME}"
+  --bundle-id "${MCP_SETUP_APP_BUNDLE_ID}"
+  --version "${VERSION}"
+)
+
+if [[ -n "${APP_SIGN_IDENTITY}" ]]; then
+  build_mcp_setup_app_args+=(--sign "${APP_SIGN_IDENTITY}")
+fi
+
+"${REPO_ROOT}/scripts/build_macos_mcp_setup_app.sh" "${build_mcp_setup_app_args[@]}"
 
 build_start_app_args=(
   --output-dir "${STAGING_DIR}/root"

--- a/spx-mcp-setup.command
+++ b/spx-mcp-setup.command
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+LAUNCHER="./spx-mcp-setup.sh"
+if [ ! -f "$LAUNCHER" ]; then
+  echo "[spx-mcp-setup] Missing launcher in $SCRIPT_DIR"
+  read -r -p "Press Enter to close..." _
+  exit 1
+fi
+
+if command -v xattr >/dev/null 2>&1; then
+  xattr -d com.apple.quarantine "$LAUNCHER" >/dev/null 2>&1 || true
+fi
+
+bash "$LAUNCHER" "$@"
+EXIT_CODE=$?
+
+echo ""
+echo "Exit code: $EXIT_CODE"
+read -r -p "Press Enter to close..." _
+
+exit $EXIT_CODE

--- a/spx-mcp-setup.sh
+++ b/spx-mcp-setup.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="${SPX_MCP_WORKSPACE_DIR:-}"
+SERVER_NAME="${SPX_MCP_SERVER_NAME:-spx}"
+
+default_workspace_dir() {
+  case "$(uname -s)" in
+    Darwin)
+      printf '%s\n' "${HOME}/Documents/SPX Codex Workspace"
+      ;;
+    *)
+      printf '%s\n' "${HOME}/spx-codex-workspace"
+      ;;
+  esac
+}
+
+default_seed_env() {
+  case "$(uname -s)" in
+    Darwin)
+      printf '%s\n' "${HOME}/Library/Application Support/SPX/generated/.env"
+      ;;
+    *)
+      printf '%s\n' "${HOME}/.local/share/spx/generated/.env"
+      ;;
+  esac
+}
+
+resolve_candidate_path() {
+  local candidate="$1"
+  if [[ "${candidate}" == */* ]]; then
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+    return 1
+  fi
+
+  command -v "${candidate}" 2>/dev/null || return 1
+}
+
+python_supports_mcp() {
+  local python_bin="$1"
+  "${python_bin}" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 10) else 1)' >/dev/null 2>&1
+}
+
+resolve_mcp_python() {
+  local resolved=""
+  local candidate=""
+  local seen="|"
+  local -a candidates=()
+
+  if [[ -n "${PYTHON_BIN:-}" ]]; then
+    candidates+=("${PYTHON_BIN}")
+  fi
+  candidates+=(python3.13 python3.12 python3.11 python3.10 python3 python)
+
+  for candidate in "${candidates[@]}"; do
+    resolved="$(resolve_candidate_path "${candidate}" || true)"
+    if [[ -z "${resolved}" ]]; then
+      continue
+    fi
+    if [[ "${seen}" == *"|${resolved}|"* ]]; then
+      continue
+    fi
+    seen="${seen}${resolved}|"
+    if python_supports_mcp "${resolved}"; then
+      printf '%s\n' "${resolved}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+if [[ -z "${WORKSPACE_DIR}" ]]; then
+  WORKSPACE_DIR="$(default_workspace_dir)"
+fi
+
+SEED_ENV_PATH="${SPX_MCP_SOURCE_ENV:-$(default_seed_env)}"
+MCP_PYTHON="$(resolve_mcp_python || true)"
+if [[ -z "${MCP_PYTHON}" ]]; then
+  echo "[spx-mcp-setup] Python 3.10+ is required to install the local Codex MCP workspace." >&2
+  echo "[spx-mcp-setup] Install Python 3.10+ and rerun this launcher." >&2
+  exit 1
+fi
+
+echo "[spx-mcp-setup] Source payload: ${SCRIPT_DIR}"
+echo "[spx-mcp-setup] Workspace directory: ${WORKSPACE_DIR}"
+echo "[spx-mcp-setup] Python runtime: ${MCP_PYTHON}"
+if [[ -f "${SEED_ENV_PATH}" ]]; then
+  echo "[spx-mcp-setup] Seeding MCP workspace env from: ${SEED_ENV_PATH}"
+else
+  echo "[spx-mcp-setup] No generated SPX env found. The workspace will use SPX_PRODUCT_KEY=REPLACE_ME."
+fi
+
+"${MCP_PYTHON}" "${SCRIPT_DIR}/installer/mcp_workspace.py" \
+  --source-root "${SCRIPT_DIR}" \
+  --workspace-dir "${WORKSPACE_DIR}" \
+  --python "${MCP_PYTHON}" \
+  --server-name "${SERVER_NAME}" \
+  --seed-env "${SEED_ENV_PATH}"
+
+echo ""
+echo "[spx-mcp-setup] Codex MCP workspace is ready."
+echo "[spx-mcp-setup] Open this folder in Codex and start a fresh thread:"
+echo "  ${WORKSPACE_DIR}"
+
+if command -v open >/dev/null 2>&1; then
+  open "${WORKSPACE_DIR}" >/dev/null 2>&1 || true
+fi

--- a/tests/installer/test_mcp_workspace.py
+++ b/tests/installer/test_mcp_workspace.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the installer-managed Codex MCP workspace bootstrap."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from installer import mcp_workspace
+
+
+def test_default_workspace_dir_uses_documents_on_macos(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = mcp_workspace.default_workspace_dir(home=home, platform_name="darwin")
+
+    assert result == home / "Documents" / "SPX Codex Workspace"
+
+
+def test_build_workspace_env_prefers_seed_and_defaults() -> None:
+    values = mcp_workspace.build_workspace_env(
+        existing={"CUSTOM_FLAG": "1"},
+        seeded={
+            "SPX_PRODUCT_KEY": "REAL-KEY",
+            "SPX_BASE_URL": "http://localhost:8000/",
+        },
+    )
+
+    assert values["SPX_PRODUCT_KEY"] == "REAL-KEY"
+    assert values["SPX_BASE_URL"] == "http://localhost:8000"
+    assert values["CUSTOM_FLAG"] == "1"
+
+
+def test_build_workspace_env_preserves_existing_base_url_when_seed_missing() -> None:
+    values = mcp_workspace.build_workspace_env(
+        existing={"SPX_BASE_URL": "http://custom-host:8000/", "SPX_PRODUCT_KEY": "KEEP"},
+        seeded={},
+    )
+
+    assert values["SPX_BASE_URL"] == "http://custom-host:8000"
+    assert values["SPX_PRODUCT_KEY"] == "KEEP"
+
+
+def test_sync_payload_replaces_managed_entries_and_keeps_local_state(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    (source_root / "README.md").write_text("new readme\n", encoding="utf-8")
+    docs_dir = source_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "MCP.md").write_text("docs\n", encoding="utf-8")
+    (source_root / "junk.txt").write_text("do not copy\n", encoding="utf-8")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("old readme\n", encoding="utf-8")
+    venv_dir = workspace / ".venv"
+    venv_dir.mkdir()
+    codex_dir = workspace / ".codex"
+    codex_dir.mkdir()
+    (workspace / "local.txt").write_text("keep me\n", encoding="utf-8")
+
+    mcp_workspace.sync_payload(source_root, workspace)
+
+    assert (workspace / "README.md").read_text(encoding="utf-8") == "new readme\n"
+    assert (workspace / "docs" / "MCP.md").read_text(encoding="utf-8") == "docs\n"
+    assert not (workspace / "junk.txt").exists()
+    assert venv_dir.exists()
+    assert codex_dir.exists()
+    assert (workspace / "local.txt").read_text(encoding="utf-8") == "keep me\n"
+
+
+def test_bootstrap_runtime_installs_workspace_editably(tmp_path: Path, monkeypatch) -> None:
+    source_root = tmp_path / "source"
+    runtime_helper = source_root / "installer" / "runtime_bootstrap.py"
+    runtime_helper.parent.mkdir(parents=True)
+    runtime_helper.write_text("", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    calls: list[list[str]] = []
+    expected_python = workspace / ".venv" / "bin" / "python"
+
+    def fake_run(argv, *, cwd=None, capture_output=False):
+        calls.append(argv)
+        if "runtime_bootstrap.py" in argv[1]:
+            return SimpleNamespace(stdout=str(expected_python) + "\n")
+        return SimpleNamespace(stdout="")
+
+    monkeypatch.setattr(mcp_workspace, "run_command", fake_run)
+
+    result = mcp_workspace.bootstrap_runtime(source_root, workspace, "python3.11")
+
+    assert result == expected_python
+    assert calls[0] == [
+        "python3.11",
+        str(runtime_helper),
+        "--venv-dir",
+        str(workspace / ".venv"),
+    ]
+    assert calls[1] == [
+        str(expected_python),
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "-e",
+        str(workspace),
+    ]
+
+
+def test_bootstrap_codex_uses_read_only_by_default(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / "workspace"
+    tools_dir = workspace / "tools"
+    tools_dir.mkdir(parents=True)
+    (tools_dir / "codex_mcp_bootstrap.py").write_text("", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_run(argv, *, cwd=None, capture_output=False):
+        calls.append(argv)
+        return SimpleNamespace(stdout="")
+
+    monkeypatch.setattr(mcp_workspace, "run_command", fake_run)
+
+    mcp_workspace.bootstrap_codex(
+        workspace,
+        "python3.11",
+        server_name="spx",
+        allow_write=False,
+    )
+
+    assert calls == [[
+        "python3.11",
+        str(workspace / "tools" / "codex_mcp_bootstrap.py"),
+        "--repo-root",
+        str(workspace),
+        "--server-name",
+        "spx",
+        "--skip-git-exclude",
+        "--read-only",
+    ]]

--- a/tests/mcp/unit/test_codex_mcp_bootstrap.py
+++ b/tests/mcp/unit/test_codex_mcp_bootstrap.py
@@ -25,8 +25,28 @@ def test_detect_server_invocation_prefers_local_venv_windows(tmp_path) -> None:
     )
 
     assert strategy == "local-venv"
-    assert invocation.command == python_exe.resolve().as_posix()
+    assert invocation.command == python_exe.as_posix()
     assert invocation.args == ["-m", "spx_mcp", "stdio", "--allow-write"]
+    assert invocation.cwd == tmp_path.resolve().as_posix()
+
+
+def test_detect_server_invocation_prefers_local_venv_posix_without_resolving_symlink(tmp_path) -> None:
+    python_exe = tmp_path / ".venv" / "bin" / "python"
+    python_exe.parent.mkdir(parents=True)
+    python_exe.write_text("", encoding="utf-8")
+
+    invocation, strategy = detect_server_invocation(
+        tmp_path,
+        allow_write=False,
+        startup_timeout_sec=20,
+        tool_timeout_sec=120,
+        platform_name="linux",
+        which=lambda _: None,
+    )
+
+    assert strategy == "local-venv"
+    assert invocation.command == python_exe.as_posix()
+    assert invocation.args == ["-m", "spx_mcp", "stdio"]
     assert invocation.cwd == tmp_path.resolve().as_posix()
 
 

--- a/tools/codex_mcp_bootstrap.py
+++ b/tools/codex_mcp_bootstrap.py
@@ -100,7 +100,7 @@ def detect_server_invocation(
     if venv_python.exists():
         return (
             ServerInvocation(
-                command=venv_python.resolve().as_posix(),
+                command=venv_python.as_posix(),
                 args=args,
                 cwd=repo_root.as_posix(),
                 startup_timeout_sec=startup_timeout_sec,


### PR DESCRIPTION
## Summary
- add `SPX MCP Setup.app` to the macOS installer package
- package the repo-local MCP assets (`spx_mcp`, `tools`, `docs`, `AGENTS.md`) inside the installer payload
- add `spx-mcp-setup.command` / `spx-mcp-setup.sh` and a Python bootstrap helper that creates an installer-managed Codex workspace with a local `.venv` and `.codex/config.toml`
- keep the generated Codex MCP config read-only by default and document the workflow
- fix local-venv Codex bootstrap so it points to `.venv/bin/python` instead of resolving the interpreter symlink to the system Python

## Testing
- `pytest`
- `bash -n spx-mcp-setup.command spx-mcp-setup.sh scripts/build_installer_package.sh scripts/build_macos_setup_app.sh scripts/build_macos_mcp_setup_app.sh scripts/build_macos_pkg.sh`
- `python3 -m py_compile installer/mcp_workspace.py tools/codex_mcp_bootstrap.py`
- `./scripts/build_macos_pkg.sh --output-dir build/pkg-mcp-finalcheck`
- `SPX_MCP_WORKSPACE_DIR="$PWD/build/mcp-workspace-smoke2" ./spx-mcp-setup.sh`
