### PR TITLE
fix(lab): finalize embedded lab metadata cleanup

### DIFF
--- a/library/domains/environment/sensor/generic/environment_sensor__lwm2m.yaml
+++ b/library/domains/environment/sensor/generic/environment_sensor__lwm2m.yaml
@@ -286,6 +286,7 @@ communication:
 scenarios:
   lwm2m_reconnect:
     name: LwM2M Reconnect
+    display_name: "LwM2M Reconnect"
     description: Temporarily detaches the LwM2M client to exercise reconnect handling.
     duration: 3.0
     call:

--- a/library/domains/environment/sensor/generic/environment_sensor__mqtt.yaml
+++ b/library/domains/environment/sensor/generic/environment_sensor__mqtt.yaml
@@ -247,10 +247,10 @@ actions:
           )
         )
 
-  # Evolve CO₂ concentration based on ventilation and occupancy respiration.
+  # Evolve CO2 concentration based on ventilation and occupancy respiration.
   - function: $in(k__co2_ppm)
     name: update_co2_ppm
-    description: Estimate indoor CO₂ with a low-order balance between emissions and ventilation.
+    description: Estimate indoor CO2 with a low-order balance between emissions and ventilation.
     outdoor_ppm: 420.0
     call: max(
           outdoor_ppm,
@@ -362,64 +362,83 @@ communication:
       default_qos: "$param(mqtt_default_qos)"
       default_retain: false
       bindings:
-        - attribute: $ext(k__temperature_c)
+        - name: publish_temperature_c
+          attribute: $ext(k__temperature_c)
           topic: telemetry/temperature_c
           direction: publish
-        - attribute: $ext(k__target_c)
+        - name: publish_target_c
+          attribute: $ext(k__target_c)
           topic: telemetry/target_c
           direction: publish
-        - attribute: $ext(k__humidity_percent)
+        - name: publish_humidity_percent
+          attribute: $ext(k__humidity_percent)
           topic: telemetry/humidity_percent
           direction: publish
-        - attribute: $ext(k__co2_ppm)
+        - name: publish_co2_ppm
+          attribute: $ext(k__co2_ppm)
           topic: telemetry/co2_ppm
           direction: publish
-        - attribute: $ext(k__comfort_index)
+        - name: publish_comfort_index
+          attribute: $ext(k__comfort_index)
           topic: telemetry/comfort_index
           direction: publish
-        - attribute: $ext(k__hvac_mode)
+        - name: publish_hvac_mode
+          attribute: $ext(k__hvac_mode)
           topic: telemetry/hvac_mode
           direction: publish
-        - attribute: $ext(k__fan_speed_percent)
+        - name: publish_fan_speed_percent
+          attribute: $ext(k__fan_speed_percent)
           topic: telemetry/fan_speed_percent
           direction: publish
-        - attribute: $ext(k__occupancy_count)
+        - name: publish_occupancy_count
+          attribute: $ext(k__occupancy_count)
           topic: telemetry/occupancy_count
           direction: publish
-        - attribute: $ext(k__status_text)
+        - name: publish_status_text
+          attribute: $ext(k__status_text)
           topic: telemetry/status
           direction: publish
-        - attribute: $ext(k__alarm_high_temp)
+        - name: publish_alarm_high_temp
+          attribute: $ext(k__alarm_high_temp)
           topic: telemetry/alarms/high_temp
           direction: publish
-        - attribute: $ext(k__alarm_co2)
+        - name: publish_alarm_co2
+          attribute: $ext(k__alarm_co2)
           topic: telemetry/alarms/co2
           direction: publish
-        - attribute: $ext(k__alarm_stale_data)
+        - name: publish_alarm_stale_data
+          attribute: $ext(k__alarm_stale_data)
           topic: telemetry/alarms/stale
           direction: publish
-        - attribute: $ext(k__mqtt_connected)
+        - name: publish_mqtt_connected
+          attribute: $ext(k__mqtt_connected)
           topic: telemetry/health/mqtt_connected
           direction: publish
-        - attribute: $attr(k__target_c)
+        - name: subscribe_target_c
+          attribute: $attr(k__target_c)
           topic: command/setpoint_c
           direction: subscribe
-        - attribute: $attr(k__hvac_mode)
+        - name: subscribe_hvac_mode
+          attribute: $attr(k__hvac_mode)
           topic: command/hvac_mode
           direction: subscribe
-        - attribute: $attr(k__fan_speed_target)
+        - name: subscribe_fan_speed_target
+          attribute: $attr(k__fan_speed_target)
           topic: command/fan_speed
           direction: subscribe
-        - attribute: $attr(k__occupancy_target)
+        - name: subscribe_occupancy_target
+          attribute: $attr(k__occupancy_target)
           topic: command/occupancy
           direction: subscribe
-        - attribute: $attr(command_source)
+        - name: subscribe_command_source
+          attribute: $attr(command_source)
           topic: command/source
           direction: subscribe
 
 scenarios:
   occupancy_spike:
     name: Occupancy Spike
+    display_name: "Occupancy Spike"
     description: Temporarily raises occupancy to exercise HVAC response under crowding.
     duration: 15.0
     overrides:
@@ -427,6 +446,7 @@ scenarios:
 
   night_setback:
     name: Night Setback
+    display_name: "Night Setback"
     description: Lowers temperature and fan demand to simulate night operation.
     duration: 30.0
     overrides:
@@ -435,6 +455,7 @@ scenarios:
 
   mqtt_disconnect:
     name: MQTT Disconnect
+    display_name: "MQTT Disconnect"
     description: Detaches the MQTT transport long enough to trigger stale-data handling.
     duration: 4.0
     call:

--- a/library/domains/industrial/sensor/generic/vacuum_gauge__modbus.yaml
+++ b/library/domains/industrial/sensor/generic/vacuum_gauge__modbus.yaml
@@ -8,6 +8,14 @@ description: >
   ionizer interlocks, relay thresholds, and discharge/leak disturbances exposed
   over Modbus TCP.
 
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5021
+  modbus_unit_id:
+    type: int
+    default: 1
+
 attributes:
   # Measured pressures [mbar]
   rough_pressure:
@@ -272,8 +280,8 @@ actions:
 communication:
   - modbus_slave:
       host: 0.0.0.0
-      port: 5021
-      unit_id: 1
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
       zero_fill: true
       # poll_interval: 0.2
       mapping:
@@ -301,6 +309,7 @@ communication:
 scenarios:
   discharge_spike:
     name: Discharge Spike
+    display_name: "Discharge Spike"
     enabled: true
     description: Injects a brief discharge event that spikes both pressure channels.
     duration: 0.1
@@ -309,6 +318,7 @@ scenarios:
 
   slow_leak:
     name: Slow Leak
+    display_name: "Slow Leak"
     enabled: true
     description: Holds the leak flag active long enough to raise pressures gradually.
     duration: 15.0
@@ -319,6 +329,7 @@ scenarios:
 
   ionizer_trip:
     name: Ionizer Trip
+    display_name: "Ionizer Trip"
     enabled: true
     description: Requests the ioniser while nudging thresholds so the interlock triggers.
     duration: 5.0
@@ -328,14 +339,17 @@ scenarios:
 
   modbus_disconnect:
     name: Modbus Disconnect
+    display_name: "Modbus Disconnect"
     enabled: true
     duration: 2.0
+    description: Temporarily detaches the Modbus slave endpoint to exercise reconnect handling.
     call:
       path: communication.modbus_slave.detach
       stop_path: communication.modbus_slave.attach
 
   relay_sweep:
     name: Relay Sweep
+    display_name: "Relay Sweep"
     enabled: true
     duration: 6.0
     description: Sweeps relay setpoints to exercise output transitions.
@@ -348,6 +362,7 @@ scenarios:
 
   sensor_drift:
     name: Sensor Drift
+    display_name: "Sensor Drift"
     enabled: true
     duration: 12.0
     description: Simulates slower sensor dynamics by reducing pump gains and adding decay.

--- a/library/domains/lab/detector/prevac/prevac_mcd7__modbus.yaml
+++ b/library/domains/lab/detector/prevac/prevac_mcd7__modbus.yaml
@@ -7,6 +7,14 @@ description: >
   impulse counts are updated after each acquisition window and scaled by
   per-channel comparator thresholds.
 
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5022
+  modbus_unit_id:
+    type: int
+    default: 1
+
 attributes:
   # Acquisition state and control registers
   measure_done:
@@ -15,30 +23,75 @@ attributes:
   measure_start:
     type: int
     default: 0
-  measure_config: 0
-  dwell_time: 100               # ms
+  measure_config:
+    type: int
+    default: 0
+  dwell_time:
+    type: int
+    default: 100
+    unit: ms
 
   # Latched channel impulse counts
-  ch_1_impulse: 0
-  ch_2_impulse: 0
-  ch_3_impulse: 0
-  ch_4_impulse: 0
-  ch_5_impulse: 0
-  ch_6_impulse: 0
-  ch_7_impulse: 0
+  ch_1_impulse:
+    type: int
+    default: 0
+    unit: count
+  ch_2_impulse:
+    type: int
+    default: 0
+    unit: count
+  ch_3_impulse:
+    type: int
+    default: 0
+    unit: count
+  ch_4_impulse:
+    type: int
+    default: 0
+    unit: count
+  ch_5_impulse:
+    type: int
+    default: 0
+    unit: count
+  ch_6_impulse:
+    type: int
+    default: 0
+    unit: count
+  ch_7_impulse:
+    type: int
+    default: 0
+    unit: count
 
   # Per-channel comparator thresholds
-  ch_1_comparator: 0
-  ch_2_comparator: 0
-  ch_3_comparator: 0
-  ch_4_comparator: 0
-  ch_5_comparator: 0
-  ch_6_comparator: 0
-  ch_7_comparator: 0
+  ch_1_comparator:
+    type: int
+    default: 0
+  ch_2_comparator:
+    type: int
+    default: 0
+  ch_3_comparator:
+    type: int
+    default: 0
+  ch_4_comparator:
+    type: int
+    default: 0
+  ch_5_comparator:
+    type: int
+    default: 0
+  ch_6_comparator:
+    type: int
+    default: 0
+  ch_7_comparator:
+    type: int
+    default: 0
 
   # Internal acquisition timing state
-  _start_ms: 0
-  auto_trigger_enable: 0
+  _start_ms:
+    type: float
+    default: 0.0
+    unit: ms
+  auto_trigger_enable:
+    type: int
+    default: 0
 
 actions:
   # Channel impulses: hold during measurement, latch new value after measurement window.
@@ -204,8 +257,8 @@ polling:
 communication:
   - modbus_slave:
       host: 0.0.0.0
-      port: 5022
-      unit_id: 1
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
       zero_fill: true
       mapping:
         measure_done:          { address: [0,0],    group: h_r, type: uint_16 }
@@ -232,6 +285,7 @@ scenarios:
     display_name: "Modbus Disconnect"
     enabled: true
     duration: 2.0
+    description: Temporarily detaches the Modbus slave endpoint to exercise reconnect handling.
     call:
       path: communication.modbus_slave.detach
       stop_path: communication.modbus_slave.attach

--- a/library/domains/lab/instrument/generic/multimeter__scpi.yaml
+++ b/library/domains/lab/instrument/generic/multimeter__scpi.yaml
@@ -52,6 +52,7 @@ communication:
 scenarios:
   voltage_static:
     name: Voltage Static
+    display_name: "Voltage Static"
     enabled: true
     description: |
       Slews the measured voltage toward a target value using a bounded
@@ -67,6 +68,7 @@ scenarios:
 
   ascii_disconnect:
     name: ASCII Disconnect
+    display_name: "ASCII Disconnect"
     description: Temporarily detaches the ASCII transport to exercise reconnect handling.
     enabled: true
     duration: 2.0
@@ -76,6 +78,7 @@ scenarios:
 
   ascii_response_delay_spike:
     name: ASCII Response Delay Spike
+    display_name: "ASCII Response Delay Spike"
     description: Increases response latency to emulate an overloaded instrument.
     enabled: true
     duration: 5.0
@@ -84,6 +87,7 @@ scenarios:
 
   discharge_spike:
     name: Discharge Spike
+    display_name: "Discharge Spike"
     description: Forces a one-shot voltage spike to emulate a transient event.
     enabled: true
     run_limit: 1

--- a/library/domains/lab/monitor/generic/vital_signs_monitor__ble_gatt.yaml
+++ b/library/domains/lab/monitor/generic/vital_signs_monitor__ble_gatt.yaml
@@ -416,6 +416,7 @@ communication:
 scenarios:
   deep_sleep:
     name: Deep Sleep
+    display_name: "Deep Sleep"
     description: Drops activity intensity to resting levels for low-vitals simulation.
     enabled: true
     duration: 10.0
@@ -424,6 +425,7 @@ scenarios:
 
   focused_work:
     name: Focused Work
+    display_name: "Focused Work"
     description: Simulates sustained desk work with moderate physiological load.
     enabled: true
     duration: 10.0
@@ -432,6 +434,7 @@ scenarios:
 
   brisk_walk:
     name: Brisk Walk
+    display_name: "Brisk Walk"
     description: Raises vital signs to a light cardio level.
     enabled: true
     duration: 10.0
@@ -440,6 +443,7 @@ scenarios:
 
   interval_training:
     name: Interval Training
+    display_name: "Interval Training"
     description: Pushes the wearable toward near-peak exercise telemetry.
     enabled: true
     duration: 10.0
@@ -448,6 +452,7 @@ scenarios:
 
   acute_stress_event:
     name: Acute Stress Event
+    display_name: "Acute Stress Event"
     description: Briefly spikes vitals without reaching full workout intensity.
     enabled: true
     duration: 10.0
@@ -456,6 +461,7 @@ scenarios:
 
   cooldown_recovery:
     name: Cooldown Recovery
+    display_name: "Cooldown Recovery"
     description: Returns the wearer toward post-exercise recovery values.
     enabled: true
     duration: 10.0

--- a/tests/packs/embedded_lab_pack/unit/test_model_metadata_refresh_batch8.py
+++ b/tests/packs/embedded_lab_pack/unit/test_model_metadata_refresh_batch8.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from tests.common.repo import repo_root
+
+
+ROOT = repo_root()
+
+
+def _load_yaml(relative_path: str) -> dict:
+    path = ROOT / Path(relative_path)
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_embedded_lab_pack_scenarios_use_display_names() -> None:
+    pack_index = _load_yaml("library/industries/embedded_lab_pack/MODELS.yaml")
+    catalog = _load_yaml("library/catalog/models.yaml")
+    index = {entry["id"]: entry for entry in catalog["models"]}
+
+    missing_display_names: list[str] = []
+    for entry in pack_index["models"]:
+        model = _load_yaml(index[entry["id"]]["path"])
+        for scenario_name, scenario in (model.get("scenarios") or {}).items():
+            if isinstance(scenario, dict) and "display_name" not in scenario:
+                missing_display_names.append(f"{entry['id']}:{scenario_name}")
+
+    assert missing_display_names == []
+
+
+def test_environment_sensor_mqtt_bindings_are_named() -> None:
+    model = _load_yaml(
+        "library/domains/environment/sensor/generic/environment_sensor__mqtt.yaml"
+    )
+    communication = model["communication"]
+    mqtt = communication[0]["mqtt"]
+    bindings = mqtt["bindings"]
+
+    assert bindings
+    assert all("name" in binding for binding in bindings)
+    assert bindings[0]["name"] == "publish_temperature_c"
+    assert bindings[-1]["name"] == "subscribe_command_source"
+
+
+def test_recent_protocol_cleanup_models_use_parameterized_endpoints() -> None:
+    mcd7 = _load_yaml("library/domains/lab/detector/prevac/prevac_mcd7__modbus.yaml")
+    mcd7_meta = mcd7["meta_parameters"]
+    mcd7_modbus = mcd7["communication"][0]["modbus_slave"]
+    assert mcd7_meta["modbus_port"]["default"] == 5022
+    assert mcd7_meta["modbus_unit_id"]["default"] == 1
+    assert mcd7_modbus["port"] == "$param(modbus_port)"
+    assert mcd7_modbus["unit_id"] == "$param(modbus_unit_id)"
+
+    vacuum = _load_yaml("library/domains/industrial/sensor/generic/vacuum_gauge__modbus.yaml")
+    vacuum_meta = vacuum["meta_parameters"]
+    vacuum_modbus = vacuum["communication"][0]["modbus_slave"]
+    assert vacuum_meta["modbus_port"]["default"] == 5021
+    assert vacuum_meta["modbus_unit_id"]["default"] == 1
+    assert vacuum_modbus["port"] == "$param(modbus_port)"
+    assert vacuum_modbus["unit_id"] == "$param(modbus_unit_id)"

--- a/tests/packs/embedded_lab_pack/unit/test_prevac_mcd7_modbus_model.py
+++ b/tests/packs/embedded_lab_pack/unit/test_prevac_mcd7_modbus_model.py
@@ -31,16 +31,28 @@ def test_prevac_mcd7_modbus_model_loads() -> None:
     assert "prevac mcd7" in description
     assert "multichanneltron detector" in description
 
+    meta_parameters = doc.get("meta_parameters")
+    assert isinstance(meta_parameters, dict)
+    assert meta_parameters["modbus_port"]["default"] == 5022
+    assert meta_parameters["modbus_unit_id"]["default"] == 1
+
     attributes = doc.get("attributes")
     assert isinstance(attributes, dict)
     assert attributes["measure_done"]["default"] == 1
     assert attributes["measure_start"]["default"] == 0
-    assert attributes["dwell_time"] == 100
+    assert attributes["measure_config"]["type"] == "int"
+    assert attributes["dwell_time"]["default"] == 100
+    assert attributes["dwell_time"]["unit"] == "ms"
+    assert attributes["ch_1_impulse"]["unit"] == "count"
+    assert attributes["ch_7_impulse"]["type"] == "int"
+    assert attributes["_start_ms"]["unit"] == "ms"
 
     communication = doc.get("communication")
     assert isinstance(communication, list) and communication
     modbus = communication[0].get("modbus_slave")
     assert isinstance(modbus, dict)
+    assert modbus["port"] == "$param(modbus_port)"
+    assert modbus["unit_id"] == "$param(modbus_unit_id)"
 
     mapping = modbus.get("mapping")
     assert isinstance(mapping, dict)
@@ -51,6 +63,7 @@ def test_prevac_mcd7_modbus_model_loads() -> None:
     scenarios = doc.get("scenarios")
     assert isinstance(scenarios, dict)
     assert scenarios["modbus_disconnect"]["display_name"] == "Modbus Disconnect"
+    assert "reconnect handling" in scenarios["modbus_disconnect"]["description"].lower()
     assert scenarios["channel_3_dropout"]["display_name"] == "Channel 3 Dropout"
 
 


### PR DESCRIPTION
## Summary
- finish the non-breaking metadata cleanup pass for embedded_lab_pack models
- type and parameterize the Prevac MCD7 and vacuum gauge Modbus endpoints
- add scenario display names and named MQTT bindings where the pack still used legacy metadata

## Validation
- poetry run python tools/validate_models.py
- poetry run pytest tests/packs/embedded_lab_pack/unit