### PR TITLE
fix(industrial): standardize industrial iiot model metadata

### DIFF
--- a/library/domains/energy/power_meter/abb/abb_m1m_power_meter__modbus.yaml
+++ b/library/domains/energy/power_meter/abb/abb_m1m_power_meter__modbus.yaml
@@ -16,57 +16,169 @@ meta_parameters:
     default: 1
 
 attributes:
-  k__load_kw: 12.0
-  k__power_factor: 0.96
-  k__voltage_nominal_v: 230.0
-  k__frequency_nominal_hz: 50.0
-  power_factor_leading: 0
+  k__load_kw:
+    type: float
+    default: 12.0
+    unit: kW
+  k__power_factor:
+    type: float
+    default: 0.96
+    unit: ratio
+  k__voltage_nominal_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__frequency_nominal_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  power_factor_leading:
+    type: int
+    default: 0
 
-  voltage_drop_per_kw: 0.35
-  voltage_floor_v: 200.0
-  voltage_ceiling_v: 245.0
+  voltage_drop_per_kw:
+    type: float
+    default: 0.35
+    unit: V/kW
+  voltage_floor_v:
+    type: float
+    default: 200.0
+    unit: V
+  voltage_ceiling_v:
+    type: float
+    default: 245.0
+    unit: V
 
-  frequency_droop_per_kw: 0.02
-  frequency_floor_hz: 47.5
-  frequency_ceiling_hz: 52.0
+  frequency_droop_per_kw:
+    type: float
+    default: 0.02
+    unit: Hz/kW
+  frequency_floor_hz:
+    type: float
+    default: 47.5
+    unit: Hz
+  frequency_ceiling_hz:
+    type: float
+    default: 52.0
+    unit: Hz
 
-  voltage_system_v: 0.0
-  voltage_l1_v: 0.0
-  voltage_l2_v: 0.0
-  voltage_l3_v: 0.0
-  voltage_l1_l2_v: 0.0
-  voltage_l2_l3_v: 0.0
-  voltage_l3_l1_v: 0.0
+  voltage_system_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l1_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l2_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l1_l2_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l2_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l3_l1_v:
+    type: float
+    default: 0.0
+    unit: V
 
-  current_l1_a: 0.0
-  current_l2_a: 0.0
-  current_l3_a: 0.0
-  current_avg_a: 0.0
+  current_l1_a:
+    type: float
+    default: 0.0
+    unit: A
+  current_l2_a:
+    type: float
+    default: 0.0
+    unit: A
+  current_l3_a:
+    type: float
+    default: 0.0
+    unit: A
+  current_avg_a:
+    type: float
+    default: 0.0
+    unit: A
 
-  active_power_total_kw: 0.0
-  reactive_power_total_kvar: 0.0
-  apparent_power_total_kva: 0.0
-  frequency_hz: 0.0
-  power_factor_total: 0.0
+  active_power_total_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  reactive_power_total_kvar:
+    type: float
+    default: 0.0
+    unit: kVAR
+  apparent_power_total_kva:
+    type: float
+    default: 0.0
+    unit: kVA
+  frequency_hz:
+    type: float
+    default: 0.0
+    unit: Hz
+  power_factor_total:
+    type: float
+    default: 0.0
+    unit: ratio
 
-  voltage_system_raw: 0
-  voltage_l1_raw: 0
-  voltage_l2_raw: 0
-  voltage_l3_raw: 0
-  voltage_l1_l2_raw: 0
-  voltage_l2_l3_raw: 0
-  voltage_l3_l1_raw: 0
+  voltage_system_raw:
+    type: int
+    default: 0
+  voltage_l1_raw:
+    type: int
+    default: 0
+  voltage_l2_raw:
+    type: int
+    default: 0
+  voltage_l3_raw:
+    type: int
+    default: 0
+  voltage_l1_l2_raw:
+    type: int
+    default: 0
+  voltage_l2_l3_raw:
+    type: int
+    default: 0
+  voltage_l3_l1_raw:
+    type: int
+    default: 0
 
-  current_total_raw: 0
-  current_l1_raw: 0
-  current_l2_raw: 0
-  current_l3_raw: 0
+  current_total_raw:
+    type: int
+    default: 0
+  current_l1_raw:
+    type: int
+    default: 0
+  current_l2_raw:
+    type: int
+    default: 0
+  current_l3_raw:
+    type: int
+    default: 0
 
-  active_power_total_raw: 0
-  reactive_power_total_raw: 0
-  apparent_power_total_raw: 0
-  frequency_raw: 0
-  power_factor_total_raw: 0
+  active_power_total_raw:
+    type: int
+    default: 0
+  reactive_power_total_raw:
+    type: int
+    default: 0
+  apparent_power_total_raw:
+    type: int
+    default: 0
+  frequency_raw:
+    type: int
+    default: 0
+  power_factor_total_raw:
+    type: int
+    default: 0
 
 actions:
   - function: $in(voltage_system_v)
@@ -276,6 +388,7 @@ communication:
 
 scenarios:
   nominal_load:
+    display_name: "Nominal Load"
     description: Balanced nominal load at high power factor.
     duration: 30.0
     overrides:
@@ -283,6 +396,7 @@ scenarios:
       $in(k__power_factor): 0.98
 
   overload:
+    display_name: "Overload"
     description: Elevated load with voltage sag.
     duration: 25.0
     overrides:
@@ -291,6 +405,7 @@ scenarios:
       $in(voltage_drop_per_kw): 0.6
 
   low_power_factor:
+    display_name: "Low Power Factor"
     description: Inductive load with low power factor.
     duration: 30.0
     overrides:
@@ -299,6 +414,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   recovery:
+    display_name: "Recovery"
     description: Return to lighter load and nominal voltage.
     duration: 20.0
     overrides:

--- a/library/domains/energy/rack_pdu/apc/rack_pdu_rpdu2g__modbus.yaml
+++ b/library/domains/energy/rack_pdu/apc/rack_pdu_rpdu2g__modbus.yaml
@@ -16,56 +16,157 @@ meta_parameters:
 
 attributes:
   # Phase measurements
-  k__phase_l1_current_a: 7.8
-  k__phase_l1_voltage_v: 230.0
-  k__phase_l1_power_kw: 1.8
-  k__phase_l1_apparent_power_kva: 1.95
+  k__phase_l1_current_a:
+    type: float
+    default: 7.8
+    unit: A
+  k__phase_l1_voltage_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__phase_l1_power_kw:
+    type: float
+    default: 1.8
+    unit: kW
+  k__phase_l1_apparent_power_kva:
+    type: float
+    default: 1.95
+    unit: kVA
 
-  k__phase_l2_current_a: 7.5
-  k__phase_l2_voltage_v: 229.0
-  k__phase_l2_power_kw: 1.7
-  k__phase_l2_apparent_power_kva: 1.9
+  k__phase_l2_current_a:
+    type: float
+    default: 7.5
+    unit: A
+  k__phase_l2_voltage_v:
+    type: float
+    default: 229.0
+    unit: V
+  k__phase_l2_power_kw:
+    type: float
+    default: 1.7
+    unit: kW
+  k__phase_l2_apparent_power_kva:
+    type: float
+    default: 1.9
+    unit: kVA
 
-  k__phase_l3_current_a: 7.7
-  k__phase_l3_voltage_v: 231.0
-  k__phase_l3_power_kw: 1.75
-  k__phase_l3_apparent_power_kva: 1.93
+  k__phase_l3_current_a:
+    type: float
+    default: 7.7
+    unit: A
+  k__phase_l3_voltage_v:
+    type: float
+    default: 231.0
+    unit: V
+  k__phase_l3_power_kw:
+    type: float
+    default: 1.75
+    unit: kW
+  k__phase_l3_apparent_power_kva:
+    type: float
+    default: 1.93
+    unit: kVA
 
   # Derived device totals
-  device_real_load_power_kw: 0.0
-  device_apparent_load_power_kva: 0.0
-  device_power_factor: 0.0
-  device_energy_kwh: 0.0
-  device_state: 2
-  device_peak_power_kw: 0.0
+  device_real_load_power_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  device_apparent_load_power_kva:
+    type: float
+    default: 0.0
+    unit: kVA
+  device_power_factor:
+    type: float
+    default: 0.0
+    unit: ratio
+  device_energy_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  device_state:
+    type: int
+    default: 2
+  device_peak_power_kw:
+    type: float
+    default: 0.0
+    unit: kW
 
   # Register-scaled raw values
-  device_real_load_power_raw: 0
-  device_apparent_load_power_raw: 0
-  device_power_factor_raw: 0
-  device_energy_raw: 0
-  device_state_raw: 2
-  device_peak_power_raw: 0
+  device_real_load_power_raw:
+    type: int
+    default: 0
+  device_apparent_load_power_raw:
+    type: int
+    default: 0
+  device_power_factor_raw:
+    type: int
+    default: 0
+  device_energy_raw:
+    type: int
+    default: 0
+  device_state_raw:
+    type: int
+    default: 2
+  device_peak_power_raw:
+    type: int
+    default: 0
 
-  phase_l1_current_raw: 0
-  phase_l1_voltage_raw: 0
-  phase_l1_power_raw: 0
-  phase_l1_apparent_power_raw: 0
+  phase_l1_current_raw:
+    type: int
+    default: 0
+  phase_l1_voltage_raw:
+    type: int
+    default: 0
+  phase_l1_power_raw:
+    type: int
+    default: 0
+  phase_l1_apparent_power_raw:
+    type: int
+    default: 0
 
-  phase_l2_current_raw: 0
-  phase_l2_voltage_raw: 0
-  phase_l2_power_raw: 0
-  phase_l2_apparent_power_raw: 0
+  phase_l2_current_raw:
+    type: int
+    default: 0
+  phase_l2_voltage_raw:
+    type: int
+    default: 0
+  phase_l2_power_raw:
+    type: int
+    default: 0
+  phase_l2_apparent_power_raw:
+    type: int
+    default: 0
 
-  phase_l3_current_raw: 0
-  phase_l3_voltage_raw: 0
-  phase_l3_power_raw: 0
-  phase_l3_apparent_power_raw: 0
+  phase_l3_current_raw:
+    type: int
+    default: 0
+  phase_l3_voltage_raw:
+    type: int
+    default: 0
+  phase_l3_power_raw:
+    type: int
+    default: 0
+  phase_l3_apparent_power_raw:
+    type: int
+    default: 0
 
-  low_load_threshold_kw: 2.0
-  near_overload_threshold_kw: 7.0
-  overload_threshold_kw: 8.5
-  _cycle_time_s: 1.0
+  low_load_threshold_kw:
+    type: float
+    default: 2.0
+    unit: kW
+  near_overload_threshold_kw:
+    type: float
+    default: 7.0
+    unit: kW
+  overload_threshold_kw:
+    type: float
+    default: 8.5
+    unit: kW
+  _cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 
 actions:
   - function: $in(device_real_load_power_kw)
@@ -213,6 +314,7 @@ communication:
 
 scenarios:
   balanced_load:
+    display_name: "Balanced Load"
     description: Balanced three-phase load at nominal voltage.
     duration: 30.0
     overrides:
@@ -227,6 +329,7 @@ scenarios:
       $in(k__phase_l3_apparent_power_kva): 1.85
 
   overload_event:
+    display_name: "Overload Event"
     description: High power draw that crosses overload threshold.
     duration: 20.0
     overrides:
@@ -241,6 +344,7 @@ scenarios:
       $in(k__phase_l3_apparent_power_kva): 3.1
 
   low_load:
+    display_name: "Low Load"
     description: Light load with power reduction on all phases.
     duration: 20.0
     overrides:

--- a/library/domains/environment/station/generic/air_quality_station__http.yaml
+++ b/library/domains/environment/station/generic/air_quality_station__http.yaml
@@ -18,93 +18,148 @@ meta_parameters:
     default: 8092
 
 attributes:
-  k__station_id: "PL-WAW-001"
-  k__station_name: "Warsaw Srodmiescie Monitor"
-  k__latitude: 52.2297
-  k__longitude: 21.0122
-  k__timezone: Europe/Warsaw
-  generation_time_ms: 11.2
-  measurement_interval_minutes: 60
-  monitoring_window_hours: 24
-  k__active_profile: urban-baseline
+  k__station_id:
+    type: str
+    default: "PL-WAW-001"
+  k__station_name:
+    type: str
+    default: "Warsaw Srodmiescie Monitor"
+  k__latitude:
+    type: float
+    default: 52.2297
+    unit: deg
+  k__longitude:
+    type: float
+    default: 21.0122
+    unit: deg
+  k__timezone:
+    type: str
+    default: "Europe/Warsaw"
+  generation_time_ms:
+    type: float
+    default: 11.2
+    unit: ms
+  measurement_interval_minutes:
+    type: int
+    default: 60
+    unit: min
+  monitoring_window_hours:
+    type: int
+    default: 24
+    unit: h
+  k__active_profile:
+    type: str
+    default: "urban-baseline"
 
   hourly_time:
-    - "2025-01-01T00:00"
-    - "2025-01-01T03:00"
-    - "2025-01-01T06:00"
-    - "2025-01-01T09:00"
-    - "2025-01-01T12:00"
-    - "2025-01-01T15:00"
-    - "2025-01-01T18:00"
-    - "2025-01-01T21:00"
-
+    type: list
+    default:
+      - "2025-01-01T00:00"
+      - "2025-01-01T03:00"
+      - "2025-01-01T06:00"
+      - "2025-01-01T09:00"
+      - "2025-01-01T12:00"
+      - "2025-01-01T15:00"
+      - "2025-01-01T18:00"
+      - "2025-01-01T21:00"
   hourly_pm2_5:
-    - 12.8
-    - 15.4
-    - 18.3
-    - 22.7
-    - 26.4
-    - 24.2
-    - 19.6
-    - 15.8
-
+    type: list
+    default:
+      - 12.8
+      - 15.4
+      - 18.3
+      - 22.7
+      - 26.4
+      - 24.2
+      - 19.6
+      - 15.8
+    unit: ug/m3
   hourly_pm10:
-    - 20.1
-    - 24.5
-    - 28.8
-    - 34.2
-    - 39.5
-    - 36.1
-    - 30.4
-    - 24.9
-
+    type: list
+    default:
+      - 20.1
+      - 24.5
+      - 28.8
+      - 34.2
+      - 39.5
+      - 36.1
+      - 30.4
+      - 24.9
+    unit: ug/m3
   hourly_no2:
-    - 18.5
-    - 20.1
-    - 22.4
-    - 25.7
-    - 28.3
-    - 26.5
-    - 23.6
-    - 21.0
-
+    type: list
+    default:
+      - 18.5
+      - 20.1
+      - 22.4
+      - 25.7
+      - 28.3
+      - 26.5
+      - 23.6
+      - 21.0
+    unit: ug/m3
   hourly_o3:
-    - 61.0
-    - 59.2
-    - 57.4
-    - 54.8
-    - 52.6
-    - 53.9
-    - 56.8
-    - 59.7
-
+    type: list
+    default:
+      - 61.0
+      - 59.2
+      - 57.4
+      - 54.8
+      - 52.6
+      - 53.9
+      - 56.8
+      - 59.7
+    unit: ug/m3
   hourly_aqi:
-    - 42
-    - 49
-    - 56
-    - 67
-    - 74
-    - 70
-    - 59
-    - 50
-
+    type: list
+    default:
+      - 42
+      - 49
+      - 56
+      - 67
+      - 74
+      - 70
+      - 59
+      - 50
+    unit: index
   hourly_aqi_category:
-    - good
-    - good
-    - moderate
-    - moderate
-    - moderate
-    - moderate
-    - moderate
-    - good
+    type: list
+    default:
+      - "good"
+      - "good"
+      - "moderate"
+      - "moderate"
+      - "moderate"
+      - "moderate"
+      - "moderate"
+      - "good"
 
-  k__current_timestamp: "2025-01-01T12:00"
-  k__current_pm2_5: 26.4
-  k__current_pm10: 39.5
-  k__current_no2: 28.3
-  k__current_o3: 52.6
-  k__current_aqi: 74
-  k__current_aqi_category: moderate
+  k__current_timestamp:
+    type: str
+    default: "2025-01-01T12:00"
+  k__current_pm2_5:
+    type: float
+    default: 26.4
+    unit: ug/m3
+  k__current_pm10:
+    type: float
+    default: 39.5
+    unit: ug/m3
+  k__current_no2:
+    type: float
+    default: 28.3
+    unit: ug/m3
+  k__current_o3:
+    type: float
+    default: 52.6
+    unit: ug/m3
+  k__current_aqi:
+    type: int
+    default: 74
+    unit: index
+  k__current_aqi_category:
+    type: str
+    default: "moderate"
 
 communication:
   - http_endpoint:
@@ -197,6 +252,8 @@ communication:
 
 scenarios:
   winter_smog_episode:
+    display_name: "Winter Smog Episode"
+    description: Apply elevated particulate and NO2 readings for a severe urban pollution episode.
     duration: 45.0
     overrides:
       $in(k__active_profile): "urban-smog"
@@ -215,6 +272,8 @@ scenarios:
       $in(hourly_aqi_category): [moderate, moderate, unhealthy, unhealthy, unhealthy, unhealthy, unhealthy, moderate]
 
   coastal_reset:
+    display_name: "Coastal Reset"
+    description: Reset the station to a cleaner coastal-style air profile.
     duration: 30.0
     overrides:
       $in(k__active_profile): "coastal-clean"
@@ -227,6 +286,8 @@ scenarios:
       $in(k__current_aqi_category): good
 
   station_relocation:
+    display_name: "Station Relocation"
+    description: Move the simulated station to a different monitored city and profile.
     duration: 60.0
     overrides:
       $in(k__station_id): "PL-LOD-004"

--- a/library/domains/industrial/controller/eurotherm/eurotherm_3216__modbus.yaml
+++ b/library/domains/industrial/controller/eurotherm/eurotherm_3216__modbus.yaml
@@ -25,50 +25,134 @@ meta_parameters:
 
 attributes:
   # Key control inputs written by external clients or scenarios.
-  k__setpoint_c: 30.0
-  k__manual_out_pct: 0.0
-  k__auto_man: 0
+  k__setpoint_c:
+    type: float
+    default: 30.0
+    unit: degC
+  k__manual_out_pct:
+    type: float
+    default: 0.0
+    unit: percent
+  k__auto_man:
+    type: int
+    default: 0
 
   # Observable process state.
-  temperature_c: 25.0
-  working_setpoint_c: 30.0
-  output_pct: 0.0
+  temperature_c:
+    type: float
+    default: 25.0
+    unit: degC
+  working_setpoint_c:
+    type: float
+    default: 30.0
+    unit: degC
+  output_pct:
+    type: float
+    default: 0.0
+    unit: percent
 
   # Environment, tuning, and limits.
-  ambient_c: 22.0
-  heat_coeff: 0.25
-  cool_coeff: 0.03
-  power_gain: 1.5
-  power_integral_gain: 0.2
-  power_integral_leak: 0.05
-  power_derivative_gain: 0.8
+  ambient_c:
+    type: float
+    default: 22.0
+    unit: degC
+  heat_coeff:
+    type: float
+    default: 0.25
+  cool_coeff:
+    type: float
+    default: 0.03
+  power_gain:
+    type: float
+    default: 1.5
+  power_integral_gain:
+    type: float
+    default: 0.2
+  power_integral_leak:
+    type: float
+    default: 0.05
+  power_derivative_gain:
+    type: float
+    default: 0.8
 
-  temp_min_c: 0.0
-  temp_max_c: 200.0
-  sp_min_c: 0.0
-  sp_max_c: 200.0
-  out_min: 0.0
-  out_max: 100.0
+  temp_min_c:
+    type: float
+    default: 0.0
+    unit: degC
+  temp_max_c:
+    type: float
+    default: 200.0
+    unit: degC
+  sp_min_c:
+    type: float
+    default: 0.0
+    unit: degC
+  sp_max_c:
+    type: float
+    default: 200.0
+    unit: degC
+  out_min:
+    type: float
+    default: 0.0
+    unit: percent
+  out_max:
+    type: float
+    default: 100.0
+    unit: percent
 
   # Hidden controller state.
-  _power_integral: 0.0
-  _power_derivative: 0.0
-  _power_error_prev: 0.0
-  _scale_0p1: 10.0
+  _power_integral:
+    type: float
+    default: 0.0
+  _power_derivative:
+    type: float
+    default: 0.0
+  _power_error_prev:
+    type: float
+    default: 0.0
+  _scale_0p1:
+    type: float
+    default: 10.0
 
   # Hidden Modbus transport payloads.
-  _pv_raw: 250
-  _target_sp_raw: 300
-  _manual_out_raw: 0
-  _working_out_raw: 0
-  _working_sp_raw: 300
-  _auto_man_raw: 0
-  _target_sp_raw_prev: 300
-  _manual_out_raw_prev: 0
-  _auto_man_raw_prev: 0
-  _setpoint_c_prev: 30.0
-  _manual_out_pct_prev: 0.0
-  _auto_man_prev: 0
+  _pv_raw:
+    type: int
+    default: 250
+  _target_sp_raw:
+    type: int
+    default: 300
+  _manual_out_raw:
+    type: int
+    default: 0
+  _working_out_raw:
+    type: int
+    default: 0
+  _working_sp_raw:
+    type: int
+    default: 300
+  _auto_man_raw:
+    type: int
+    default: 0
+  _target_sp_raw_prev:
+    type: int
+    default: 300
+  _manual_out_raw_prev:
+    type: int
+    default: 0
+  _auto_man_raw_prev:
+    type: int
+    default: 0
+  _setpoint_c_prev:
+    type: float
+    default: 30.0
+    unit: degC
+  _manual_out_pct_prev:
+    type: float
+    default: 0.0
+    unit: percent
+  _auto_man_prev:
+    type: int
+    default: 0
 
 actions:
   - function: $in(k__auto_man)

--- a/library/domains/industrial/controller/eurotherm/eurotherm_3504__modbus.yaml
+++ b/library/domains/industrial/controller/eurotherm/eurotherm_3504__modbus.yaml
@@ -17,43 +17,130 @@ description: |
     - 273 Loop.1.Main.AutoMan (0=Auto, 1=Manual)
     - 556 Loop.1.OP.ManualMode (0=track, 1=step, 2=lastMOP)
 
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5027
+  modbus_unit_id:
+    type: int
+    default: 1
+
 attributes:
-  pressure_bar: 1.0
-  pressure_sp_bar: 1.5
-  pressure_sp_working_bar: 1.5
-  control_out_pct: 0.0
-  manual_out_pct: 0.0
-  ch1_out_pct: 0.0
-  auto_man: 0
-  manual_mode: 0
+  pressure_bar:
+    type: float
+    default: 1.0
+    unit: bar
+  pressure_sp_bar:
+    type: float
+    default: 1.5
+    unit: bar
+  pressure_sp_working_bar:
+    type: float
+    default: 1.5
+    unit: bar
+  control_out_pct:
+    type: float
+    default: 0.0
+    unit: percent
+  manual_out_pct:
+    type: float
+    default: 0.0
+    unit: percent
+  ch1_out_pct:
+    type: float
+    default: 0.0
+    unit: percent
+  auto_man:
+    type: int
+    default: 0
+  manual_mode:
+    type: int
+    default: 0
 
-  ambient_pressure_bar: 1.0
-  pressurize_coeff: 0.25
-  leak_coeff: 0.03
-  power_gain: 1.5
-  power_integral: 0.0
-  power_integral_gain: 0.2
-  power_integral_leak: 0.05
-  power_derivative: 0.0
-  power_derivative_gain: 0.8
-  power_error_prev: 0.0
+  ambient_pressure_bar:
+    type: float
+    default: 1.0
+    unit: bar
+  pressurize_coeff:
+    type: float
+    default: 0.25
+  leak_coeff:
+    type: float
+    default: 0.03
+  power_gain:
+    type: float
+    default: 1.5
+  power_integral:
+    type: float
+    default: 0.0
+  power_integral_gain:
+    type: float
+    default: 0.2
+  power_integral_leak:
+    type: float
+    default: 0.05
+  power_derivative:
+    type: float
+    default: 0.0
+  power_derivative_gain:
+    type: float
+    default: 0.8
+  power_error_prev:
+    type: float
+    default: 0.0
 
-  pressure_min_bar: 0.0
-  pressure_max_bar: 10.0
-  sp_min_bar: 0.0
-  sp_max_bar: 10.0
-  out_min: 0.0
-  out_max: 100.0
-  scale_0p1: 10.0
+  pressure_min_bar:
+    type: float
+    default: 0.0
+    unit: bar
+  pressure_max_bar:
+    type: float
+    default: 10.0
+    unit: bar
+  sp_min_bar:
+    type: float
+    default: 0.0
+    unit: bar
+  sp_max_bar:
+    type: float
+    default: 10.0
+    unit: bar
+  out_min:
+    type: float
+    default: 0.0
+    unit: percent
+  out_max:
+    type: float
+    default: 100.0
+    unit: percent
+  scale_0p1:
+    type: float
+    default: 10.0
 
-  pv_raw: 250
-  target_sp_raw: 300
-  working_sp_raw: 300
-  active_out_raw: 0
-  manual_out_raw: 0
-  ch1_out_raw: 0
-  auto_man_raw: 0
-  manual_mode_raw: 0
+  pv_raw:
+    type: int
+    default: 250
+  target_sp_raw:
+    type: int
+    default: 300
+  working_sp_raw:
+    type: int
+    default: 300
+  active_out_raw:
+    type: int
+    default: 0
+  manual_out_raw:
+    type: int
+    default: 0
+  ch1_out_raw:
+    type: int
+    default: 0
+  auto_man_raw:
+    type: int
+    default: 0
+  manual_mode_raw:
+    type: int
+    default: 0
 
 actions:
   - function: $in(auto_man)
@@ -184,8 +271,8 @@ actions:
 communication:
   - modbus_slave:
       host: 0.0.0.0
-      port: 5027
-      unit_id: 1
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
       zero_fill: true
       mapping:
         pv_raw:          { address: [1,1],   group: h_r, type: uint_16 }
@@ -200,6 +287,8 @@ communication:
 scenarios:
   auto_pressurize:
     enabled: true
+    display_name: "Auto Pressurize"
+    description: Run the loop in auto mode and step the pressure setpoint upward.
     duration: 20.0
     overrides:
       $in(auto_man_raw): 0
@@ -208,6 +297,8 @@ scenarios:
 
   auto_depressurize:
     enabled: true
+    display_name: "Auto Depressurize"
+    description: Run the loop in auto mode and lower the target pressure.
     duration: 18.0
     overrides:
       $in(auto_man_raw): 0
@@ -215,6 +306,8 @@ scenarios:
 
   manual_hold_40:
     enabled: true
+    display_name: "Manual Hold 40%"
+    description: Switch to manual mode and hold a fixed 40 percent output command.
     duration: 15.0
     overrides:
       $in(auto_man_raw): 1

--- a/library/domains/industrial/controller/generic/pid_process_controller__modbus.yaml
+++ b/library/domains/industrial/controller/generic/pid_process_controller__modbus.yaml
@@ -3,33 +3,74 @@
 name: pid_process_controller__modbus
 description: |
   Generic PID process controller for a single-loop process variable exposed
-  via Modbus. Represents typical industrial temperature/pressure/level loops.
+  via Modbus. Represents typical industrial temperature, pressure, or level loops.
 
 attributes:
-  pv: 0.0           # process variable
-  sp: 1.0           # setpoint
-  cv: 0.0           # controller output 0..100
+  pv:
+    type: float
+    default: 0.0
+  sp:
+    type: float
+    default: 1.0
+  cv:
+    type: float
+    default: 0.0
+    unit: percent
 
-  k_p: 2.0
-  k_i: 0.5
-  k_d: 0.0
+  k_p:
+    type: float
+    default: 2.0
+  k_i:
+    type: float
+    default: 0.5
+  k_d:
+    type: float
+    default: 0.0
 
-  i_term: 0.0
-  d_term: 0.0
-  error_prev: 0.0
+  i_term:
+    type: float
+    default: 0.0
+  d_term:
+    type: float
+    default: 0.0
+  error_prev:
+    type: float
+    default: 0.0
 
-  output_min: 0.0
-  output_max: 100.0
+  output_min:
+    type: float
+    default: 0.0
+    unit: percent
+  output_max:
+    type: float
+    default: 100.0
+    unit: percent
 
-  mode_auto: 1      # 1=auto, 0=manual
-  manual_cv: 0.0
+  mode_auto:
+    type: int
+    default: 1
+  manual_cv:
+    type: float
+    default: 0.0
+    unit: percent
 
-  alarm_high: 0
-  alarm_low: 0
-  alarm_high_limit: 1.2
-  alarm_low_limit: -0.2
+  alarm_high:
+    type: int
+    default: 0
+  alarm_low:
+    type: int
+    default: 0
+  alarm_high_limit:
+    type: float
+    default: 1.2
+  alarm_low_limit:
+    type: float
+    default: -0.2
 
-  cycle_time_s: 0.5
+  cycle_time_s:
+    type: float
+    default: 0.5
+    unit: s
 
 actions:
   - function: $in(i_term)
@@ -94,6 +135,8 @@ communication:
 scenarios:
   setpoint_step_up:
     enabled: true
+    display_name: "Setpoint Step Up"
+    description: Apply a positive setpoint step while staying in auto mode.
     duration: 12.0
     overrides:
       $in(sp): 3.0
@@ -101,6 +144,8 @@ scenarios:
 
   load_disturbance:
     enabled: true
+    display_name: "Load Disturbance"
+    description: Push the process variable away from the setpoint to test disturbance rejection.
     duration: 10.0
     overrides:
       $in(pv): 1.6
@@ -109,6 +154,8 @@ scenarios:
 
   manual_bump_test:
     enabled: true
+    display_name: "Manual Bump Test"
+    description: Switch to manual mode and hold a fixed controller output.
     duration: 8.0
     overrides:
       $in(mode_auto): 0

--- a/library/domains/industrial/controller/generic/stepper_controller__modbus.yaml
+++ b/library/domains/industrial/controller/generic/stepper_controller__modbus.yaml
@@ -2,39 +2,106 @@
 # Copyright (c) 2025 Hammerheads Engineers Sp. z o.o.
 # See the accompanying LICENSE file for terms.
 
-# Stepper motor controller with homing, soft limits, and torque monitoring
+name: stepper_controller__modbus
+description: |
+  Stepper motor controller with homing, soft limits, and torque monitoring,
+  exposed through a compact Modbus register map for axis-control demos.
+
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5020
+  modbus_unit_id:
+    type: int
+    default: 1
+
 attributes:
-  drive_enable: 1              # 1 = drive enabled
-  homing_request: 0            # 1 = start homing routine
-  homed: 0                     # 1 = reference complete
-  position_command: 120.0      # target position [mm]
-  position_feedback: 5.0       # actual position [mm]
-  velocity_command: 0.0        # internal velocity request [mm/s]
-  velocity_feedback: 0.0       # actual velocity estimate [mm/s]
-  torque_load: 40.0            # % of rated torque
-  torque_limit: 85.0           # % threshold for alarm
-  soft_limit_pos: 500.0        # mm
-  soft_limit_neg: -10.0        # mm
-  max_speed: 10.0             # mm/s limit for motion
-  max_accel: 0.25              # mm/s^2 limit for acceleration
-  max_decel: 0.5              # mm/s^2 limit for deceleration
-  motion_error: 0.0            # helper for control loop
-  velocity_goal: 0.0           # helper for control loop
-  pos_limit_switch: 0          # digital input (0/1)
-  neg_limit_switch: 0          # digital input (0/1)
-  alarm_limit: 0               # 0/1 soft or hard limit alarm
-  alarm_torque: 0              # torque overload alarm
-  alarm_drive_fault: 0         # general drive fault
-  step_mode: 16                # microstepping ratio (for display)
+  drive_enable:
+    type: int
+    default: 1
+  homing_request:
+    type: int
+    default: 0
+  homed:
+    type: int
+    default: 0
+  position_command:
+    type: float
+    default: 120.0
+    unit: mm
+  position_feedback:
+    type: float
+    default: 5.0
+    unit: mm
+  velocity_command:
+    type: float
+    default: 0.0
+    unit: mm/s
+  velocity_feedback:
+    type: float
+    default: 0.0
+    unit: mm/s
+  torque_load:
+    type: float
+    default: 40.0
+    unit: percent
+  torque_limit:
+    type: float
+    default: 85.0
+    unit: percent
+  soft_limit_pos:
+    type: float
+    default: 500.0
+    unit: mm
+  soft_limit_neg:
+    type: float
+    default: -10.0
+    unit: mm
+  max_speed:
+    type: float
+    default: 10.0
+    unit: mm/s
+  max_accel:
+    type: float
+    default: 0.25
+    unit: mm/s^2
+  max_decel:
+    type: float
+    default: 0.5
+    unit: mm/s^2
+  motion_error:
+    type: float
+    default: 0.0
+    unit: mm
+  velocity_goal:
+    type: float
+    default: 0.0
+    unit: mm/s
+  pos_limit_switch:
+    type: int
+    default: 0
+  neg_limit_switch:
+    type: int
+    default: 0
+  alarm_limit:
+    type: int
+    default: 0
+  alarm_torque:
+    type: int
+    default: 0
+  alarm_drive_fault:
+    type: int
+    default: 0
+  step_mode:
+    type: int
+    default: 16
 
 actions:
-  # Update tracking error.
   - function: $in(motion_error)
     name: update_motion_error_pre
     description: Compute the initial position tracking error before applying velocity corrections.
     call: $in(position_command) - $in(position_feedback)
 
-  # Compute velocity goal that respects braking distance.
   - function: $in(velocity_goal)
     name: compute_velocity_goal
     description: Derive the velocity setpoint given current error and braking distance limits.
@@ -52,7 +119,6 @@ actions:
             )
         )
 
-  # Ramp actual velocity toward the goal with independent accel/decel limits.
   - function: $in(velocity_command)
     name: slew_velocity_command
     description: Slew the internal velocity command toward the goal under accel/decel constraints.
@@ -68,7 +134,6 @@ actions:
             )
         )
 
-  # Integrate position with clamping to avoid overshoot.
   - function: $in(position_feedback)
     name: integrate_position_feedback
     description: Integrate velocity into position while honouring soft limits and settle ratio.
@@ -84,7 +149,6 @@ actions:
             )
         )
 
-  # Zero velocity when clamped by soft limits.
   - function: $in(velocity_command)
     name: clamp_velocity_on_limits
     description: Force velocity to zero once position feedback is clamped by soft limits.
@@ -94,13 +158,11 @@ actions:
              or ($in(position_feedback) >= $in(soft_limit_pos) and $in(velocity_command) > 0)
           else $in(velocity_command)
 
-  # Recalculate error after motion step.
   - function: $in(motion_error)
     name: update_motion_error_post
     description: Refresh the motion error after velocity and position updates.
     call: $in(position_command) - $in(position_feedback)
 
-  # Zero velocity when settled.
   - function: $in(velocity_command)
     name: freeze_velocity_when_settled
     description: Drop residual velocity once both error and commanded speed fall below thresholds.
@@ -174,8 +236,8 @@ polling:
 communication:
   - modbus_slave:
       host: 0.0.0.0
-      port: 5020
-      unit_id: 1
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
       zero_fill: true
       mapping:
         drive_enable:       { address: [0,0],   group: c_o, type: uint_16 }
@@ -202,6 +264,8 @@ communication:
 scenarios:
   homing_cycle:
     enabled: true
+    display_name: "Homing Cycle"
+    description: Run a nominal homing move back to the reference position.
     duration: 15.0
     overrides:
       $in(drive_enable): 1
@@ -213,6 +277,8 @@ scenarios:
 
   limit_overtravel:
     enabled: true
+    display_name: "Limit Overtravel"
+    description: Command travel past the positive soft limit to exercise limit alarms.
     duration: 12.0
     overrides:
       $in(drive_enable): 1
@@ -223,6 +289,8 @@ scenarios:
 
   torque_overload_test:
     enabled: true
+    display_name: "Torque Overload Test"
+    description: Lower the torque threshold while commanding a fast move.
     duration: 10.0
     overrides:
       $in(drive_enable): 1

--- a/library/domains/industrial/controller/generic/thermal_controller__modbus.yaml
+++ b/library/domains/industrial/controller/generic/thermal_controller__modbus.yaml
@@ -2,54 +2,92 @@
 # Copyright (c) 2025 Hammerheads Engineers Sp. z o.o.
 # See the accompanying LICENSE file for terms.
 
-# Thermal controller with safety features (overload protection)
-attributes:
-  # core
-  temperature: 25.0     # current process temperature [°C]
-  setpoint: 30.0        # target temperature [°C]
-  heating_power: 0.0    # actuator power 0..100 [%]
-  power_on: 1           # 1 = powered, 0 = off
-  ambient: 22.0         # ambient/environment temperature [°C]
-  heat_coeff: 0.25      # heat transfer coefficient scaling actuator power
-  cool_coeff: 0.03      # cooling coefficient driving decay to ambient
-  power_gain: 1.5       # proportional gain driving heating response to error
-  power_integral: 0.0   # integrator state compensating steady-state error
-  power_integral_gain: 0.2  # integration gain for biasing heating power
-  power_integral_leak: 0.05  # fractional decay applied when error is negative
-  power_derivative: 0.0     # derivative term damping overshoot
-  power_derivative_gain: 0.8  # derivative gain reacting to error slope
-  power_error_prev: 0.0      # stored previous control error for derivative term
+name: thermal_controller__modbus
+description: |
+  Thermal controller with safety features and a simple Modbus register map for
+  temperature-loop demos. The model exposes temperature, setpoint, power, and
+  overload-related state without changing the legacy public attribute names.
 
-  # safety
-  overload: 0           # 0/1 flag
-  overload_threshold: 70.0  # °C - demo value
-  overload_hyst: 2.0        # °C - hysteresis to avoid flicker
+attributes:
+  temperature:
+    type: float
+    default: 25.0
+    unit: degC
+  setpoint:
+    type: float
+    default: 30.0
+    unit: degC
+  heating_power:
+    type: float
+    default: 0.0
+    unit: percent
+  power_on:
+    type: int
+    default: 1
+  ambient:
+    type: float
+    default: 22.0
+    unit: degC
+  heat_coeff:
+    type: float
+    default: 0.25
+  cool_coeff:
+    type: float
+    default: 0.03
+  power_gain:
+    type: float
+    default: 1.5
+  power_integral:
+    type: float
+    default: 0.0
+  power_integral_gain:
+    type: float
+    default: 0.2
+  power_integral_leak:
+    type: float
+    default: 0.05
+  power_derivative:
+    type: float
+    default: 0.0
+  power_derivative_gain:
+    type: float
+    default: 0.8
+  power_error_prev:
+    type: float
+    default: 0.0
+
+  overload:
+    type: int
+    default: 0
+  overload_threshold:
+    type: float
+    default: 70.0
+    unit: degC
+  overload_hyst:
+    type: float
+    default: 2.0
+    unit: degC
 
 conditions:
-  # 1) Overload ON when temperature >= threshold
   - if: $in(temperature) >= $in(overload_threshold)
     actions:
       - set: $in(overload)
         value: 1
 
-  # 2) Overload OFF when temperature <= threshold - hysteresis
   - if: $in(temperature) <= ($in(overload_threshold) - $in(overload_hyst))
     actions:
       - set: $in(overload)
         value: 0
 
 actions:
-  # (1) Derivative contribution based on error slope; reset when controller disabled.
   - function: $in(power_derivative)
     call: 0.0 if ($in(power_on) == 0 or $in(overload) == 1)
           else $in(power_derivative_gain) * (($in(setpoint) - $in(temperature)) - $in(power_error_prev))
 
-  # (2) Track current error for next cycle; reset when controller disabled.
   - function: $in(power_error_prev)
     call: 0.0 if ($in(power_on) == 0 or $in(overload) == 1)
           else ($in(setpoint) - $in(temperature))
 
-  # (3) Integrator term that biases heating power to cancel ambient losses.
   - function: $in(power_integral)
     call: 0.0 if ($in(power_on) == 0 or $in(overload) == 1)
           else (
@@ -61,7 +99,6 @@ actions:
             )
           )
 
-  # (4) Slower PID blend (lower gain → gentler approach to setpoint) gated by power_on and overload state
   - function: $in(heating_power)
     call: 0.0 if ($in(power_on) == 0 or $in(overload) == 1)
           else max(
@@ -74,9 +111,6 @@ actions:
             ),
           )
 
-  # (5) Physics with guaranteed cooldown:
-  # step_factor keeps dynamics slow; cool_coeff ensures drift to ambient when power=0.
-  # temp_next = temp + step * (heat_coeff * power - cool_coeff * (temp - ambient))
   - function: $in(temperature)
     call: $in(temperature) + 0.2 * ($in(heat_coeff) * $in(heating_power) - $in(cool_coeff) * ($in(temperature) - $in(ambient)))
 
@@ -85,9 +119,9 @@ communication:
       poll_interval: 0.25
       mapping:
         temperature:        { address: [0,1], group: h_r, type: float }
-        setpoint:           { address: [2,3],  group: h_r, type: float }
+        setpoint:           { address: [2,3], group: h_r, type: float }
         heating_power:      { address: [4,5], group: h_r, type: float }
-        power_on:           { address: [6,6], group: c_o,  type: uint_16 }
+        power_on:           { address: [6,6], group: c_o, type: uint_16 }
         ambient:            { address: [7,8], group: h_r, type: float }
         overload:           { address: [9,9], group: h_r, type: uint_16 }
         overload_threshold: { address: [10,11], group: h_r, type: float }
@@ -103,6 +137,8 @@ communication:
 scenarios:
   heatup_nominal:
     enabled: true
+    display_name: "Heatup Nominal"
+    description: Run a nominal heat-up profile with a higher setpoint and gain.
     duration: 40.0
     overrides:
       $in(power_on): 1
@@ -112,6 +148,8 @@ scenarios:
 
   overload_trip_test:
     enabled: true
+    display_name: "Overload Trip Test"
+    description: Force the controller toward an overload trip condition.
     duration: 20.0
     overrides:
       $in(power_on): 1
@@ -121,6 +159,8 @@ scenarios:
 
   powered_cooldown:
     enabled: true
+    display_name: "Powered Cooldown"
+    description: Turn power off and let the thermal mass cool toward ambient.
     duration: 25.0
     overrides:
       $in(power_on): 0

--- a/library/domains/industrial/controller/generic/thermal_controller_advanced.yaml
+++ b/library/domains/industrial/controller/generic/thermal_controller_advanced.yaml
@@ -1,69 +1,113 @@
 # SPDX-License-Identifier: MIT
-# Advanced thermal controller without protocol bindings.
-# Uses FunctionAction imports/params to reduce duplication and improve physics fidelity.
+
+name: thermal_controller_advanced
+description: |
+  Advanced thermal controller twin without protocol bindings. Uses reusable
+  action params and helper imports to model actuator lag, thermal inertia, and
+  overload behavior for richer process-control demos.
+
 attributes:
-  # core state
-  temperature: 25.0
-  setpoint: 30.0
-  ambient: 22.0
-  power_on: 1
+  temperature:
+    type: float
+    default: 25.0
+    unit: degC
+  setpoint:
+    type: float
+    default: 30.0
+    unit: degC
+  ambient:
+    type: float
+    default: 22.0
+    unit: degC
+  power_on:
+    type: int
+    default: 1
 
-  # actuator
-  heating_power_target: 0.0  # controller output [%]
-  heating_power: 0.0         # actuator output after lag [%]
-  actuator_tau: 0.75         # actuator inertia time constant [s]
+  heating_power_target:
+    type: float
+    default: 0.0
+    unit: percent
+  heating_power:
+    type: float
+    default: 0.0
+    unit: percent
+  actuator_tau:
+    type: float
+    default: 0.75
+    unit: s
 
-  # dynamics / environment
-  heat_coeff: 0.25
-  cool_coeff: 0.03
-  thermal_mass: 1.2
+  heat_coeff:
+    type: float
+    default: 0.25
+  cool_coeff:
+    type: float
+    default: 0.03
+  thermal_mass:
+    type: float
+    default: 1.2
 
-  # PID terms
-  power_gain: 1.7
-  power_integral: 0.0
-  power_integral_gain: 0.25
-  power_integral_leak: 0.05
-  power_derivative: 0.0
-  power_derivative_gain: 0.8
-  power_error_prev: 0.0
-  controller_enabled: true  # cached enable flag (power_on && !overload)
+  power_gain:
+    type: float
+    default: 1.7
+  power_integral:
+    type: float
+    default: 0.0
+  power_integral_gain:
+    type: float
+    default: 0.25
+  power_integral_leak:
+    type: float
+    default: 0.05
+  power_derivative:
+    type: float
+    default: 0.0
+  power_derivative_gain:
+    type: float
+    default: 0.8
+  power_error_prev:
+    type: float
+    default: 0.0
+  controller_enabled:
+    type: int
+    default: 1
 
-  # safety
-  overload: 0
-  overload_threshold: 100.0
-  overload_hyst: 2.0
+  overload:
+    type: int
+    default: 0
+  overload_threshold:
+    type: float
+    default: 100.0
+    unit: degC
+  overload_hyst:
+    type: float
+    default: 2.0
+    unit: degC
 
 conditions:
-  # 1) Overload ON when temperature >= threshold
   - if: $in(temperature) >= $in(overload_threshold)
     actions:
       - set: $in(overload)
         value: 1
 
-  # 2) Overload OFF when temperature <= threshold - hysteresis
   - if: $in(temperature) <= ($in(overload_threshold) - $in(overload_hyst))
     actions:
       - set: $in(overload)
         value: 0
 
-
 actions:
   - function: $in(controller_enabled)
     call: ($in(power_on) == 1) and ($in(overload) == 0)
 
-  # Derivative term with explicit enable/error params (no repeated expressions)
   - function: $in(power_derivative)
     params:
       error: "$in(setpoint) - $in(temperature)"
     call: 0.0 if not $in(controller_enabled) else $in(power_derivative_gain) * (error - $in(power_error_prev))
 
-  # Error memory for derivative
   - function: $in(power_error_prev)
     params:
       error: "$in(setpoint) - $in(temperature)"
     call: 0.0 if not $in(controller_enabled) else error
 
-  # Integrator with leak and clipping
   - function: $in(power_integral)
     imports: {np: numpy}
     params:
@@ -76,7 +120,6 @@ actions:
         else $in(power_integral) + $in(power_integral_gain) * error,
         integral_min, integral_max)
 
-  # PID blend for target power
   - function: $in(heating_power_target)
     imports: {np: numpy}
     params:
@@ -90,7 +133,6 @@ actions:
         + $in(power_derivative),
         power_min, power_max)
 
-  # Actuator lag (first-order) toward target power
   - function: $in(heating_power)
     imports: {first_order: "extensions.thermal_model.first_order_step"}
     params:
@@ -103,7 +145,6 @@ actions:
         $in(actuator_tau),
       )
 
-  # Thermal physics using closed-form solution for linear system
   - function: $in(temperature)
     imports: {thermal_step: "extensions.thermal_model.thermal_step"}
     params:
@@ -121,6 +162,8 @@ actions:
 
 scenarios:
   fast_heatup:
+    display_name: "Fast Heatup"
+    description: Increase setpoint and controller gain for a faster warm-up cycle.
     duration: 40.0
     overrides:
       $in(power_on): 1
@@ -129,6 +172,8 @@ scenarios:
       $in(power_gain): 1.9
 
   overload_trip_test:
+    display_name: "Overload Trip Test"
+    description: Drive the model into an overload trip with a high requested setpoint.
     duration: 20.0
     overrides:
       $in(power_on): 1
@@ -137,6 +182,8 @@ scenarios:
       $in(overload_hyst): 3.0
 
   powered_cooldown:
+    display_name: "Powered Cooldown"
+    description: Switch power off and let the process cool back toward ambient.
     duration: 25.0
     overrides:
       $in(power_on): 0
@@ -146,6 +193,8 @@ scenarios:
       $in(power_derivative_gain): 0.0
 
   ramped_heatup:
+    display_name: "Ramped Heatup"
+    description: Ramp the thermal setpoint upward over time while keeping power enabled.
     duration: 40.0
     actions:
       - function: $in(setpoint)
@@ -162,10 +211,11 @@ scenarios:
         call: ambient_target
 
   ambient_perturbation:
+    display_name: "Ambient Perturbation"
+    description: Alternate ambient temperature to exercise compensation behavior.
     duration: 30.0
     period: 5.0
     actions:
-      # Alternate ambient ±3°C every 5s to test controller compensation
       - function: $in(ambient)
         params:
           ambient_base: 22.0
@@ -175,6 +225,8 @@ scenarios:
           ambient_base + (ambient_amp if (int($attr(timer.time) / toggle_period) % 2 == 0) else -ambient_amp)
 
   noisy_temperature_output:
+    display_name: "Noisy Temperature Output"
+    description: Add proportional noise to the observed temperature output.
     actions:
       - noise: $out(temperature)
         name: Rough Gauge Noise
@@ -183,6 +235,8 @@ scenarios:
         mode: proportional
 
   ramped_cooldown:
+    display_name: "Ramped Cooldown"
+    description: Ramp the setpoint downward over time while holding power on.
     duration: 40.0
     actions:
       - function: $in(setpoint)
@@ -199,6 +253,8 @@ scenarios:
         call: ambient_target
 
   temperature_sensor_spike:
+    display_name: "Temperature Sensor Spike"
+    description: Inject a short measurement spike into the temperature output.
     duration: 35.0
     actions:
       - function: $out(temperature)
@@ -212,6 +268,8 @@ scenarios:
           )($attr(timer.time), $out(temperature))
 
   heat_treat_sequence_if:
+    display_name: "Heat Treat Sequence (If)"
+    description: Run a ramp-soak-cool heat-treatment profile using explicit scenario conditions.
     duration: 80.0
     conditions:
       - if: $attr(timer.time) < 20.0
@@ -238,6 +296,8 @@ scenarios:
             call: heat_target - (heat_target - cool_target) * min(1.0, max(0.0, ($attr(timer.time) - 40.0)) / cool_dur)
 
   heat_treat_sequence_profile:
+    display_name: "Heat Treat Sequence (Profile)"
+    description: Run a compact ramp-soak-cool heat-treatment profile from one expression.
     duration: 80.0
     actions:
       - function: $in(setpoint)
@@ -257,6 +317,8 @@ scenarios:
           )($attr(timer.time))
 
   power_cycle_recovery:
+    display_name: "Power Cycle Recovery"
+    description: Drop power briefly and verify the controller recovers after restart.
     duration: 60.0
     actions:
       - function: $in(setpoint)

--- a/library/domains/industrial/counter/generic/line_counter__mqtt.yaml
+++ b/library/domains/industrial/counter/generic/line_counter__mqtt.yaml
@@ -5,19 +5,66 @@ description: |
   Virtual production line counter publishing piece counts and line speed over MQTT.
   The model is suitable for testing OEE-style dashboards and simple MES consumers.
 
-attributes:
-  count_total: 0            # total pieces produced
-  count_good: 0             # good pieces
-  count_bad: 0              # rejected pieces
-  line_speed_mpm: 0.0       # current line speed [m/min]
-  target_speed_mpm: 30.0    # target line speed [m/min]
-  pulse_per_meter: 10.0     # encoder pulses per meter of material
-  scrap_rate_percent: 2.0   # nominal scrap rate [%]
-  running: 1                # 1 = running, 0 = stopped
-  jam_alarm: 0              # 1 = jam detected
-  state_text: "STOPPED"     # textual state for dashboards
+meta_parameters:
+  mqtt_broker_host:
+    type: str
+    default: "host.docker.internal"
+  mqtt_broker_port:
+    type: int
+    default: 1883
+  mqtt_topic_prefix:
+    type: str
+    default: "spx/examples/line_counter"
+  mqtt_publish_interval:
+    type: float
+    default: 1.0
+  mqtt_default_qos:
+    type: int
+    default: 1
 
-  cycle_time_s: 1.0         # integration step [s]
+attributes:
+  count_total:
+    type: float
+    default: 0.0
+    unit: count
+  count_good:
+    type: float
+    default: 0.0
+    unit: count
+  count_bad:
+    type: float
+    default: 0.0
+    unit: count
+  line_speed_mpm:
+    type: float
+    default: 0.0
+    unit: m/min
+  target_speed_mpm:
+    type: float
+    default: 30.0
+    unit: m/min
+  pulse_per_meter:
+    type: float
+    default: 10.0
+    unit: pulse/m
+  scrap_rate_percent:
+    type: float
+    default: 2.0
+    unit: percent
+  running:
+    type: int
+    default: 1
+  jam_alarm:
+    type: int
+    default: 0
+  state_text:
+    type: str
+    default: "STOPPED"
+
+  cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 
 actions:
   - function: $in(line_speed_mpm)
@@ -77,41 +124,50 @@ actions:
 
 communication:
   - mqtt:
-      broker: "host.docker.internal"
-      port: 1883
-      publish_interval: 1.0
-      topic_prefix: "spx/examples/line_counter"
-      default_qos: 1
+      broker: "$param(mqtt_broker_host)"
+      port: "$param(mqtt_broker_port)"
+      publish_interval: "$param(mqtt_publish_interval)"
+      topic_prefix: "$param(mqtt_topic_prefix)"
+      default_qos: "$param(mqtt_default_qos)"
       default_retain: false
       bindings:
-        - attribute: $ext(count_total)
+        - name: publish_count_total
+          attribute: $ext(count_total)
           topic: telemetry/count_total
           direction: publish
-        - attribute: $ext(count_good)
+        - name: publish_count_good
+          attribute: $ext(count_good)
           topic: telemetry/count_good
           direction: publish
-        - attribute: $ext(count_bad)
+        - name: publish_count_bad
+          attribute: $ext(count_bad)
           topic: telemetry/count_bad
           direction: publish
-        - attribute: $ext(line_speed_mpm)
+        - name: publish_line_speed_mpm
+          attribute: $ext(line_speed_mpm)
           topic: telemetry/line_speed_mpm
           direction: publish
-        - attribute: $ext(jam_alarm)
+        - name: publish_jam_alarm
+          attribute: $ext(jam_alarm)
           topic: telemetry/alarms/jam
           direction: publish
-        - attribute: $ext(state_text)
+        - name: publish_state_text
+          attribute: $ext(state_text)
           topic: telemetry/state
           direction: publish
-        - attribute: $attr(target_speed_mpm)
+        - name: subscribe_target_speed_mpm
+          attribute: $attr(target_speed_mpm)
           topic: command/target_speed_mpm
           direction: subscribe
-        - attribute: $attr(running)
+        - name: subscribe_running
+          attribute: $attr(running)
           topic: command/running
           direction: subscribe
 
 scenarios:
   start_line:
     enabled: true
+    display_name: "Start Line"
     description: |
       Bring the line from stopped state to the nominal target speed and let the
       counter integrate pieces for a short window.
@@ -122,6 +178,7 @@ scenarios:
 
   line_jam:
     enabled: true
+    display_name: "Line Jam"
     description: |
       Simulate a temporary jam: the line remains commanded to run but the
       effective speed drops near zero, raising the jam_alarm for dashboards.

--- a/library/domains/industrial/drive/generic/vfd_drive__modbus.yaml
+++ b/library/domains/industrial/drive/generic/vfd_drive__modbus.yaml
@@ -7,20 +7,49 @@ description: |
   simple PLC integrations.
 
 attributes:
-  enable: 1                 # 1 = enabled
-  speed_set_rpm: 1500.0     # commanded speed [rpm]
-  speed_actual_rpm: 0.0     # feedback speed [rpm]
-  torque_percent: 0.0       # load torque [%]
-  torque_limit_percent: 120.0
+  enable:
+    type: int
+    default: 1
+  speed_set_rpm:
+    type: float
+    default: 1500.0
+    unit: rpm
+  speed_actual_rpm:
+    type: float
+    default: 0.0
+    unit: rpm
+  torque_percent:
+    type: float
+    default: 0.0
+    unit: percent
+  torque_limit_percent:
+    type: float
+    default: 120.0
+    unit: percent
 
-  accel_ramp_s: 2.0         # accel time from 0..100% [s]
-  decel_ramp_s: 3.0         # decel time [s]
+  accel_ramp_s:
+    type: float
+    default: 2.0
+    unit: s
+  decel_ramp_s:
+    type: float
+    default: 3.0
+    unit: s
 
-  alarm_overload: 0         # torque overload alarm
-  alarm_drive_fault: 0      # generic drive fault
-  status_word: 0            # encoded state bits
+  alarm_overload:
+    type: int
+    default: 0
+  alarm_drive_fault:
+    type: int
+    default: 0
+  status_word:
+    type: int
+    default: 0
 
-  cycle_time_s: 0.1         # integration step
+  cycle_time_s:
+    type: float
+    default: 0.1
+    unit: s
 
 actions:
   - function: $in(speed_actual_rpm)
@@ -86,6 +115,8 @@ communication:
 scenarios:
   speed_step_profile:
     enabled: true
+    display_name: "Speed Step Profile"
+    description: Apply a higher speed command with quicker ramps for commissioning checks.
     duration: 25.0
     overrides:
       $in(enable): 1
@@ -95,6 +126,8 @@ scenarios:
 
   torque_overload:
     enabled: true
+    display_name: "Torque Overload"
+    description: Increase speed while reducing torque headroom to trigger overload handling.
     duration: 15.0
     overrides:
       $in(enable): 1
@@ -103,6 +136,8 @@ scenarios:
 
   emergency_stop_fault:
     enabled: true
+    display_name: "Emergency Stop Fault"
+    description: Force a rapid deceleration that mimics an emergency-stop event.
     duration: 10.0
     overrides:
       $in(enable): 1

--- a/library/domains/industrial/drive/schneider/schneider_altivar_320__modbus.yaml
+++ b/library/domains/industrial/drive/schneider/schneider_altivar_320__modbus.yaml
@@ -10,23 +10,67 @@ description: |
     - 12761 CMD control word (output word 1)
     - 12762 LFRD speed reference (output word 2)
 
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5030
+  modbus_unit_id:
+    type: int
+    default: 1
+
 attributes:
-  cmd__control_word_raw: 0
-  k__speed_setpoint_raw: 0
-  status_word_raw: 0
-  speed_actual_raw: 0
+  cmd__control_word_raw:
+    type: int
+    default: 0
+  k__speed_setpoint_raw:
+    type: int
+    default: 0
+  status_word_raw:
+    type: int
+    default: 0
+  speed_actual_raw:
+    type: int
+    default: 0
 
-  speed_setpoint_hz: 0.0
-  speed_actual_hz: 0.0
-  run_enable: 0
-  fault_active: 0
+  speed_setpoint_hz:
+    type: float
+    default: 0.0
+    unit: Hz
+  speed_actual_hz:
+    type: float
+    default: 0.0
+    unit: Hz
+  run_enable:
+    type: int
+    default: 0
+  fault_active:
+    type: int
+    default: 0
 
-  speed_scale_hz_per_unit: 1.0
-  speed_max_hz: 60.0
-  speed_dev_hz: 0.5
-  accel_ramp_s: 2.5
-  decel_ramp_s: 3.5
-  cycle_time_s: 0.1
+  speed_scale_hz_per_unit:
+    type: float
+    default: 1.0
+    unit: Hz/unit
+  speed_max_hz:
+    type: float
+    default: 60.0
+    unit: Hz
+  speed_dev_hz:
+    type: float
+    default: 0.5
+    unit: Hz
+  accel_ramp_s:
+    type: float
+    default: 2.5
+    unit: s
+  decel_ramp_s:
+    type: float
+    default: 3.5
+    unit: s
+  cycle_time_s:
+    type: float
+    default: 0.1
+    unit: s
 
 actions:
   - function: $in(speed_setpoint_hz)
@@ -86,8 +130,8 @@ actions:
 communication:
   - modbus_slave:
       host: 0.0.0.0
-      port: 5030
-      unit_id: 1
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
       zero_fill: true
       mapping:
         cmd__control_word_raw: { address: [12761,12761], group: h_r, type: uint_16 }

--- a/library/domains/industrial/drive/siemens/g120c__modbus.yaml
+++ b/library/domains/industrial/drive/siemens/g120c__modbus.yaml
@@ -11,23 +11,66 @@ description: |
     - 40102  ZSW1 status word (basic bits)
     - 40103  Actual speed (Hz)
 
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5028
+  modbus_unit_id:
+    type: int
+    default: 1
+
 attributes:
-  control_word_raw: 0
-  speed_setpoint_raw: 0
-  status_word_raw: 0
-  speed_actual_raw: 0
+  control_word_raw:
+    type: int
+    default: 0
+  speed_setpoint_raw:
+    type: int
+    default: 0
+  status_word_raw:
+    type: int
+    default: 0
+  speed_actual_raw:
+    type: int
+    default: 0
 
-  speed_setpoint_hz: 0.0
-  speed_actual_hz: 0.0
-  run_enable: 0
-  direction: 1
-  fault_active: 0
+  speed_setpoint_hz:
+    type: float
+    default: 0.0
+    unit: Hz
+  speed_actual_hz:
+    type: float
+    default: 0.0
+    unit: Hz
+  run_enable:
+    type: int
+    default: 0
+  direction:
+    type: int
+    default: 1
+  fault_active:
+    type: int
+    default: 0
 
-  speed_max_hz: 60.0
-  speed_dev_hz: 0.5
-  accel_ramp_s: 2.0
-  decel_ramp_s: 3.0
-  cycle_time_s: 0.1
+  speed_max_hz:
+    type: float
+    default: 60.0
+    unit: Hz
+  speed_dev_hz:
+    type: float
+    default: 0.5
+    unit: Hz
+  accel_ramp_s:
+    type: float
+    default: 2.0
+    unit: s
+  decel_ramp_s:
+    type: float
+    default: 3.0
+    unit: s
+  cycle_time_s:
+    type: float
+    default: 0.1
+    unit: s
 
 actions:
   - function: $in(speed_setpoint_hz)
@@ -100,8 +143,8 @@ actions:
 communication:
   - modbus_slave:
       host: 0.0.0.0
-      port: 5028
-      unit_id: 1
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
       zero_fill: true
       mapping:
         control_word_raw:     { address: [40100,40100], group: h_r, type: uint_16 }

--- a/library/domains/industrial/io_module/generic/io_module__modbus.yaml
+++ b/library/domains/industrial/io_module/generic/io_module__modbus.yaml
@@ -2,23 +2,47 @@
 
 name: io_module__modbus
 description: |
-  Simple remote I/O module exposing digital inputs/outputs and analog inputs
-  over Modbus. Useful for testing PLC mappings and edge gateways.
+  Simple remote I/O module exposing digital inputs, digital outputs, and analog
+  inputs over Modbus. Useful for testing PLC mappings and edge gateways.
 
 attributes:
-  di_1: 0
-  di_2: 0
-  di_3: 0
-  di_4: 0
-  do_1: 0
-  do_2: 0
-  do_3: 0
-  do_4: 0
+  di_1:
+    type: int
+    default: 0
+  di_2:
+    type: int
+    default: 0
+  di_3:
+    type: int
+    default: 0
+  di_4:
+    type: int
+    default: 0
+  do_1:
+    type: int
+    default: 0
+  do_2:
+    type: int
+    default: 0
+  do_3:
+    type: int
+    default: 0
+  do_4:
+    type: int
+    default: 0
 
-  ai_1: 0.0   # e.g., 4-20 mA scaled engineering value
-  ai_2: 0.0
-  ai_3: 0.0
-  ai_4: 0.0
+  ai_1:
+    type: float
+    default: 0.0
+  ai_2:
+    type: float
+    default: 0.0
+  ai_3:
+    type: float
+    default: 0.0
+  ai_4:
+    type: float
+    default: 0.0
 
 communication:
   - modbus_tcp:
@@ -40,6 +64,8 @@ communication:
 scenarios:
   all_clear:
     enabled: true
+    display_name: "All Clear"
+    description: Hold all digital channels low with low analog signal levels.
     duration: 15.0
     overrides:
       $in(di_1): 0
@@ -57,6 +83,8 @@ scenarios:
 
   alarm_trip:
     enabled: true
+    display_name: "Alarm Trip"
+    description: Assert alarm-style digital states and high analog inputs.
     duration: 8.0
     overrides:
       $in(di_1): 1
@@ -74,6 +102,8 @@ scenarios:
 
   analog_ramp_high:
     enabled: true
+    display_name: "Analog Ramp High"
+    description: Drive multiple analog inputs into a higher operating range.
     duration: 20.0
     overrides:
       $in(di_1): 0
@@ -91,6 +121,8 @@ scenarios:
 
   maintenance_loopback:
     enabled: true
+    display_name: "Maintenance Loopback"
+    description: Mirror alternating digital states for loopback and maintenance checks.
     duration: 25.0
     overrides:
       $in(di_1): 1

--- a/library/domains/industrial/io_module/wago/wago_750_8000__modbus.yaml
+++ b/library/domains/industrial/io_module/wago/wago_750_8000__modbus.yaml
@@ -2,30 +2,61 @@
 
 name: wago_750_8000__modbus
 description: |
-  WAGO 750-8000 I/O system (sim) exposing a minimal Modbus TCP slave process image
-  for digital inputs/outputs and analog inputs. Use it to validate PLC I/O
-  mappings and edge gateways.
+  WAGO 750-8000 I/O system simulation exposing a minimal Modbus TCP slave
+  process image for digital inputs, digital outputs, and analog inputs.
+
+meta_parameters:
+  modbus_port:
+    type: int
+    default: 5024
+  modbus_unit_id:
+    type: int
+    default: 1
 
 attributes:
-  di_1: 0
-  di_2: 0
-  di_3: 0
-  di_4: 0
-  do_1: 0
-  do_2: 0
-  do_3: 0
-  do_4: 0
+  di_1:
+    type: int
+    default: 0
+  di_2:
+    type: int
+    default: 0
+  di_3:
+    type: int
+    default: 0
+  di_4:
+    type: int
+    default: 0
+  do_1:
+    type: int
+    default: 0
+  do_2:
+    type: int
+    default: 0
+  do_3:
+    type: int
+    default: 0
+  do_4:
+    type: int
+    default: 0
 
-  ai_1: 0.0   # e.g., 4-20 mA scaled engineering value
-  ai_2: 0.0
-  ai_3: 0.0
-  ai_4: 0.0
+  ai_1:
+    type: float
+    default: 0.0
+  ai_2:
+    type: float
+    default: 0.0
+  ai_3:
+    type: float
+    default: 0.0
+  ai_4:
+    type: float
+    default: 0.0
 
 communication:
   - modbus_slave:
       host: 0.0.0.0
-      port: 5024
-      unit_id: 1
+      port: "$param(modbus_port)"
+      unit_id: "$param(modbus_unit_id)"
       zero_fill: true
       mapping:
         di_1: { address: [0,0], group: h_r, type: uint_16 }
@@ -44,6 +75,8 @@ communication:
 scenarios:
   all_clear:
     enabled: true
+    display_name: "All Clear"
+    description: Hold all digital channels low with low analog signal levels.
     duration: 15.0
     overrides:
       $in(di_1): 0
@@ -61,6 +94,8 @@ scenarios:
 
   alarm_trip:
     enabled: true
+    display_name: "Alarm Trip"
+    description: Assert alarm-style digital states and high analog inputs.
     duration: 8.0
     overrides:
       $in(di_1): 1
@@ -78,6 +113,8 @@ scenarios:
 
   analog_ramp_high:
     enabled: true
+    display_name: "Analog Ramp High"
+    description: Drive multiple analog inputs into a higher operating range.
     duration: 20.0
     overrides:
       $in(di_1): 0
@@ -95,6 +132,8 @@ scenarios:
 
   maintenance_loopback:
     enabled: true
+    display_name: "Maintenance Loopback"
+    description: Mirror alternating digital states for loopback and maintenance checks.
     duration: 25.0
     overrides:
       $in(di_1): 1

--- a/library/domains/industrial/line/generic/packaging_line__opcua.yaml
+++ b/library/domains/industrial/line/generic/packaging_line__opcua.yaml
@@ -2,33 +2,83 @@
 
 name: packaging_line__opcua
 description: |
-  OPC UA model of a packaging line with infeed queue, wrapper and palletizer diagnostics.
-  Provides bidirectional commands for speed/targets and exposes typical jam / low-film alarms.
+  OPC UA model of a packaging line with infeed queue, wrapper, and palletizer
+  diagnostics. Provides bidirectional commands for speed and targets while
+  exposing typical jam and low-film alarms.
 
 attributes:
-  line_state: stopped            # stopped, running, fault
-  line_mode: automatic           # automatic/manual
-  shift_order_id: "PKG-1001"
-  pallet_destination: "Dock-A"
+  line_state:
+    type: str
+    default: "stopped"
+  line_mode:
+    type: str
+    default: "automatic"
+  shift_order_id:
+    type: str
+    default: "PKG-1001"
+  pallet_destination:
+    type: str
+    default: "Dock-A"
 
-  line_speed_mpm: 0.0
-  target_speed_mpm: 35.0
-  cases_per_min: 0.0
-  throughput_today: 0
-  reject_today: 0
-  infeed_queue_count: 12
-  pallet_count_ready: 1
+  line_speed_mpm:
+    type: float
+    default: 0.0
+    unit: m/min
+  target_speed_mpm:
+    type: float
+    default: 35.0
+    unit: m/min
+  cases_per_min:
+    type: float
+    default: 0.0
+    unit: count/min
+  throughput_today:
+    type: float
+    default: 0.0
+    unit: count
+  reject_today:
+    type: float
+    default: 0.0
+    unit: count
+  infeed_queue_count:
+    type: float
+    default: 12.0
+    unit: count
+  pallet_count_ready:
+    type: int
+    default: 1
+    unit: count
 
-  wrapper_temperature_c: 135.0
-  wrapper_target_temp_c: 140.0
-  film_roll_percent: 85.0
-  diverter_mode: main             # main / rework
+  wrapper_temperature_c:
+    type: float
+    default: 135.0
+    unit: degC
+  wrapper_target_temp_c:
+    type: float
+    default: 140.0
+    unit: degC
+  film_roll_percent:
+    type: float
+    default: 85.0
+    unit: percent
+  diverter_mode:
+    type: str
+    default: "main"
 
-  alarm_jam: 0
-  alarm_low_film: 0
-  alarm_overtemp: 0
+  alarm_jam:
+    type: int
+    default: 0
+  alarm_low_film:
+    type: int
+    default: 0
+  alarm_overtemp:
+    type: int
+    default: 0
 
-  cycle_time_s: 1.0
+  cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 
 actions:
   - function: $in(line_state)
@@ -73,7 +123,7 @@ actions:
 
   - function: $in(reject_today)
     name: integrate_rejects
-    description: Assume 2% reject rate when running.
+    description: Assume 2 percent reject rate when running.
     call: (
           $in(reject_today)
           + (0.02 * $in(cases_per_min) * cycle_time_s / 60.0 if $in(line_state) == "running" else 0.0)
@@ -257,6 +307,8 @@ communication:
 scenarios:
   steady_run:
     enabled: true
+    display_name: "Steady Run"
+    description: Run the line automatically at a stable target speed and wrapper temperature.
     duration: 40.0
     overrides:
       $in(line_mode): automatic
@@ -265,6 +317,8 @@ scenarios:
 
   film_break:
     enabled: true
+    display_name: "Film Break"
+    description: Simulate low film and a jammed packaging event.
     duration: 15.0
     overrides:
       $in(film_roll_percent): 5.0
@@ -273,6 +327,8 @@ scenarios:
 
   changeover_pause:
     enabled: true
+    display_name: "Changeover Pause"
+    description: Pause production during a manual changeover and divert to rework.
     duration: 25.0
     overrides:
       $in(line_mode): manual

--- a/library/domains/industrial/monitor/generic/condition_monitor__mqtt.yaml
+++ b/library/domains/industrial/monitor/generic/condition_monitor__mqtt.yaml
@@ -5,20 +5,68 @@ description: |
   Simplified condition monitoring node for rotating equipment. Publishes vibration
   RMS values and winding temperature over MQTT with a derived health index.
 
+meta_parameters:
+  mqtt_broker_host:
+    type: str
+    default: "host.docker.internal"
+  mqtt_broker_port:
+    type: int
+    default: 1883
+  mqtt_topic_prefix:
+    type: str
+    default: "spx/examples/condition_monitor"
+  mqtt_publish_interval:
+    type: float
+    default: 1.0
+  mqtt_default_qos:
+    type: int
+    default: 1
+
 attributes:
-  vib_rms_x: 2.0           # [mm/s]
-  vib_rms_y: 1.5           # [mm/s]
-  vib_rms_z: 1.8           # [mm/s]
-  vib_limit_warning: 4.5   # [mm/s]
-  vib_limit_alarm: 7.0     # [mm/s]
+  vib_rms_x:
+    type: float
+    default: 2.0
+    unit: mm/s
+  vib_rms_y:
+    type: float
+    default: 1.5
+    unit: mm/s
+  vib_rms_z:
+    type: float
+    default: 1.8
+    unit: mm/s
+  vib_limit_warning:
+    type: float
+    default: 4.5
+    unit: mm/s
+  vib_limit_alarm:
+    type: float
+    default: 7.0
+    unit: mm/s
 
-  temp_stator_c: 65.0      # [°C]
-  temp_limit_warning_c: 90.0
-  temp_limit_alarm_c: 110.0
+  temp_stator_c:
+    type: float
+    default: 65.0
+    unit: degC
+  temp_limit_warning_c:
+    type: float
+    default: 90.0
+    unit: degC
+  temp_limit_alarm_c:
+    type: float
+    default: 110.0
+    unit: degC
 
-  health_index: 100.0      # 0..100 (100 = perfect)
-  alarm_vibration: 0       # 1 = vibration alarm
-  alarm_temperature: 0     # 1 = over-temperature alarm
+  health_index:
+    type: float
+    default: 100.0
+    unit: score
+  alarm_vibration:
+    type: int
+    default: 0
+  alarm_temperature:
+    type: int
+    default: 0
 
 actions:
   - function: $in(health_index)
@@ -46,38 +94,47 @@ actions:
 
 communication:
   - mqtt:
-      broker: "host.docker.internal"
-      port: 1883
-      publish_interval: 1.0
-      topic_prefix: "spx/examples/condition_monitor"
-      default_qos: 1
+      broker: "$param(mqtt_broker_host)"
+      port: "$param(mqtt_broker_port)"
+      publish_interval: "$param(mqtt_publish_interval)"
+      topic_prefix: "$param(mqtt_topic_prefix)"
+      default_qos: "$param(mqtt_default_qos)"
       default_retain: false
       bindings:
-        - attribute: $ext(vib_rms_x)
+        - name: publish_vib_rms_x
+          attribute: $ext(vib_rms_x)
           topic: telemetry/vib_rms_x
           direction: publish
-        - attribute: $ext(vib_rms_y)
+        - name: publish_vib_rms_y
+          attribute: $ext(vib_rms_y)
           topic: telemetry/vib_rms_y
           direction: publish
-        - attribute: $ext(vib_rms_z)
+        - name: publish_vib_rms_z
+          attribute: $ext(vib_rms_z)
           topic: telemetry/vib_rms_z
           direction: publish
-        - attribute: $ext(temp_stator_c)
+        - name: publish_temp_stator_c
+          attribute: $ext(temp_stator_c)
           topic: telemetry/temp_stator_c
           direction: publish
-        - attribute: $ext(health_index)
+        - name: publish_health_index
+          attribute: $ext(health_index)
           topic: telemetry/health_index
           direction: publish
-        - attribute: $ext(alarm_vibration)
+        - name: publish_alarm_vibration
+          attribute: $ext(alarm_vibration)
           topic: telemetry/alarms/vibration
           direction: publish
-        - attribute: $ext(alarm_temperature)
+        - name: publish_alarm_temperature
+          attribute: $ext(alarm_temperature)
           topic: telemetry/alarms/temperature
           direction: publish
 
 scenarios:
   bearing_fault_spike:
     enabled: true
+    display_name: "Bearing Fault Spike"
+    description: Raise vibration on all axes to emulate a bearing failure signature.
     duration: 12.0
     overrides:
       $in(vib_rms_x): 8.0
@@ -86,6 +143,8 @@ scenarios:
 
   thermal_warning:
     enabled: true
+    display_name: "Thermal Warning"
+    description: Raise stator temperature into the warning range with moderate vibration.
     duration: 15.0
     overrides:
       $in(temp_stator_c): 105.0
@@ -95,6 +154,8 @@ scenarios:
 
   sensor_dropout:
     enabled: true
+    display_name: "Sensor Dropout"
+    description: Collapse measured vibration and temperature to emulate a sensor outage.
     duration: 6.0
     overrides:
       $in(vib_rms_x): 0.2

--- a/library/domains/industrial/pressure_transmitter/generic/pressure_transmitter__modbus.yaml
+++ b/library/domains/industrial/pressure_transmitter/generic/pressure_transmitter__modbus.yaml
@@ -6,16 +6,40 @@ description: |
   for testing analog input scaling and alarm handling.
 
 attributes:
-  pressure_bar: 1.0          # process pressure [bar]
-  pressure_min_bar: 0.0      # lower clamp of the transmitter span
-  pressure_max_bar: 10.0     # upper clamp of the transmitter span
-  pressure_target_bar: 1.0   # helper driven by scenarios to create ramps
-  pressure_slew_rate_bar: 0.35  # max bar change per simulation tick
+  pressure_bar:
+    type: float
+    default: 1.0
+    unit: bar
+  pressure_min_bar:
+    type: float
+    default: 0.0
+    unit: bar
+  pressure_max_bar:
+    type: float
+    default: 10.0
+    unit: bar
+  pressure_target_bar:
+    type: float
+    default: 1.0
+    unit: bar
+  pressure_slew_rate_bar:
+    type: float
+    default: 0.35
 
-  alarm_high: 0
-  alarm_low: 0
-  alarm_high_limit: 8.0
-  alarm_low_limit: 0.5
+  alarm_high:
+    type: int
+    default: 0
+  alarm_low:
+    type: int
+    default: 0
+  alarm_high_limit:
+    type: float
+    default: 8.0
+    unit: bar
+  alarm_low_limit:
+    type: float
+    default: 0.5
+    unit: bar
 
 actions:
   - function: $in(pressure_bar)
@@ -61,6 +85,8 @@ communication:
 scenarios:
   pressure_ramp_up:
     enabled: true
+    display_name: "Pressure Ramp Up"
+    description: Ramp the transmitter pressure toward the high alarm region.
     duration: 12.0
     overrides:
       $in(pressure_target_bar): 8.5
@@ -68,6 +94,8 @@ scenarios:
 
   pressure_ramp_down:
     enabled: true
+    display_name: "Pressure Ramp Down"
+    description: Drop the transmitter pressure toward the low alarm region.
     duration: 10.0
     overrides:
       $in(pressure_target_bar): 0.4
@@ -75,6 +103,8 @@ scenarios:
 
   pressure_spike:
     enabled: true
+    display_name: "Pressure Spike"
+    description: Inject a short high-pressure spike to exercise limit handling.
     duration: 2.0
     overrides:
       $in(pressure_target_bar): 9.8
@@ -82,6 +112,8 @@ scenarios:
 
   pressure_dropout:
     enabled: true
+    display_name: "Pressure Dropout"
+    description: Force a brief low-pressure dropout below the configured span.
     duration: 2.5
     overrides:
       $in(pressure_target_bar): 0.1

--- a/library/domains/industrial/process_cell/generic/process_cell__opcua.yaml
+++ b/library/domains/industrial/process_cell/generic/process_cell__opcua.yaml
@@ -2,35 +2,86 @@
 
 name: process_cell__opcua
 description: |
-  OPC UA process cell exporting typical temperature/flow/pressure tags via OPC UA sections.
-  The built-in dynamics and alarms let OPC UA clients exercise read/write flows,
-  username security tokens, and diagnostics trees without needing external hardware.
+  OPC UA process cell exporting typical temperature, flow, and pressure tags.
+  The built-in dynamics and alarms let OPC UA clients exercise read/write
+  flows, username security tokens, and diagnostics trees without external hardware.
 
 attributes:
-  temperature_c: 28.0
-  temperature_setpoint_c: 32.0
-  operator_setpoint_c: 32.0
-  ambient_c: 24.0
-  temperature_gain: 0.18
-  heat_loss_gain: 0.04
+  temperature_c:
+    type: float
+    default: 28.0
+    unit: degC
+  temperature_setpoint_c:
+    type: float
+    default: 32.0
+    unit: degC
+  operator_setpoint_c:
+    type: float
+    default: 32.0
+    unit: degC
+  ambient_c:
+    type: float
+    default: 24.0
+    unit: degC
+  temperature_gain:
+    type: float
+    default: 0.18
+  heat_loss_gain:
+    type: float
+    default: 0.04
 
-  pump_speed_percent: 45.0
-  pump_command_percent: 45.0
-  valve_position_percent: 35.0
+  pump_speed_percent:
+    type: float
+    default: 45.0
+    unit: percent
+  pump_command_percent:
+    type: float
+    default: 45.0
+    unit: percent
+  valve_position_percent:
+    type: float
+    default: 35.0
+    unit: percent
 
-  flow_target_lpm: 48.0
-  flow_rate_lpm: 45.0
+  flow_target_lpm:
+    type: float
+    default: 48.0
+    unit: L/min
+  flow_rate_lpm:
+    type: float
+    default: 45.0
+    unit: L/min
 
-  pressure_bar: 1.2
-  pressure_target_bar: 1.5
-  pressure_override_bar: 0.0
+  pressure_bar:
+    type: float
+    default: 1.2
+    unit: bar
+  pressure_target_bar:
+    type: float
+    default: 1.5
+    unit: bar
+  pressure_override_bar:
+    type: float
+    default: 0.0
+    unit: bar
 
-  alarm_overtemp: 0
-  alarm_pressure: 0
-  alarm_low_flow: 0
-  status_text: "IDLE"
+  alarm_overtemp:
+    type: int
+    default: 0
+  alarm_pressure:
+    type: int
+    default: 0
+  alarm_low_flow:
+    type: int
+    default: 0
+  status_text:
+    type: str
+    default: "IDLE"
 
-  cycle_time_s: 0.5
+  cycle_time_s:
+    type: float
+    default: 0.5
+    unit: s
 
 actions:
   - function: $in(temperature_setpoint_c)
@@ -241,6 +292,8 @@ communication:
 scenarios:
   heatup_cycle:
     enabled: true
+    display_name: "Heatup Cycle"
+    description: Raise temperature demand and pump command for an active process run.
     duration: 20.0
     overrides:
       $in(operator_setpoint_c): 70.0
@@ -248,6 +301,8 @@ scenarios:
 
   pressure_upset:
     enabled: true
+    display_name: "Pressure Upset"
+    description: Apply a pressure override and higher pump command for an upset case.
     duration: 12.0
     overrides:
       $in(flow_target_lpm): 95.0
@@ -256,6 +311,8 @@ scenarios:
 
   maintenance_idle:
     enabled: true
+    display_name: "Maintenance Idle"
+    description: Return the cell to a low-output maintenance-friendly idle state.
     duration: 15.0
     overrides:
       $in(operator_setpoint_c): 30.0

--- a/library/domains/industrial/process_cell/siemens/s7_1500_process_cell__opcua.yaml
+++ b/library/domains/industrial/process_cell/siemens/s7_1500_process_cell__opcua.yaml
@@ -2,35 +2,86 @@
 
 name: s7_1500_process_cell__opcua
 description: |
-  Siemens SIMATIC S7-1500 process cell (Sim) exposing temperature/flow/pressure
-  tags over OPC UA for SCADA/MES demos. The dynamics and alarms mirror the
-  generic process cell while providing a vendor-specific OPC UA endpoint.
+  Siemens SIMATIC S7-1500 process cell twin exposing temperature, flow, and
+  pressure tags over OPC UA for SCADA and MES demos. The dynamics and alarms
+  mirror the generic process cell while providing a vendor-specific endpoint.
 
 attributes:
-  temperature_c: 28.0
-  temperature_setpoint_c: 32.0
-  operator_setpoint_c: 32.0
-  ambient_c: 24.0
-  temperature_gain: 0.18
-  heat_loss_gain: 0.04
+  temperature_c:
+    type: float
+    default: 28.0
+    unit: degC
+  temperature_setpoint_c:
+    type: float
+    default: 32.0
+    unit: degC
+  operator_setpoint_c:
+    type: float
+    default: 32.0
+    unit: degC
+  ambient_c:
+    type: float
+    default: 24.0
+    unit: degC
+  temperature_gain:
+    type: float
+    default: 0.18
+  heat_loss_gain:
+    type: float
+    default: 0.04
 
-  pump_speed_percent: 45.0
-  pump_command_percent: 45.0
-  valve_position_percent: 35.0
+  pump_speed_percent:
+    type: float
+    default: 45.0
+    unit: percent
+  pump_command_percent:
+    type: float
+    default: 45.0
+    unit: percent
+  valve_position_percent:
+    type: float
+    default: 35.0
+    unit: percent
 
-  flow_target_lpm: 48.0
-  flow_rate_lpm: 45.0
+  flow_target_lpm:
+    type: float
+    default: 48.0
+    unit: L/min
+  flow_rate_lpm:
+    type: float
+    default: 45.0
+    unit: L/min
 
-  pressure_bar: 1.2
-  pressure_target_bar: 1.5
-  pressure_override_bar: 0.0
+  pressure_bar:
+    type: float
+    default: 1.2
+    unit: bar
+  pressure_target_bar:
+    type: float
+    default: 1.5
+    unit: bar
+  pressure_override_bar:
+    type: float
+    default: 0.0
+    unit: bar
 
-  alarm_overtemp: 0
-  alarm_pressure: 0
-  alarm_low_flow: 0
-  status_text: "IDLE"
+  alarm_overtemp:
+    type: int
+    default: 0
+  alarm_pressure:
+    type: int
+    default: 0
+  alarm_low_flow:
+    type: int
+    default: 0
+  status_text:
+    type: str
+    default: "IDLE"
 
-  cycle_time_s: 0.5
+  cycle_time_s:
+    type: float
+    default: 0.5
+    unit: s
 
 actions:
   - function: $in(temperature_setpoint_c)
@@ -241,6 +292,8 @@ communication:
 scenarios:
   heatup_cycle:
     enabled: true
+    display_name: "Heatup Cycle"
+    description: Raise temperature demand and pump command for an active process run.
     duration: 20.0
     overrides:
       $in(operator_setpoint_c): 70.0
@@ -248,6 +301,8 @@ scenarios:
 
   pressure_upset:
     enabled: true
+    display_name: "Pressure Upset"
+    description: Apply a pressure override and higher pump command for an upset case.
     duration: 12.0
     overrides:
       $in(flow_target_lpm): 95.0
@@ -256,6 +311,8 @@ scenarios:
 
   maintenance_idle:
     enabled: true
+    display_name: "Maintenance Idle"
+    description: Return the cell to a low-output maintenance-friendly idle state.
     duration: 15.0
     overrides:
       $in(operator_setpoint_c): 30.0

--- a/library/domains/industrial/station/generic/vision_quality_station__http.yaml
+++ b/library/domains/industrial/station/generic/vision_quality_station__http.yaml
@@ -2,22 +2,56 @@
 
 name: vision_quality_station__http
 description: |
-  Simple vision/quality inspection station. Exposes HTTP endpoints for fetching
-  inspection statistics and simulating new inspection results. Useful for
-  Industry 4.0 quality dashboards and scrap analysis.
+  Simple vision and quality inspection station. Exposes HTTP endpoints for
+  fetching inspection statistics and simulating new inspection results for
+  Industry 4.0 dashboards and scrap analysis.
+
+meta_parameters:
+  http_host:
+    type: str
+    default: "0.0.0.0"
+  http_port:
+    type: int
+    default: 8093
 
 attributes:
-  ok_count: 0
-  nok_count: 0
-  last_result: ok          # ok / nok
-  last_defect_code: none
-  last_part_id: ""
-  sample_queued: 0
+  ok_count:
+    type: int
+    default: 0
+    unit: count
+  nok_count:
+    type: int
+    default: 0
+    unit: count
+  last_result:
+    type: str
+    default: "ok"
+  last_defect_code:
+    type: str
+    default: "none"
+  last_part_id:
+    type: str
+    default: ""
+  sample_queued:
+    type: int
+    default: 0
 
-  defect_count_none: 0
-  defect_count_scratch: 0
-  defect_count_dent: 0
-  defect_count_offset: 0
+  defect_count_none:
+    type: int
+    default: 0
+    unit: count
+  defect_count_scratch:
+    type: int
+    default: 0
+    unit: count
+  defect_count_dent:
+    type: int
+    default: 0
+    unit: count
+  defect_count_offset:
+    type: int
+    default: 0
+    unit: count
 
 actions:
   - function: $in(ok_count)
@@ -76,8 +110,8 @@ actions:
 
 communication:
   - http_endpoint:
-      host: 0.0.0.0
-      port: 8093
+      host: "$param(http_host)"
+      port: "$param(http_port)"
       endpoints:
         "/v1/inspection/stats":
           method: GET
@@ -109,6 +143,8 @@ communication:
 scenarios:
   steady_ok_run:
     enabled: true
+    display_name: "Steady OK Run"
+    description: Continuously queue accepted parts without defects.
     duration: 20.0
     overrides:
       $in(sample_queued): 1
@@ -117,6 +153,8 @@ scenarios:
 
   defect_burst:
     enabled: true
+    display_name: "Defect Burst"
+    description: Queue a burst of NOK parts with scratch defects.
     duration: 12.0
     overrides:
       $in(sample_queued): 1
@@ -126,6 +164,8 @@ scenarios:
 
   maintenance_pause:
     enabled: true
+    display_name: "Maintenance Pause"
+    description: Pause sample intake while clearing back to a nominal OK state.
     duration: 15.0
     overrides:
       $in(sample_queued): 0

--- a/library/domains/industrial/vehicle/generic/agv_vehicle__mqtt.yaml
+++ b/library/domains/industrial/vehicle/generic/agv_vehicle__mqtt.yaml
@@ -5,23 +5,76 @@ description: |
   Autonomous guided vehicle (AGV) model for intralogistics scenarios. Publishes
   position, battery state, mission status and load information over MQTT.
 
+meta_parameters:
+  mqtt_broker_host:
+    type: str
+    default: "host.docker.internal"
+  mqtt_broker_port:
+    type: int
+    default: 1883
+  mqtt_topic_prefix:
+    type: str
+    default: "spx/examples/agv"
+  mqtt_publish_interval:
+    type: float
+    default: 0.5
+  mqtt_default_qos:
+    type: int
+    default: 1
+
 attributes:
-  pos_x_m: 0.0              # current X position [m]
-  pos_y_m: 0.0              # current Y position [m]
-  heading_deg: 0.0          # heading angle [deg]
-  speed_mps: 0.0            # current speed [m/s]
-  target_x_m: 10.0          # target waypoint X [m]
-  target_y_m: 0.0           # target waypoint Y [m]
-  target_speed_mps: 1.0     # commanded speed [m/s]
+  pos_x_m:
+    type: float
+    default: 0.0
+    unit: m
+  pos_y_m:
+    type: float
+    default: 0.0
+    unit: m
+  heading_deg:
+    type: float
+    default: 0.0
+    unit: deg
+  speed_mps:
+    type: float
+    default: 0.0
+    unit: m/s
+  target_x_m:
+    type: float
+    default: 10.0
+    unit: m
+  target_y_m:
+    type: float
+    default: 0.0
+    unit: m
+  target_speed_mps:
+    type: float
+    default: 1.0
+    unit: m/s
 
-  battery_soc_percent: 100.0   # state of charge [%]
-  battery_discharge_rate: 0.02 # discharge per second at nominal speed
+  battery_soc_percent:
+    type: float
+    default: 100.0
+    unit: percent
+  battery_discharge_rate:
+    type: float
+    default: 0.02
+    unit: percent/s
 
-  mission_state: idle       # idle, navigating, waiting, error
-  load_present: 0           # 1 = pallet/box on board
-  alarm_obstacle: 0         # 1 = obstacle detected
+  mission_state:
+    type: str
+    default: "idle"
+  load_present:
+    type: int
+    default: 0
+  alarm_obstacle:
+    type: int
+    default: 0
 
-  cycle_time_s: 0.5         # integration step [s]
+  cycle_time_s:
+    type: float
+    default: 0.5
+    unit: s
 
 actions:
   - function: $in(speed_mps)
@@ -77,59 +130,75 @@ actions:
 
 communication:
   - mqtt:
-      broker: "host.docker.internal"
-      port: 1883
-      publish_interval: 0.5
-      topic_prefix: "spx/examples/agv"
-      default_qos: 1
+      broker: "$param(mqtt_broker_host)"
+      port: "$param(mqtt_broker_port)"
+      publish_interval: "$param(mqtt_publish_interval)"
+      topic_prefix: "$param(mqtt_topic_prefix)"
+      default_qos: "$param(mqtt_default_qos)"
       default_retain: false
       bindings:
-        - attribute: $ext(pos_x_m)
+        - name: publish_pos_x_m
+          attribute: $ext(pos_x_m)
           topic: telemetry/pos_x_m
           direction: publish
-        - attribute: $ext(pos_y_m)
+        - name: publish_pos_y_m
+          attribute: $ext(pos_y_m)
           topic: telemetry/pos_y_m
           direction: publish
-        - attribute: $ext(heading_deg)
+        - name: publish_heading_deg
+          attribute: $ext(heading_deg)
           topic: telemetry/heading_deg
           direction: publish
-        - attribute: $ext(speed_mps)
+        - name: publish_speed_mps
+          attribute: $ext(speed_mps)
           topic: telemetry/speed_mps
           direction: publish
-        - attribute: $ext(battery_soc_percent)
+        - name: publish_battery_soc_percent
+          attribute: $ext(battery_soc_percent)
           topic: telemetry/battery_soc_percent
           direction: publish
-        - attribute: $ext(mission_state)
+        - name: publish_mission_state
+          attribute: $ext(mission_state)
           topic: telemetry/mission_state
           direction: publish
-        - attribute: $ext(load_present)
+        - name: publish_load_present
+          attribute: $ext(load_present)
           topic: telemetry/load_present
           direction: publish
-        - attribute: $ext(alarm_obstacle)
+        - name: publish_alarm_obstacle
+          attribute: $ext(alarm_obstacle)
           topic: telemetry/alarms/obstacle
           direction: publish
-        - attribute: $attr(target_x_m)
+        - name: subscribe_target_x_m
+          attribute: $attr(target_x_m)
           topic: command/target_x_m
           direction: subscribe
-        - attribute: $attr(target_y_m)
+        - name: subscribe_target_y_m
+          attribute: $attr(target_y_m)
           topic: command/target_y_m
           direction: subscribe
-        - attribute: $attr(target_speed_mps)
+        - name: subscribe_target_speed_mps
+          attribute: $attr(target_speed_mps)
           topic: command/target_speed_mps
           direction: subscribe
-        - attribute: $attr(heading_deg)
+        - name: subscribe_heading_deg
+          attribute: $attr(heading_deg)
           topic: command/heading_deg
           direction: subscribe
-        - attribute: $attr(load_present)
+        - name: subscribe_load_present
+          attribute: $attr(load_present)
           topic: command/load_present
           direction: subscribe
-        - attribute: $attr(alarm_obstacle)
+        - name: subscribe_alarm_obstacle
+          attribute: $attr(alarm_obstacle)
           topic: command/obstacle
           direction: subscribe
 
 scenarios:
   mission_run:
     enabled: true
+    display_name: "Mission Run"
+    description: Drive toward a waypoint with cargo on board at nominal mission speed.
     duration: 30.0
     overrides:
       $in(target_x_m): 25.0
@@ -140,6 +209,8 @@ scenarios:
 
   obstacle_stop:
     enabled: true
+    display_name: "Obstacle Stop"
+    description: Force an obstacle alarm and halt the mission.
     duration: 10.0
     overrides:
       $in(target_speed_mps): 0.0
@@ -148,6 +219,8 @@ scenarios:
 
   battery_service_window:
     enabled: true
+    display_name: "Battery Service Window"
+    description: Slow the AGV and drop battery state into a maintenance window.
     duration: 20.0
     overrides:
       $in(target_speed_mps): 0.3

--- a/library/domains/industrial/workcell/generic/production_workcell__opcua.yaml
+++ b/library/domains/industrial/workcell/generic/production_workcell__opcua.yaml
@@ -2,41 +2,106 @@
 
 name: production_workcell__opcua
 description: |
-  OPC UA-enabled machining/assembly workcell exposing station state, spindle and robot
-  telemetry as well as quality counters. Useful for validating OPC UA client behaviour
-  around bidirectional setpoints, alarms, and basic scheduling data.
+  OPC UA-enabled machining and assembly workcell exposing station state,
+  spindle and robot telemetry, and quality counters. Useful for validating
+  OPC UA client behavior around bidirectional setpoints, alarms, and schedules.
 
 attributes:
-  machine_state: idle           # idle, running, fault
-  station_mode: auto            # auto or manual
-  order_id: "ORDER-001"
-  latest_serial: ""
-  part_present: 0
-  clamp_closed: 0
+  machine_state:
+    type: str
+    default: "idle"
+  station_mode:
+    type: str
+    default: "auto"
+  order_id:
+    type: str
+    default: "ORDER-001"
+  latest_serial:
+    type: str
+    default: ""
+  part_present:
+    type: int
+    default: 0
+  clamp_closed:
+    type: int
+    default: 0
 
-  cycle_progress_percent: 0.0
-  target_cycle_time_s: 22.0
-  actual_cycle_time_s: 22.0
-  cycle_counter_total: 0
-  cycle_counter_ok: 0
-  cycle_counter_nok: 0
-  quality_flag: 1
+  cycle_progress_percent:
+    type: float
+    default: 0.0
+    unit: percent
+  target_cycle_time_s:
+    type: float
+    default: 22.0
+    unit: s
+  actual_cycle_time_s:
+    type: float
+    default: 22.0
+    unit: s
+  cycle_counter_total:
+    type: int
+    default: 0
+    unit: count
+  cycle_counter_ok:
+    type: int
+    default: 0
+    unit: count
+  cycle_counter_nok:
+    type: int
+    default: 0
+    unit: count
+  quality_flag:
+    type: int
+    default: 1
 
-  robot_position_deg: 0.0
-  robot_target_deg: 0.0
-  spindle_rpm: 0.0
-  spindle_target_rpm: 3500.0
-  tool_temperature_c: 45.0
-  tool_temperature_limit_c: 80.0
+  robot_position_deg:
+    type: float
+    default: 0.0
+    unit: deg
+  robot_target_deg:
+    type: float
+    default: 0.0
+    unit: deg
+  spindle_rpm:
+    type: float
+    default: 0.0
+    unit: rpm
+  spindle_target_rpm:
+    type: float
+    default: 3500.0
+    unit: rpm
+  tool_temperature_c:
+    type: float
+    default: 45.0
+    unit: degC
+  tool_temperature_limit_c:
+    type: float
+    default: 80.0
+    unit: degC
 
-  maintenance_timer_hours: 120.0
-  maintenance_threshold_hours: 8.0
+  maintenance_timer_hours:
+    type: float
+    default: 120.0
+    unit: h
+  maintenance_threshold_hours:
+    type: float
+    default: 8.0
+    unit: h
 
-  alarm_safety_gate: 0
-  alarm_tool_overtemp: 0
-  alarm_robot_fault: 0
+  alarm_safety_gate:
+    type: int
+    default: 0
+  alarm_tool_overtemp:
+    type: int
+    default: 0
+  alarm_robot_fault:
+    type: int
+    default: 0
 
-  cycle_time_s: 0.5
+  cycle_time_s:
+    type: float
+    default: 0.5
+    unit: s
 
 actions:
   - function: $in(machine_state)
@@ -314,6 +379,8 @@ communication:
 scenarios:
   auto_cycle:
     enabled: true
+    display_name: "Auto Cycle"
+    description: Run the workcell in automatic mode with a present and clamped part.
     duration: 30.0
     overrides:
       $in(station_mode): auto
@@ -322,6 +389,8 @@ scenarios:
 
   safety_gate_fault:
     enabled: true
+    display_name: "Safety Gate Fault"
+    description: Trigger a safety-gate fault and stop normal automatic work.
     duration: 12.0
     overrides:
       $in(alarm_safety_gate): 1
@@ -329,6 +398,8 @@ scenarios:
 
   maintenance_pause:
     enabled: true
+    display_name: "Maintenance Pause"
+    description: Switch the workcell to manual mode for a maintenance stop.
     duration: 20.0
     overrides:
       $in(station_mode): manual

--- a/tests/packs/industrial_iiot_pack/unit/test_model_metadata_refresh.py
+++ b/tests/packs/industrial_iiot_pack/unit/test_model_metadata_refresh.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+
+import yaml
+
+from tests.common.repo import repo_root
+
+
+ROOT = repo_root()
+
+
+def _load_yaml(relative_path: str) -> dict[str, Any]:
+    path = ROOT / Path(relative_path)
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _iter_pack_models() -> Iterator[tuple[str, dict[str, Any]]]:
+    pack_index = _load_yaml("library/industries/industrial_iiot_pack/MODELS.yaml")
+    catalog = _load_yaml("library/catalog/models.yaml")
+    catalog_index = {entry["id"]: entry for entry in catalog["models"]}
+
+    for entry in pack_index["models"]:
+        yield entry["id"], _load_yaml(catalog_index[entry["id"]]["path"])
+
+
+def _iter_bindings(node: Any) -> Iterator[dict[str, Any]]:
+    if isinstance(node, dict):
+        bindings = node.get("bindings")
+        if isinstance(bindings, list):
+            for binding in bindings:
+                if isinstance(binding, dict):
+                    yield binding
+        for value in node.values():
+            yield from _iter_bindings(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_bindings(item)
+
+
+def test_industrial_pack_models_use_typed_attributes_and_labeled_scenarios() -> None:
+    scalar_attrs: list[str] = []
+    missing_display_names: list[str] = []
+    unnamed_bindings: list[str] = []
+    missing_name: list[str] = []
+    missing_description: list[str] = []
+
+    for model_id, model in _iter_pack_models():
+        if not model.get("name"):
+            missing_name.append(model_id)
+        if not model.get("description"):
+            missing_description.append(model_id)
+
+        attributes = model.get("attributes") or {}
+        for attr_name, attr_spec in attributes.items():
+            if not isinstance(attr_spec, dict) or "type" not in attr_spec or "default" not in attr_spec:
+                scalar_attrs.append(f"{model_id}:{attr_name}")
+
+        for scenario_name, scenario in (model.get("scenarios") or {}).items():
+            if isinstance(scenario, dict) and "display_name" not in scenario:
+                missing_display_names.append(f"{model_id}:{scenario_name}")
+
+        for binding in _iter_bindings(model.get("communication") or []):
+            if "name" not in binding:
+                unnamed_bindings.append(model_id)
+
+    assert scalar_attrs == []
+    assert missing_display_names == []
+    assert unnamed_bindings == []
+    assert missing_name == []
+    assert missing_description == []
+
+
+def test_industrial_pack_representative_models_expose_modern_metadata() -> None:
+    abb_m1m = _load_yaml(
+        "library/domains/energy/power_meter/abb/abb_m1m_power_meter__modbus.yaml"
+    )
+    assert abb_m1m["attributes"]["k__load_kw"]["unit"] == "kW"
+    assert abb_m1m["attributes"]["frequency_droop_per_kw"]["unit"] == "Hz/kW"
+    assert abb_m1m["scenarios"]["low_power_factor"]["display_name"] == "Low Power Factor"
+
+    eurotherm_3504 = _load_yaml(
+        "library/domains/industrial/controller/eurotherm/eurotherm_3504__modbus.yaml"
+    )
+    assert eurotherm_3504["meta_parameters"]["modbus_port"]["default"] == 5027
+    assert eurotherm_3504["attributes"]["control_out_pct"]["unit"] == "percent"
+    assert eurotherm_3504["scenarios"]["manual_hold_40"]["display_name"] == "Manual Hold 40%"
+
+    thermal_advanced = _load_yaml(
+        "library/domains/industrial/controller/generic/thermal_controller_advanced.yaml"
+    )
+    assert thermal_advanced["name"] == "thermal_controller_advanced"
+    assert thermal_advanced["attributes"]["temperature"]["unit"] == "degC"
+    assert thermal_advanced["scenarios"]["heat_treat_sequence_profile"]["display_name"] == (
+        "Heat Treat Sequence (Profile)"
+    )
+
+    process_cell = _load_yaml(
+        "library/domains/industrial/process_cell/generic/process_cell__opcua.yaml"
+    )
+    assert process_cell["attributes"]["flow_rate_lpm"]["unit"] == "L/min"
+    assert process_cell["scenarios"]["maintenance_idle"]["display_name"] == "Maintenance Idle"
+
+    vision_station = _load_yaml(
+        "library/domains/industrial/station/generic/vision_quality_station__http.yaml"
+    )
+    assert vision_station["meta_parameters"]["http_port"]["default"] == 8093
+    assert vision_station["attributes"]["ok_count"]["unit"] == "count"
+    assert vision_station["scenarios"]["defect_burst"]["display_name"] == "Defect Burst"


### PR DESCRIPTION
## Summary
- standardize industrial_iiot_pack models to the current metadata shape across MQTT, Modbus, HTTP, and OPC UA families
- add typed attributes, units, scenario display names, and parameterized transport settings where supported without breaking public model APIs
- add a unit regression test that guards typed attributes, labeled scenarios, and named bindings across the pack

## Validation
- poetry run python tools/validate_models.py
- poetry run pytest tests/packs/industrial_iiot_pack/unit
- poetry run pytest tests/packs/industrial_iiot_pack