### PR TITLE
fix(building): standardize smart building pack metadata

### DIFF
--- a/library/domains/building/actuator/abb/abb_jra_s4_230_5_1__knx.yaml
+++ b/library/domains/building/actuator/abb/abb_jra_s4_230_5_1__knx.yaml
@@ -31,50 +31,144 @@ meta_parameters:
     default: "2"
 
 attributes:
-  invert_move_long: 1
-  invert_position: 1
-  position_tolerance_pct: 0.5
+  invert_move_long:
+    type: int
+    default: 1
+  invert_position:
+    type: int
+    default: 1
+  position_tolerance_pct:
+    type: float
+    default: 0.5
+    unit: percent
 
-  k__c1_position_pct: 10.0
-  k__c1_target_pct: 10.0
-  c1_target_active: 0
-  c1_moving: 0            # -1=down, 0=stop, +1=up
-  c1_travel_time_s: 42.0
-  c1_move_long_cmd: 2      # 0=down, 1=up, 2=no command (cleared by model)
-  c1_stop_cmd: 0
-  c1_position_set_raw_cmd: -1.0
-  c1_position_state_raw: 26
+  k__c1_position_pct:
+    type: float
+    default: 10.0
+    unit: percent
+  k__c1_target_pct:
+    type: float
+    default: 10.0
+    unit: percent
+  c1_target_active:
+    type: int
+    default: 0
+  c1_moving:
+    type: int
+    default: 0
+  c1_travel_time_s:
+    type: float
+    default: 42.0
+    unit: s
+  c1_move_long_cmd:
+    type: int
+    default: 2
+  c1_stop_cmd:
+    type: int
+    default: 0
+  c1_position_set_raw_cmd:
+    type: float
+    default: -1.0
+  c1_position_state_raw:
+    type: int
+    default: 26
 
-  k__c2_position_pct: 40.0
-  k__c2_target_pct: 40.0
-  c2_target_active: 0
-  c2_moving: 0
-  c2_travel_time_s: 42.0
-  c2_move_long_cmd: 2
-  c2_stop_cmd: 0
-  c2_position_set_raw_cmd: -1.0
-  c2_position_state_raw: 102
+  k__c2_position_pct:
+    type: float
+    default: 40.0
+    unit: percent
+  k__c2_target_pct:
+    type: float
+    default: 40.0
+    unit: percent
+  c2_target_active:
+    type: int
+    default: 0
+  c2_moving:
+    type: int
+    default: 0
+  c2_travel_time_s:
+    type: float
+    default: 42.0
+    unit: s
+  c2_move_long_cmd:
+    type: int
+    default: 2
+  c2_stop_cmd:
+    type: int
+    default: 0
+  c2_position_set_raw_cmd:
+    type: float
+    default: -1.0
+  c2_position_state_raw:
+    type: int
+    default: 102
 
-  k__c3_position_pct: 70.0
-  k__c3_target_pct: 70.0
-  c3_target_active: 0
-  c3_moving: 0
-  c3_travel_time_s: 42.0
-  c3_move_long_cmd: 2
-  c3_stop_cmd: 0
-  c3_position_set_raw_cmd: -1.0
-  c3_position_state_raw: 178
+  k__c3_position_pct:
+    type: float
+    default: 70.0
+    unit: percent
+  k__c3_target_pct:
+    type: float
+    default: 70.0
+    unit: percent
+  c3_target_active:
+    type: int
+    default: 0
+  c3_moving:
+    type: int
+    default: 0
+  c3_travel_time_s:
+    type: float
+    default: 42.0
+    unit: s
+  c3_move_long_cmd:
+    type: int
+    default: 2
+  c3_stop_cmd:
+    type: int
+    default: 0
+  c3_position_set_raw_cmd:
+    type: float
+    default: -1.0
+  c3_position_state_raw:
+    type: int
+    default: 178
 
-  k__c4_position_pct: 0.0
-  k__c4_target_pct: 0.0
-  c4_target_active: 0
-  c4_moving: 0
-  c4_travel_time_s: 42.0
-  c4_move_long_cmd: 2
-  c4_stop_cmd: 0
-  c4_position_set_raw_cmd: -1.0
-  c4_position_state_raw: 0
-  _cycle_time_s: 0.2
+  k__c4_position_pct:
+    type: float
+    default: 0.0
+    unit: percent
+  k__c4_target_pct:
+    type: float
+    default: 0.0
+    unit: percent
+  c4_target_active:
+    type: int
+    default: 0
+  c4_moving:
+    type: int
+    default: 0
+  c4_travel_time_s:
+    type: float
+    default: 42.0
+    unit: s
+  c4_move_long_cmd:
+    type: int
+    default: 2
+  c4_stop_cmd:
+    type: int
+    default: 0
+  c4_position_set_raw_cmd:
+    type: float
+    default: -1.0
+  c4_position_state_raw:
+    type: int
+    default: 0
+  _cycle_time_s:
+    type: float
+    default: 0.2
+    unit: s
   
 actions:
   # ------------------------------------------------------------------

--- a/library/domains/building/actuator/abb/abb_sa_s12_16_5_1__knx.yaml
+++ b/library/domains/building/actuator/abb/abb_sa_s12_16_5_1__knx.yaml
@@ -27,22 +27,51 @@ meta_parameters:
     default: "1"
 
 attributes:
-  _cycle_time_s: 0.2
+  _cycle_time_s:
+    type: float
+    default: 0.2
+    unit: s
 
-  all_off_cmd: 0
+  all_off_cmd:
+    type: int
+    default: 0
 
-  k__ch01: 0
-  k__ch02: 0
-  k__ch03: 0
-  k__ch04: 0
-  k__ch05: 0
-  k__ch06: 0
-  k__ch07: 0
-  k__ch08: 0
-  k__ch09: 0
-  k__ch10: 0
-  k__ch11: 0
-  k__ch12: 0
+  k__ch01:
+    type: int
+    default: 0
+  k__ch02:
+    type: int
+    default: 0
+  k__ch03:
+    type: int
+    default: 0
+  k__ch04:
+    type: int
+    default: 0
+  k__ch05:
+    type: int
+    default: 0
+  k__ch06:
+    type: int
+    default: 0
+  k__ch07:
+    type: int
+    default: 0
+  k__ch08:
+    type: int
+    default: 0
+  k__ch09:
+    type: int
+    default: 0
+  k__ch10:
+    type: int
+    default: 0
+  k__ch11:
+    type: int
+    default: 0
+  k__ch12:
+    type: int
+    default: 0
 
 conditions:
   - if: $attr(all_off_cmd) == 1

--- a/library/domains/building/actuator/generic/robot_vacuum__mqtt.yaml
+++ b/library/domains/building/actuator/generic/robot_vacuum__mqtt.yaml
@@ -9,34 +9,96 @@ description: |
 
 attributes:
   # Command latches and discrete state (int 0/1 flags)
-  desired_cleaning: 0
-  dock_request: 0
-  cleaning_active: 0
-  returning_home: 0
-  docked: 1
+  desired_cleaning:
+    type: int
+    default: 0
+  dock_request:
+    type: int
+    default: 0
+  cleaning_active:
+    type: int
+    default: 0
+  returning_home:
+    type: int
+    default: 0
+  docked:
+    type: int
+    default: 1
 
   # Telemetry ([%], [m2], [min], [W])
-  battery_percent: 100.0
-  bin_fill_percent: 5.0
-  area_cleaned_m2: 0.0
-  runtime_min: 0.0
-  suction_level_percent: 70.0
-  active_power_w: 0.0
+  battery_percent:
+    type: float
+    default: 100.0
+    unit: percent
+  bin_fill_percent:
+    type: float
+    default: 5.0
+    unit: percent
+  area_cleaned_m2:
+    type: float
+    default: 0.0
+    unit: m2
+  runtime_min:
+    type: float
+    default: 0.0
+    unit: min
+  suction_level_percent:
+    type: float
+    default: 70.0
+    unit: percent
+  active_power_w:
+    type: float
+    default: 0.0
+    unit: W
 
   # Timing and behavior tuning ([s], [%], [m2/min], [%/min])
-  return_timer_s: 0.0
-  return_duration_s: 15.0
-  low_battery_threshold_percent: 15.0
-  bin_full_threshold_percent: 95.0
-  cleaning_rate_m2_per_min: 1.1
-  bin_fill_rate_percent_per_min: 1.8
-  discharge_clean_percent_per_min: 5.0
-  discharge_return_percent_per_min: 2.0
-  charge_rate_percent_per_min: 10.0
-  cycle_time_s: 1.0
+  return_timer_s:
+    type: float
+    default: 0.0
+    unit: s
+  return_duration_s:
+    type: float
+    default: 15.0
+    unit: s
+  low_battery_threshold_percent:
+    type: float
+    default: 15.0
+    unit: percent
+  bin_full_threshold_percent:
+    type: float
+    default: 95.0
+    unit: percent
+  cleaning_rate_m2_per_min:
+    type: float
+    default: 1.1
+    unit: m2/min
+  bin_fill_rate_percent_per_min:
+    type: float
+    default: 1.8
+    unit: percent/min
+  discharge_clean_percent_per_min:
+    type: float
+    default: 5.0
+    unit: percent/min
+  discharge_return_percent_per_min:
+    type: float
+    default: 2.0
+    unit: percent/min
+  charge_rate_percent_per_min:
+    type: float
+    default: 10.0
+    unit: percent/min
+  cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 
-  error_code: 0
-  status_text: "DOCKED"
+  error_code:
+    type: int
+    default: 0
+  status_text:
+    type: str
+    default: "DOCKED"
 
 actions:
   - function: $in(desired_cleaning)

--- a/library/domains/building/actuator/generic/smart_plug__matter.yaml
+++ b/library/domains/building/actuator/generic/smart_plug__matter.yaml
@@ -8,17 +8,44 @@ description: |
   Uses command counters to emit On/Off commands and subscribes to the OnOff attribute for feedback.
 
 attributes:
-  switch_state: 0           # 0/1, live state from the Matter device (OnOff attribute)
-  desired_state: 0          # 0/1, target state driven by BMS logic or scenarios
-  command_issued_state: 0   # remembers the last target we already dispatched
-  command_on_counter: 0     # monotonically increasing trigger for On commands
-  command_off_counter: 0    # monotonically increasing trigger for Off commands
-  retry_timer_s: 0.0        # accumulates time while device state mismatches the target
-  retry_interval_s: 8.0     # resend command if mismatch persists beyond this interval
-  load_power_w: 45.0        # nominal load when ON (used for synthetic telemetry)
-  active_power_w: 0.0       # derived power reading
-  energy_wh: 0.0            # synthetic energy accumulator
-  status_text: "OFF"
+  switch_state:
+    type: int
+    default: 0
+  desired_state:
+    type: int
+    default: 0
+  command_issued_state:
+    type: int
+    default: 0
+  command_on_counter:
+    type: int
+    default: 0
+  command_off_counter:
+    type: int
+    default: 0
+  retry_timer_s:
+    type: float
+    default: 0.0
+    unit: s
+  retry_interval_s:
+    type: float
+    default: 8.0
+    unit: s
+  load_power_w:
+    type: float
+    default: 45.0
+    unit: W
+  active_power_w:
+    type: float
+    default: 0.0
+    unit: W
+  energy_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  status_text:
+    type: str
+    default: "OFF"
 
 actions:
   - function: $in(command_on_counter)
@@ -144,12 +171,16 @@ communication:
 scenarios:
   plug_on:
     enabled: true
+    display_name: "Plug On"
+    description: Request the plug to switch on.
     duration: 20.0
     overrides:
       $in(desired_state): 1
 
   plug_off:
     enabled: true
+    display_name: "Plug Off"
+    description: Request the plug to switch off.
     duration: 20.0
     overrides:
       $in(desired_state): 0

--- a/library/domains/building/controller/generic/bms_controller__opcua.yaml
+++ b/library/domains/building/controller/generic/bms_controller__opcua.yaml
@@ -6,40 +6,115 @@ description: |
   Ideal for testing BAS integrations that read/write setpoints, schedules and alarm states.
 
 attributes:
-  hvac_mode: auto
-  schedule_override: none
-  occupancy_percent: 35.0
-  occupancy_target_percent: 50.0
+  hvac_mode:
+    type: str
+    default: "auto"
+  schedule_override:
+    type: str
+    default: "none"
+  occupancy_percent:
+    type: float
+    default: 35.0
+    unit: percent
+  occupancy_target_percent:
+    type: float
+    default: 50.0
+    unit: percent
 
-  supply_air_temp_c: 16.5
-  supply_air_setpoint_c: 16.0
-  supply_air_command_c: 16.0
-  return_air_temp_c: 24.0
-  zone_temp_average_c: 22.2
+  supply_air_temp_c:
+    type: float
+    default: 16.5
+    unit: degC
+  supply_air_setpoint_c:
+    type: float
+    default: 16.0
+    unit: degC
+  supply_air_command_c:
+    type: float
+    default: 16.0
+    unit: degC
+  return_air_temp_c:
+    type: float
+    default: 24.0
+    unit: degC
+  zone_temp_average_c:
+    type: float
+    default: 22.2
+    unit: degC
 
-  fan_speed_percent: 55.0
-  fan_command_percent: 55.0
-  fan_status_text: "RUN"
+  fan_speed_percent:
+    type: float
+    default: 55.0
+    unit: percent
+  fan_command_percent:
+    type: float
+    default: 55.0
+    unit: percent
+  fan_status_text:
+    type: str
+    default: "RUN"
 
-  filter_dp_pa: 120.0
-  filter_dp_limit_pa: 250.0
+  filter_dp_pa:
+    type: float
+    default: 120.0
+    unit: Pa
+  filter_dp_limit_pa:
+    type: float
+    default: 250.0
+    unit: Pa
 
-  chilled_supply_temp_c: 6.5
-  chilled_return_temp_c: 11.2
-  chilled_setpoint_c: 6.0
-  pump_speed_percent: 60.0
-  pump_command_percent: 60.0
-  valve_position_percent: 45.0
+  chilled_supply_temp_c:
+    type: float
+    default: 6.5
+    unit: degC
+  chilled_return_temp_c:
+    type: float
+    default: 11.2
+    unit: degC
+  chilled_setpoint_c:
+    type: float
+    default: 6.0
+    unit: degC
+  pump_speed_percent:
+    type: float
+    default: 60.0
+    unit: percent
+  pump_command_percent:
+    type: float
+    default: 60.0
+    unit: percent
+  valve_position_percent:
+    type: float
+    default: 45.0
+    unit: percent
 
-  energy_consumption_kwh: 1280.0
-  demand_limit_kw: 90.0
-  power_draw_kw: 78.0
+  energy_consumption_kwh:
+    type: float
+    default: 1280.0
+    unit: kWh
+  demand_limit_kw:
+    type: float
+    default: 90.0
+    unit: kW
+  power_draw_kw:
+    type: float
+    default: 78.0
+    unit: kW
 
-  alarm_chiller: 0
-  alarm_fan: 0
-  alarm_filter: 0
+  alarm_chiller:
+    type: int
+    default: 0
+  alarm_fan:
+    type: int
+    default: 0
+  alarm_filter:
+    type: int
+    default: 0
 
-  cycle_time_s: 1.0
+  cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 
 actions:
   - function: $in(occupancy_percent)
@@ -345,6 +420,8 @@ communication:
 scenarios:
   morning_warmup:
     enabled: true
+    display_name: "Morning Warmup"
+    description: Raise occupancy and chiller demand for a morning startup sequence.
     duration: 20.0
     overrides:
       $in(schedule_override): occupied
@@ -353,6 +430,8 @@ scenarios:
 
   demand_response:
     enabled: true
+    display_name: "Demand Response"
+    description: Reduce fan and pump demand to stay below the power cap.
     duration: 25.0
     overrides:
       $in(demand_limit_kw): 60.0
@@ -361,6 +440,8 @@ scenarios:
 
   maintenance_stop:
     enabled: true
+    display_name: "Maintenance Stop"
+    description: Switch the HVAC plant to an off state for maintenance.
     duration: 15.0
     overrides:
       $in(hvac_mode): off

--- a/library/domains/building/controller/generic/hvac_flexit_nordic__bacnet.yaml
+++ b/library/domains/building/controller/generic/hvac_flexit_nordic__bacnet.yaml
@@ -5,82 +5,188 @@ description: |
   Minimal BACnet/IP simulation of Flexit Nordic (EcoNordic) for Home Assistant using flexit_bacnet object map.
 
 attributes:
-  cycle_time_s: 1.0
-
-  # Temperatures (°C)
-  outside_air_temp_c: 5.0
-  supply_air_temp_c: 18.0
-  exhaust_air_temp_c: 16.0
-  extract_air_temp_c: 21.0
-  room_temp_c: 21.0
-
-  # Air temperature setpoints (degC)
-  k__air_temp_setpoint_home_c: 19.0
-  k__air_temp_setpoint_away_c: 18.0
-  active_air_temp_setpoint_c: 19.0
-
-  # Simple thermal model
-  room_thermal_mass_kwh_per_k: 4.0
-  heat_loss_kw_per_k: 0.15
-  fan_loss_kw_per_k: 0.04
-  heating_boost_kw_per_k: 0.6
-  thermal_time_scale: 6.0
-  heat_loss_kw: 0.0
-  heating_demand_kw: 0.0
-
-  # Comfort button
-  cmd__comfort_button: 1
-  comfort_button_delay_min: 0
-
-  # Fireplace ventilation
-  cmd__fireplace_ventilation_trigger: 1
-  fireplace_active: 0
-  fireplace_remaining_min: 0.0
-
-  # Cooker hood
-  cooker_hood_active: 0
-
-  # Ventilation mode (MultiStateValue,42)
-  # Range used in this model: 1..4
-  # 1=Stop, 2=Away, 3=Home, 4=High
-  k__ventilation_mode: 3
-  _ventilation_mode_prev: 3
-
-  # Fans
-  supply_fan_speed_pct: 35.0
-  exhaust_fan_speed_pct: 35.0
-  supply_fan_rpm: 1200.0
-  exhaust_fan_rpm: 1200.0
-
-  # Electric heater (kW)
-  k__electric_heater_enabled: 0
-  heater_fault: 0
-  electric_heater_nom_power: 5.0
-  heater_load_pct: 0.0
-  heating_coil_electric_power_kw: 0.0
-
-  # Filter
-  air_filter_operating_time_h: 1000.0
-  air_filter_polluted: 0
-
-  # Rotary heat exchanger
-  rotary_hex_speed_pct: 60.0
-  rotary_hex_efficiency_pct: 75.0
-
-  # Ventilation setpoints (%) (AnalogValue 1835..1844)
-  supply_set_high: 60.0
-  supply_set_home: 35.0
-  supply_set_away: 20.0
-  supply_set_fire: 50.0
-  supply_set_cooker: 70.0
-
-  exhaust_set_high: 60.0
-  exhaust_set_home: 35.0
-  exhaust_set_away: 20.0
-  exhaust_set_fire: 50.0
-  exhaust_set_cooker: 70.0
-
-  fireplace_runtime_min: 30
+  cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
+  outside_air_temp_c:
+    type: float
+    default: 5.0
+    unit: degC
+  supply_air_temp_c:
+    type: float
+    default: 18.0
+    unit: degC
+  exhaust_air_temp_c:
+    type: float
+    default: 16.0
+    unit: degC
+  extract_air_temp_c:
+    type: float
+    default: 21.0
+    unit: degC
+  room_temp_c:
+    type: float
+    default: 21.0
+    unit: degC
+  k__air_temp_setpoint_home_c:
+    type: float
+    default: 19.0
+    unit: degC
+  k__air_temp_setpoint_away_c:
+    type: float
+    default: 18.0
+    unit: degC
+  active_air_temp_setpoint_c:
+    type: float
+    default: 19.0
+    unit: degC
+  room_thermal_mass_kwh_per_k:
+    type: float
+    default: 4.0
+    unit: kWh/K
+  heat_loss_kw_per_k:
+    type: float
+    default: 0.15
+    unit: kW/K
+  fan_loss_kw_per_k:
+    type: float
+    default: 0.04
+    unit: kW/K
+  heating_boost_kw_per_k:
+    type: float
+    default: 0.6
+    unit: kW/K
+  thermal_time_scale:
+    type: float
+    default: 6.0
+  heat_loss_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  heating_demand_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  cmd__comfort_button:
+    type: int
+    default: 1
+  comfort_button_delay_min:
+    type: int
+    default: 0
+    unit: min
+  cmd__fireplace_ventilation_trigger:
+    type: int
+    default: 1
+  fireplace_active:
+    type: int
+    default: 0
+  fireplace_remaining_min:
+    type: float
+    default: 0.0
+    unit: min
+  cooker_hood_active:
+    type: int
+    default: 0
+  k__ventilation_mode:
+    type: int
+    default: 3
+  _ventilation_mode_prev:
+    type: int
+    default: 3
+  supply_fan_speed_pct:
+    type: float
+    default: 35.0
+    unit: "%"
+  exhaust_fan_speed_pct:
+    type: float
+    default: 35.0
+    unit: "%"
+  supply_fan_rpm:
+    type: float
+    default: 1200.0
+    unit: rpm
+  exhaust_fan_rpm:
+    type: float
+    default: 1200.0
+    unit: rpm
+  k__electric_heater_enabled:
+    type: int
+    default: 0
+  heater_fault:
+    type: int
+    default: 0
+  electric_heater_nom_power:
+    type: float
+    default: 5.0
+    unit: kW
+  heater_load_pct:
+    type: float
+    default: 0.0
+    unit: "%"
+  heating_coil_electric_power_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  air_filter_operating_time_h:
+    type: float
+    default: 1000.0
+    unit: h
+  air_filter_polluted:
+    type: int
+    default: 0
+  rotary_hex_speed_pct:
+    type: float
+    default: 60.0
+    unit: "%"
+  rotary_hex_efficiency_pct:
+    type: float
+    default: 75.0
+    unit: "%"
+  supply_set_high:
+    type: float
+    default: 60.0
+    unit: "%"
+  supply_set_home:
+    type: float
+    default: 35.0
+    unit: "%"
+  supply_set_away:
+    type: float
+    default: 20.0
+    unit: "%"
+  supply_set_fire:
+    type: float
+    default: 50.0
+    unit: "%"
+  supply_set_cooker:
+    type: float
+    default: 70.0
+    unit: "%"
+  exhaust_set_high:
+    type: float
+    default: 60.0
+    unit: "%"
+  exhaust_set_home:
+    type: float
+    default: 35.0
+    unit: "%"
+  exhaust_set_away:
+    type: float
+    default: 20.0
+    unit: "%"
+  exhaust_set_fire:
+    type: float
+    default: 50.0
+    unit: "%"
+  exhaust_set_cooker:
+    type: float
+    default: 70.0
+    unit: "%"
+  fireplace_runtime_min:
+    type: int
+    default: 30
+    unit: min
 
 actions:
   - function: $in(k__ventilation_mode)
@@ -362,8 +468,6 @@ communication:
             presentValue:
               read: "#attr(k__air_temp_setpoint_away_c)"
               write: "#attr(k__air_temp_setpoint_away_c)"
-              read: "#attr(k__air_temp_setpoint_away_c)"
-              write: "#attr(k__air_temp_setpoint_away_c)"
             units: "degreesCelsius"
 
         air_temp_setpoint_home:
@@ -371,8 +475,6 @@ communication:
           instance: 1994
           properties:
             presentValue:
-              read: "#attr(k__air_temp_setpoint_home_c)"
-              write: "#attr(k__air_temp_setpoint_home_c)"
               read: "#attr(k__air_temp_setpoint_home_c)"
               write: "#attr(k__air_temp_setpoint_home_c)"
             units: "degreesCelsius"

--- a/library/domains/building/controller/generic/room_controller__knx.yaml
+++ b/library/domains/building/controller/generic/room_controller__knx.yaml
@@ -21,30 +21,87 @@ meta_parameters:
     default: "2"
 
 attributes:
-  k__room_temperature_c: 22.5
-  k__room_setpoint_c: 22.0
-  k__room_command_c: 22.0
-  min_setpoint_c: 7.0
-  max_setpoint_c: 28.0
-  setpoint_step_k: 0.1
-  k__hvac_mode_code: 1         # DPT 20.102: 0 auto, 1 comfort, 2 standby, 3 economy, 4 building protection
-  hvac_mode: comfort        # derived from k__hvac_mode_code and hvac_on
-  hvac_on: 1
-  hvac_active: 1
-  fan_speed_percent: 35.0
-  k__fan_command_percent: 35.0
-  k__valve_position_percent: 40.0
-  cooling_mode: 0
-  relative_humidity_percent: 45.0
-  k__occupancy_present: 1
-  k__window_open: 0
-  alarm_window: 0
-  comfort_mode_request: 0
-  economy_mode_request: 0
-  standby_mode_request: 0
-  building_protection_request: 0
+  k__room_temperature_c:
+    type: float
+    default: 22.5
+    unit: degC
+  k__room_setpoint_c:
+    type: float
+    default: 22.0
+    unit: degC
+  k__room_command_c:
+    type: float
+    default: 22.0
+    unit: degC
+  min_setpoint_c:
+    type: float
+    default: 7.0
+    unit: degC
+  max_setpoint_c:
+    type: float
+    default: 28.0
+    unit: degC
+  setpoint_step_k:
+    type: float
+    default: 0.1
+    unit: K
+  k__hvac_mode_code:
+    type: int
+    default: 1
+  hvac_mode:
+    type: str
+    default: "comfort"
+  hvac_on:
+    type: int
+    default: 1
+  hvac_active:
+    type: int
+    default: 1
+  fan_speed_percent:
+    type: float
+    default: 35.0
+    unit: percent
+  k__fan_command_percent:
+    type: float
+    default: 35.0
+    unit: percent
+  k__valve_position_percent:
+    type: float
+    default: 40.0
+    unit: percent
+  cooling_mode:
+    type: int
+    default: 0
+  relative_humidity_percent:
+    type: float
+    default: 45.0
+    unit: percent
+  k__occupancy_present:
+    type: int
+    default: 1
+  k__window_open:
+    type: int
+    default: 0
+  alarm_window:
+    type: int
+    default: 0
+  comfort_mode_request:
+    type: int
+    default: 0
+  economy_mode_request:
+    type: int
+    default: 0
+  standby_mode_request:
+    type: int
+    default: 0
+  building_protection_request:
+    type: int
+    default: 0
 
-  cycle_time_s: 0.5
+  cycle_time_s:
+    type: float
+    default: 0.5
+    unit: s
 
 actions:
   - function: $in(k__room_setpoint_c)
@@ -259,6 +316,8 @@ communication:
 
 scenarios:
   comfort_mode:
+    display_name: "Comfort Mode"
+    description: Keep the room occupied and comfortable with a higher setpoint.
     duration: 20.0
     overrides:
       $in(k__hvac_mode_code): 1
@@ -268,6 +327,8 @@ scenarios:
       $in(k__window_open): 0
 
   energy_saver:
+    display_name: "Energy Saver"
+    description: Lower fan and occupancy demand for a reduced-energy operating mode.
     duration: 15.0
     overrides:
       $in(k__hvac_mode_code): 2

--- a/library/domains/building/controller/generic/security_access_controller__bacnet.yaml
+++ b/library/domains/building/controller/generic/security_access_controller__bacnet.yaml
@@ -8,16 +8,32 @@ description: |
   lock command and partition mode via BACnet/IP.
 
 attributes:
-  entry_door_contact: 0   # 1 when door open
-  server_room_contact: 0  # 1 when door open
-  motion_zone: 0          # 1 when movement detected
+  entry_door_contact:
+    type: int
+    default: 0
+  server_room_contact:
+    type: int
+    default: 0
+  motion_zone:
+    type: int
+    default: 0
 
-  lock_command: 1         # 1=locked, 0=unlocked
-  siren_command: 0
-  alarm_active: 0
+  lock_command:
+    type: int
+    default: 1
+  siren_command:
+    type: int
+    default: 0
+  alarm_active:
+    type: int
+    default: 0
 
-  access_mode: 1          # 1=disarmed, 2=armed-stay, 3=armed-away, 4=alarm
-  alarm_text: "DISARMED"
+  access_mode:
+    type: int
+    default: 1
+  alarm_text:
+    type: str
+    default: "DISARMED"
 
 conditions:
   # Trigger alarm when armed and intrusion detected.

--- a/library/domains/building/panel/generic/fire_alarm_panel__bacnet.yaml
+++ b/library/domains/building/panel/generic/fire_alarm_panel__bacnet.yaml
@@ -9,22 +9,53 @@ description: |
 
 attributes:
   # sensing
-  smoke_zone1_ppm: 35.0
-  smoke_zone2_ppm: 18.0
-  heat_zone1_c: 28.0
-  heat_zone2_c: 26.0
-  manual_callpoint: 0        # 1 when break-glass is pressed
+  smoke_zone1_ppm:
+    type: float
+    default: 35.0
+    unit: ppm
+  smoke_zone2_ppm:
+    type: float
+    default: 18.0
+    unit: ppm
+  heat_zone1_c:
+    type: float
+    default: 28.0
+    unit: degC
+  heat_zone2_c:
+    type: float
+    default: 26.0
+    unit: degC
+  manual_callpoint:
+    type: int
+    default: 0
 
   # states/outputs
-  alarm_active: 0
-  siren_command: 0
-  system_status: 1           # 1=normal, 2=pre-alarm, 3=alarm, 4=fault
-  alarm_text: "NORMAL"
+  alarm_active:
+    type: int
+    default: 0
+  siren_command:
+    type: int
+    default: 0
+  system_status:
+    type: int
+    default: 1
+  alarm_text:
+    type: str
+    default: "NORMAL"
 
   # thresholds
-  smoke_alarm_threshold_ppm: 80.0
-  heat_alarm_threshold_c: 68.0
-  prealarm_margin_ppm: 20.0
+  smoke_alarm_threshold_ppm:
+    type: float
+    default: 80.0
+    unit: ppm
+  heat_alarm_threshold_c:
+    type: float
+    default: 68.0
+    unit: degC
+  prealarm_margin_ppm:
+    type: float
+    default: 20.0
+    unit: ppm
 
 conditions:
   # Raise alarm on smoke/heat/manual trigger.

--- a/library/domains/building/panel/generic/lighting_panel__opcua.yaml
+++ b/library/domains/building/panel/generic/lighting_panel__opcua.yaml
@@ -6,32 +6,83 @@ description: |
   Useful for showcasing BMS/BAS OPC UA integrations focused on lighting and occupancy.
 
 attributes:
-  panel_state: automatic        # automatic/manual/off
-  active_scene: daylight
-  schedule_state: workday
+  panel_state:
+    type: str
+    default: "automatic"
+  active_scene:
+    type: str
+    default: "daylight"
+  schedule_state:
+    type: str
+    default: "workday"
 
-  zone1_level_percent: 65.0
-  zone1_target_percent: 70.0
-  zone2_level_percent: 40.0
-  zone2_target_percent: 45.0
-  zone3_level_percent: 15.0
-  zone3_target_percent: 20.0
+  zone1_level_percent:
+    type: float
+    default: 65.0
+    unit: percent
+  zone1_target_percent:
+    type: float
+    default: 70.0
+    unit: percent
+  zone2_level_percent:
+    type: float
+    default: 40.0
+    unit: percent
+  zone2_target_percent:
+    type: float
+    default: 45.0
+    unit: percent
+  zone3_level_percent:
+    type: float
+    default: 15.0
+    unit: percent
+  zone3_target_percent:
+    type: float
+    default: 20.0
+    unit: percent
 
-  daylight_lux: 320.0
-  daylight_setpoint_lux: 350.0
+  daylight_lux:
+    type: float
+    default: 320.0
+    unit: lx
+  daylight_setpoint_lux:
+    type: float
+    default: 350.0
+    unit: lx
 
-  occupancy_zone1: 1
-  occupancy_zone2: 0
-  occupancy_zone3: 0
+  occupancy_zone1:
+    type: int
+    default: 1
+  occupancy_zone2:
+    type: int
+    default: 0
+  occupancy_zone3:
+    type: int
+    default: 0
 
-  energy_today_kwh: 12.5
-  energy_week_kwh: 86.0
+  energy_today_kwh:
+    type: float
+    default: 12.5
+    unit: kWh
+  energy_week_kwh:
+    type: float
+    default: 86.0
+    unit: kWh
 
-  emergency_test_active: 0
-  alarm_emergency: 0
-  alarm_power: 0
+  emergency_test_active:
+    type: int
+    default: 0
+  alarm_emergency:
+    type: int
+    default: 0
+  alarm_power:
+    type: int
+    default: 0
 
-  cycle_time_s: 0.5
+  cycle_time_s:
+    type: float
+    default: 0.5
+    unit: s
 
 actions:
   - function: $in(zone1_level_percent)
@@ -245,6 +296,8 @@ communication:
 scenarios:
   evening_scene:
     enabled: true
+    display_name: "Evening Scene"
+    description: Switch the panel to a lower evening lighting scene.
     duration: 20.0
     overrides:
       $in(active_scene): evening
@@ -254,6 +307,8 @@ scenarios:
 
   night_shutdown:
     enabled: true
+    display_name: "Night Shutdown"
+    description: Turn the lighting panel off for night schedule operation.
     duration: 25.0
     overrides:
       $in(panel_state): off
@@ -264,6 +319,8 @@ scenarios:
 
   emergency_test:
     enabled: true
+    display_name: "Emergency Test"
+    description: Run an emergency-lighting test while the panel stays in manual mode.
     duration: 10.0
     overrides:
       $in(emergency_test_active): 1

--- a/library/domains/building/sensor/theben/theronda_p360__knx.yaml
+++ b/library/domains/building/sensor/theben/theronda_p360__knx.yaml
@@ -26,93 +26,214 @@ meta_parameters:
 
 attributes:
   # --- Environment inputs ---
-  k__motion_detected: 0               # 0/1 - simulate PIR detection
-  k__brightness_ceiling_lux: 280.0    # lux - "internal" sensor measurement (pre room-correction)
-  brightness_external_lux: 280.0   # lux - provided via KNX object 10 when external measurement is used
-
-  # --- General parameters (ETS-like) ---
-  k__operating_mode: master           # master|slave
-  k__master_operating_mode: individual_switching  # individual_switching|parallel_switching
-  parallel_switching_cycle_s: 60.0 # 30,60,120,180,240 (manual)
-
-  k__brightness_measurement_source: internal  # internal|external
-  room_correction_factor: 0.3      # 0.05..2.0 (manual)
-
-  lighting_channel_c1_function: switching  # switching|constant_light|constant_light_no_presence|inactive
-  lighting_channel_c2_function: switching  # switching|constant_light|constant_light_no_presence|inactive
-  lighting_configuration_type: fully_automatic  # fully_automatic|semi_automatic
-
-  k__brightness_setpoint_lux: 500.0
-  k__brightness_alt_setpoint_lux: 400.0
-  lighting_time_delay_s: 600.0     # 30..3600 (manual)
-  lighting_standby_enabled_param: 1          # 0/1 - standby time feature enabled in parameters
-  lighting_standby_duration_s: 1800.0        # 30..3600 (manual)
-  lighting_standby_value_percent: 10.0       # 1..25 (manual)
-
-  # --- Presence channels parameters (C4/C5) ---
-  presence_c4_enabled: 1
-  presence_c4_switch_on_delay_s: 0.0         # 0..1800 (manual)
-  presence_c4_time_delay_s: 900.0            # 10..7200 (manual)
-  presence_c4_send_second_telegram: 0        # 0/1 -> enables C4.2 in addition to C4.1
-
-  presence_c5_enabled: 1
-  presence_c5_switch_on_delay_s: 0.0
-  presence_c5_time_delay_s: 900.0
-  presence_c5_send_second_telegram: 0
-
-  # --- KNX objects (inputs / configuration via bus) ---
-  obj10_external_brightness_lux_in: 280.0
-  obj22_select_alt_setpoint_in: 0
-  obj25_standby_enable_in: 1
-  obj27_lighting_time_delay_in_s: 600.0
-  obj28_lighting_block_in: 0
-  obj29_central_command_in: 0
-  obj33_presence_c4_block_in: 0
-  obj36_presence_c5_block_in: 0
-
-  # Push button overrides share the same group address as outputs. We model them as inbound commands
-  # feeding internal override state, while outputs are sent on separate attributes.
-  obj0_c1_switch_cmd_in: 0
-  obj11_c2_switch_cmd_in: 0
-
-  # --- Internal state/timers ---
-  lighting_timer_s: 0.0
-  standby_timer_s: 0.0
-
-  c1_cmd_prev: 0
-  c2_cmd_prev: 0
-  central_cmd_prev: 0
-
-  c1_manual_on_timer_s: 0.0
-  c2_manual_on_timer_s: 0.0
-  c1_manual_force_off: 0
-  c2_manual_force_off: 0
-
-  presence_c4_on_delay_timer_s: 0.0
-  presence_c4_timer_s: 0.0
-  presence_c5_on_delay_timer_s: 0.0
-  presence_c5_timer_s: 0.0
-
-  trigger_timer_s: 0.0
-  motion_prev: 0
-
-  # --- Derived values / outputs (KNX objects) ---
-  brightness_lux: 280.0
-  active_setpoint_lux: 500.0
-
-  obj9_brightness_out_lux: 280.0
-  obj8_room_correction_factor_out_scaled: 30.0   # factor * 100, reported as 2-byte float
-
-  obj0_c1_switch_out: 0
-  obj11_c2_switch_out: 0
-
-  obj31_presence_c4_1_out: 0
-  obj32_presence_c4_2_out: 0
-  obj34_presence_c5_1_out: 0
-  obj35_presence_c5_2_out: 0
-
-  obj41_parallel_trigger_out: 0
-
+  k__motion_detected:
+    type: int
+    default: 0
+  k__brightness_ceiling_lux:
+    type: float
+    default: 280.0
+    unit: lux
+  brightness_external_lux:
+    type: float
+    default: 280.0
+    unit: lux
+  k__operating_mode:
+    type: str
+    default: master
+  k__master_operating_mode:
+    type: str
+    default: individual_switching
+  parallel_switching_cycle_s:
+    type: float
+    default: 60.0
+    unit: s
+  k__brightness_measurement_source:
+    type: str
+    default: internal
+  room_correction_factor:
+    type: float
+    default: 0.3
+  lighting_channel_c1_function:
+    type: str
+    default: switching
+  lighting_channel_c2_function:
+    type: str
+    default: switching
+  lighting_configuration_type:
+    type: str
+    default: fully_automatic
+  k__brightness_setpoint_lux:
+    type: float
+    default: 500.0
+    unit: lux
+  k__brightness_alt_setpoint_lux:
+    type: float
+    default: 400.0
+    unit: lux
+  lighting_time_delay_s:
+    type: float
+    default: 600.0
+    unit: s
+  lighting_standby_enabled_param:
+    type: int
+    default: 1
+  lighting_standby_duration_s:
+    type: float
+    default: 1800.0
+    unit: s
+  lighting_standby_value_percent:
+    type: float
+    default: 10.0
+    unit: '%'
+  presence_c4_enabled:
+    type: int
+    default: 1
+  presence_c4_switch_on_delay_s:
+    type: float
+    default: 0.0
+    unit: s
+  presence_c4_time_delay_s:
+    type: float
+    default: 900.0
+    unit: s
+  presence_c4_send_second_telegram:
+    type: int
+    default: 0
+  presence_c5_enabled:
+    type: int
+    default: 1
+  presence_c5_switch_on_delay_s:
+    type: float
+    default: 0.0
+    unit: s
+  presence_c5_time_delay_s:
+    type: float
+    default: 900.0
+    unit: s
+  presence_c5_send_second_telegram:
+    type: int
+    default: 0
+  obj10_external_brightness_lux_in:
+    type: float
+    default: 280.0
+  obj22_select_alt_setpoint_in:
+    type: int
+    default: 0
+  obj25_standby_enable_in:
+    type: int
+    default: 1
+  obj27_lighting_time_delay_in_s:
+    type: float
+    default: 600.0
+    unit: s
+  obj28_lighting_block_in:
+    type: int
+    default: 0
+  obj29_central_command_in:
+    type: int
+    default: 0
+  obj33_presence_c4_block_in:
+    type: int
+    default: 0
+  obj36_presence_c5_block_in:
+    type: int
+    default: 0
+  obj0_c1_switch_cmd_in:
+    type: int
+    default: 0
+  obj11_c2_switch_cmd_in:
+    type: int
+    default: 0
+  lighting_timer_s:
+    type: float
+    default: 0.0
+    unit: s
+  standby_timer_s:
+    type: float
+    default: 0.0
+    unit: s
+  c1_cmd_prev:
+    type: int
+    default: 0
+  c2_cmd_prev:
+    type: int
+    default: 0
+  central_cmd_prev:
+    type: int
+    default: 0
+  c1_manual_on_timer_s:
+    type: float
+    default: 0.0
+    unit: s
+  c2_manual_on_timer_s:
+    type: float
+    default: 0.0
+    unit: s
+  c1_manual_force_off:
+    type: int
+    default: 0
+  c2_manual_force_off:
+    type: int
+    default: 0
+  presence_c4_on_delay_timer_s:
+    type: float
+    default: 0.0
+    unit: s
+  presence_c4_timer_s:
+    type: float
+    default: 0.0
+    unit: s
+  presence_c5_on_delay_timer_s:
+    type: float
+    default: 0.0
+    unit: s
+  presence_c5_timer_s:
+    type: float
+    default: 0.0
+    unit: s
+  trigger_timer_s:
+    type: float
+    default: 0.0
+    unit: s
+  motion_prev:
+    type: int
+    default: 0
+  brightness_lux:
+    type: float
+    default: 280.0
+    unit: lux
+  active_setpoint_lux:
+    type: float
+    default: 500.0
+    unit: lux
+  obj9_brightness_out_lux:
+    type: float
+    default: 280.0
+    unit: lux
+  obj8_room_correction_factor_out_scaled:
+    type: float
+    default: 30.0
+  obj0_c1_switch_out:
+    type: int
+    default: 0
+  obj11_c2_switch_out:
+    type: int
+    default: 0
+  obj31_presence_c4_1_out:
+    type: int
+    default: 0
+  obj32_presence_c4_2_out:
+    type: int
+    default: 0
+  obj34_presence_c5_1_out:
+    type: int
+    default: 0
+  obj35_presence_c5_2_out:
+    type: int
+    default: 0
+  obj41_parallel_trigger_out:
+    type: int
+    default: 0
 actions:
   - function: $in(room_correction_factor)
     call: max(0.05, min(2.0, $in(room_correction_factor)))
@@ -127,11 +248,7 @@ actions:
     call: ($in(k__brightness_alt_setpoint_lux) if $in(obj22_select_alt_setpoint_in) == 1 else $in(k__brightness_setpoint_lux))
 
   - function: $in(brightness_lux)
-    call: (
-          max(0.0, $in(brightness_external_lux))
-          if $in(k__brightness_measurement_source) == "external"
-          else max(0.0, $in(k__brightness_ceiling_lux) / $in(room_correction_factor))
-        )
+    call: ( max(0.0, $in(brightness_external_lux)) if $in(k__brightness_measurement_source) == "external" else max(0.0, $in(k__brightness_ceiling_lux) / $in(room_correction_factor)) )
 
   - function: $in(obj9_brightness_out_lux)
     call: $in(brightness_lux)
@@ -145,42 +262,26 @@ actions:
       dt: "$(~.timer.default_step) or $(~.polling.interval) or 0.25"
       rise: "(($in(obj0_c1_switch_cmd_in) == 1) and ($in(c1_cmd_prev) == 0)) or (($in(obj29_central_command_in) == 1) and ($in(central_cmd_prev) == 0))"
       fall: "(($in(obj0_c1_switch_cmd_in) == 0) and ($in(c1_cmd_prev) == 1)) or (($in(obj29_central_command_in) == 0) and ($in(central_cmd_prev) == 1))"
-    call: (
-          1800.0 if rise
-          else 0.0 if fall
-          else max(0.0, $in(c1_manual_on_timer_s) - dt)
-        )
+    call: ( 1800.0 if rise else 0.0 if fall else max(0.0, $in(c1_manual_on_timer_s) - dt) )
 
   - function: $in(c2_manual_on_timer_s)
     params:
       dt: "$(~.timer.default_step) or $(~.polling.interval) or 0.25"
       rise: "(($in(obj11_c2_switch_cmd_in) == 1) and ($in(c2_cmd_prev) == 0)) or (($in(obj29_central_command_in) == 1) and ($in(central_cmd_prev) == 0))"
       fall: "(($in(obj11_c2_switch_cmd_in) == 0) and ($in(c2_cmd_prev) == 1)) or (($in(obj29_central_command_in) == 0) and ($in(central_cmd_prev) == 1))"
-    call: (
-          1800.0 if rise
-          else 0.0 if fall
-          else max(0.0, $in(c2_manual_on_timer_s) - dt)
-        )
+    call: ( 1800.0 if rise else 0.0 if fall else max(0.0, $in(c2_manual_on_timer_s) - dt) )
 
   - function: $in(c1_manual_force_off)
     params:
       fall: "(($in(obj0_c1_switch_cmd_in) == 0) and ($in(c1_cmd_prev) == 1)) or (($in(obj29_central_command_in) == 0) and ($in(central_cmd_prev) == 1))"
       rise: "(($in(obj0_c1_switch_cmd_in) == 1) and ($in(c1_cmd_prev) == 0)) or (($in(obj29_central_command_in) == 1) and ($in(central_cmd_prev) == 0))"
-    call: (
-          1 if fall
-          else 0 if rise
-          else (0 if ($in(c1_manual_force_off) == 1 and $in(lighting_timer_s) == 0) else $in(c1_manual_force_off))
-        )
+    call: ( 1 if fall else 0 if rise else (0 if ($in(c1_manual_force_off) == 1 and $in(lighting_timer_s) == 0) else $in(c1_manual_force_off)) )
 
   - function: $in(c2_manual_force_off)
     params:
       fall: "(($in(obj11_c2_switch_cmd_in) == 0) and ($in(c2_cmd_prev) == 1)) or (($in(obj29_central_command_in) == 0) and ($in(central_cmd_prev) == 1))"
       rise: "(($in(obj11_c2_switch_cmd_in) == 1) and ($in(c2_cmd_prev) == 0)) or (($in(obj29_central_command_in) == 1) and ($in(central_cmd_prev) == 0))"
-    call: (
-          1 if fall
-          else 0 if rise
-          else (0 if ($in(c2_manual_force_off) == 1 and $in(lighting_timer_s) == 0) else $in(c2_manual_force_off))
-        )
+    call: ( 1 if fall else 0 if rise else (0 if ($in(c2_manual_force_off) == 1 and $in(lighting_timer_s) == 0) else $in(c2_manual_force_off)) )
 
   - function: $in(c1_cmd_prev)
     call: $in(obj0_c1_switch_cmd_in)
@@ -196,24 +297,12 @@ actions:
     params:
       dt: "$(~.timer.default_step) or $(~.polling.interval) or 0.25"
       any_lighting: "($in(lighting_channel_c1_function) != \"inactive\") or ($in(lighting_channel_c2_function) != \"inactive\")"
-    call: (
-          0.0
-          if ($in(k__operating_mode) == "slave") or (not any_lighting)
-          else (
-            $in(lighting_time_delay_s)
-            if $in(k__motion_detected) == 1
-            else max(0.0, $in(lighting_timer_s) - dt)
-          )
-        )
+    call: ( 0.0 if ($in(k__operating_mode) == "slave") or (not any_lighting) else ( $in(lighting_time_delay_s) if $in(k__motion_detected) == 1 else max(0.0, $in(lighting_timer_s) - dt) ) )
 
   - function: $in(standby_timer_s)
     params:
       dt: "$(~.timer.default_step) or $(~.polling.interval) or 0.25"
-    call: (
-          $in(lighting_standby_duration_s)
-          if $in(lighting_timer_s) > 0
-          else max(0.0, $in(standby_timer_s) - dt)
-        )
+    call: ( $in(lighting_standby_duration_s) if $in(lighting_timer_s) > 0 else max(0.0, $in(standby_timer_s) - dt) )
 
   - function: $in(obj0_c1_switch_out)
     params:
@@ -222,22 +311,7 @@ actions:
       standby_active: "($in(lighting_standby_enabled_param) == 1) and ($in(obj25_standby_enable_in) == 1) and ($in(lighting_timer_s) == 0) and ($in(standby_timer_s) > 0)"
       should_auto_on: "($in(lighting_timer_s) > 0) and (measurement_off or ($in(c1_manual_on_timer_s) > 0) or ($in(brightness_lux) < $in(active_setpoint_lux)))"
       should_semi_on: "($in(lighting_timer_s) > 0) and ($in(c1_manual_on_timer_s) > 0)"
-    call: (
-          0
-          if ($in(k__operating_mode) == "slave")
-             or ($in(lighting_channel_c1_function) == "inactive")
-             or blocked
-          else (
-            0 if $in(c1_manual_force_off) == 1
-            else (
-              1 if standby_active
-              else (
-                1 if ($in(lighting_configuration_type) == "semi_automatic" and should_semi_on)
-                else (1 if ($in(lighting_configuration_type) != "semi_automatic" and should_auto_on) else 0)
-              )
-            )
-          )
-        )
+    call: ( 0 if ($in(k__operating_mode) == "slave") or ($in(lighting_channel_c1_function) == "inactive") or blocked else ( 0 if $in(c1_manual_force_off) == 1 else ( 1 if standby_active else ( 1 if ($in(lighting_configuration_type) == "semi_automatic" and should_semi_on) else (1 if ($in(lighting_configuration_type) != "semi_automatic" and should_auto_on) else 0) ) ) ) )
 
   - function: $in(obj11_c2_switch_out)
     params:
@@ -246,93 +320,42 @@ actions:
       standby_active: "($in(lighting_standby_enabled_param) == 1) and ($in(obj25_standby_enable_in) == 1) and ($in(lighting_timer_s) == 0) and ($in(standby_timer_s) > 0)"
       should_auto_on: "($in(lighting_timer_s) > 0) and (measurement_off or ($in(c2_manual_on_timer_s) > 0) or ($in(brightness_lux) < $in(active_setpoint_lux)))"
       should_semi_on: "($in(lighting_timer_s) > 0) and ($in(c2_manual_on_timer_s) > 0)"
-    call: (
-          0
-          if ($in(k__operating_mode) == "slave")
-             or ($in(lighting_channel_c2_function) == "inactive")
-             or blocked
-          else (
-            0 if $in(c2_manual_force_off) == 1
-            else (
-              1 if standby_active
-              else (
-                1 if ($in(lighting_configuration_type) == "semi_automatic" and should_semi_on)
-                else (1 if ($in(lighting_configuration_type) != "semi_automatic" and should_auto_on) else 0)
-              )
-            )
-          )
-        )
+    call: ( 0 if ($in(k__operating_mode) == "slave") or ($in(lighting_channel_c2_function) == "inactive") or blocked else ( 0 if $in(c2_manual_force_off) == 1 else ( 1 if standby_active else ( 1 if ($in(lighting_configuration_type) == "semi_automatic" and should_semi_on) else (1 if ($in(lighting_configuration_type) != "semi_automatic" and should_auto_on) else 0) ) ) ) )
 
   # --- Presence channels C4/C5 (basic ON/OFF behavior, switch command style) ---
   - function: $in(presence_c4_on_delay_timer_s)
     params:
       dt: "$(~.timer.default_step) or $(~.polling.interval) or 0.25"
-    call: (
-          0.0
-          if ($in(presence_c4_enabled) == 0) or ($in(obj33_presence_c4_block_in) == 1) or ($in(k__motion_detected) == 0 and $in(presence_c4_timer_s) == 0)
-          else (
-            min($in(presence_c4_switch_on_delay_s), $in(presence_c4_on_delay_timer_s) + dt)
-            if $in(k__motion_detected) == 1
-            else $in(presence_c4_on_delay_timer_s)
-          )
-        )
+    call: ( 0.0 if ($in(presence_c4_enabled) == 0) or ($in(obj33_presence_c4_block_in) == 1) or ($in(k__motion_detected) == 0 and $in(presence_c4_timer_s) == 0) else ( min($in(presence_c4_switch_on_delay_s), $in(presence_c4_on_delay_timer_s) + dt) if $in(k__motion_detected) == 1 else $in(presence_c4_on_delay_timer_s) ) )
 
   - function: $in(presence_c4_timer_s)
     params:
       dt: "$(~.timer.default_step) or $(~.polling.interval) or 0.25"
       delay_ok: "$in(presence_c4_on_delay_timer_s) >= $in(presence_c4_switch_on_delay_s)"
-    call: (
-          0.0
-          if ($in(presence_c4_enabled) == 0) or ($in(obj33_presence_c4_block_in) == 1) or (not delay_ok)
-          else (
-            $in(presence_c4_time_delay_s) if $in(k__motion_detected) == 1 else max(0.0, $in(presence_c4_timer_s) - dt)
-          )
-        )
+    call: ( 0.0 if ($in(presence_c4_enabled) == 0) or ($in(obj33_presence_c4_block_in) == 1) or (not delay_ok) else ( $in(presence_c4_time_delay_s) if $in(k__motion_detected) == 1 else max(0.0, $in(presence_c4_timer_s) - dt) ) )
 
   - function: $in(obj31_presence_c4_1_out)
     call: 1 if ($in(presence_c4_enabled) == 1 and $in(obj33_presence_c4_block_in) == 0 and $in(presence_c4_timer_s) > 0) else 0
 
   - function: $in(obj32_presence_c4_2_out)
-    call: (
-          $in(obj31_presence_c4_1_out)
-          if $in(presence_c4_send_second_telegram) == 1
-          else 0
-        )
+    call: ( $in(obj31_presence_c4_1_out) if $in(presence_c4_send_second_telegram) == 1 else 0 )
 
   - function: $in(presence_c5_on_delay_timer_s)
     params:
       dt: "$(~.timer.default_step) or $(~.polling.interval) or 0.25"
-    call: (
-          0.0
-          if ($in(presence_c5_enabled) == 0) or ($in(obj36_presence_c5_block_in) == 1) or ($in(k__motion_detected) == 0 and $in(presence_c5_timer_s) == 0)
-          else (
-            min($in(presence_c5_switch_on_delay_s), $in(presence_c5_on_delay_timer_s) + dt)
-            if $in(k__motion_detected) == 1
-            else $in(presence_c5_on_delay_timer_s)
-          )
-        )
+    call: ( 0.0 if ($in(presence_c5_enabled) == 0) or ($in(obj36_presence_c5_block_in) == 1) or ($in(k__motion_detected) == 0 and $in(presence_c5_timer_s) == 0) else ( min($in(presence_c5_switch_on_delay_s), $in(presence_c5_on_delay_timer_s) + dt) if $in(k__motion_detected) == 1 else $in(presence_c5_on_delay_timer_s) ) )
 
   - function: $in(presence_c5_timer_s)
     params:
       dt: "$(~.timer.default_step) or $(~.polling.interval) or 0.25"
       delay_ok: "$in(presence_c5_on_delay_timer_s) >= $in(presence_c5_switch_on_delay_s)"
-    call: (
-          0.0
-          if ($in(presence_c5_enabled) == 0) or ($in(obj36_presence_c5_block_in) == 1) or (not delay_ok)
-          else (
-            $in(presence_c5_time_delay_s) if $in(k__motion_detected) == 1 else max(0.0, $in(presence_c5_timer_s) - dt)
-          )
-        )
+    call: ( 0.0 if ($in(presence_c5_enabled) == 0) or ($in(obj36_presence_c5_block_in) == 1) or (not delay_ok) else ( $in(presence_c5_time_delay_s) if $in(k__motion_detected) == 1 else max(0.0, $in(presence_c5_timer_s) - dt) ) )
 
   - function: $in(obj34_presence_c5_1_out)
     call: 1 if ($in(presence_c5_enabled) == 1 and $in(obj36_presence_c5_block_in) == 0 and $in(presence_c5_timer_s) > 0) else 0
 
   - function: $in(obj35_presence_c5_2_out)
-    call: (
-          $in(obj34_presence_c5_1_out)
-          if $in(presence_c5_send_second_telegram) == 1
-          else 0
-        )
+    call: ( $in(obj34_presence_c5_1_out) if $in(presence_c5_send_second_telegram) == 1 else 0 )
 
   # --- Parallel switching trigger (pulse/toggle) ---
   - function: $in(obj41_parallel_trigger_out)
@@ -344,14 +367,7 @@ actions:
     params:
       dt: "$(~.timer.default_step) or $(~.polling.interval) or 0.25"
       enabled: "($in(k__operating_mode) == \"slave\") or ($in(k__master_operating_mode) == \"parallel_switching\")"
-    call: (
-          0.0
-          if (not enabled) or ($in(k__motion_detected) == 0)
-          else (
-            0.0 if $in(trigger_timer_s) >= $in(parallel_switching_cycle_s)
-            else min($in(parallel_switching_cycle_s), $in(trigger_timer_s) + dt)
-          )
-        )
+    call: ( 0.0 if (not enabled) or ($in(k__motion_detected) == 0) else ( 0.0 if $in(trigger_timer_s) >= $in(parallel_switching_cycle_s) else min($in(parallel_switching_cycle_s), $in(trigger_timer_s) + dt) ) )
 
   - function: $in(motion_prev)
     call: $in(k__motion_detected)
@@ -476,6 +492,7 @@ communication:
 scenarios:
   motion_detected:
     duration: 20.0
+    display_name: "Motion Detected"
     description: "Presence detected with low ambient light."
     overrides:
       $in(k__motion_detected): 1
@@ -484,6 +501,7 @@ scenarios:
 
   manual_switch_c1:
     duration: 10.0
+    display_name: "Manual Switch C1"
     description: "Manual toggle of channel C1 via KNX."
     overrides:
       $in(obj0_c1_switch_cmd_in): 1
@@ -491,6 +509,7 @@ scenarios:
 
   parallel_switching_pulse:
     duration: 12.0
+    display_name: "Parallel Switching Pulse"
     description: "Parallel switching trigger based on motion."
     overrides:
       $in(k__master_operating_mode): parallel_switching

--- a/library/domains/building/thermostat/generic/thermostat__matter.yaml
+++ b/library/domains/building/thermostat/generic/thermostat__matter.yaml
@@ -2,30 +2,64 @@
 
 name: thermostat__matter
 description: |
-  Virtual thermostat published over Matter clusters. Matches python-matter-server API surface
-  used by Home Assistant; values are scaled to the 0.01 °C resolution Matter expects.
+  Virtual thermostat published over Matter clusters. Matches the
+  python-matter-server API surface used by Home Assistant; values are scaled to
+  the 0.01 degC resolution Matter expects.
 
 attributes:
-  room_temperature_c: 22.5
-  room_setpoint_c: 22.0
-  room_command_raw: 2200           # 0.01 °C units written by Matter
-  room_command_c: 22.0
-  measured_value_raw: 2250         # TemperatureMeasurement.MeasuredValue (0.01 °C)
-  heating_setpoint_raw: 2200       # Thermostat.OccupiedHeatingSetpoint (0.01 °C)
-  hvac_mode: heat                  # heat/cool/auto/off
-  hvac_mode_code: 3                # Thermostat.SystemMode: 0=off,1=auto,2=cool,3=heat
-  hvac_active: 1
+  room_temperature_c:
+    type: float
+    default: 22.5
+    unit: degC
+  room_setpoint_c:
+    type: float
+    default: 22.0
+    unit: degC
+  room_command_raw:
+    type: int
+    default: 2200
+  room_command_c:
+    type: float
+    default: 22.0
+    unit: degC
+  measured_value_raw:
+    type: int
+    default: 2250
+  heating_setpoint_raw:
+    type: int
+    default: 2200
+  hvac_mode:
+    type: str
+    default: "heat"
+  hvac_mode_code:
+    type: int
+    default: 3
+  hvac_active:
+    type: int
+    default: 1
 
-  min_setpoint_c: 15.0
-  max_setpoint_c: 28.0
-  setpoint_step_k: 0.5
+  min_setpoint_c:
+    type: float
+    default: 15.0
+    unit: degC
+  max_setpoint_c:
+    type: float
+    default: 28.0
+    unit: degC
+  setpoint_step_k:
+    type: float
+    default: 0.5
+    unit: K
 
-  cycle_time_s: 0.5
+  cycle_time_s:
+    type: float
+    default: 0.5
+    unit: s
 
 actions:
   - function: $in(room_command_c)
     name: convert_command_raw_to_c
-    description: Convert inbound Matter raw setpoint to °C.
+    description: Convert inbound Matter raw setpoint to degC.
     call: $in(room_command_raw) / 100.0
 
   - function: $in(room_setpoint_c)
@@ -56,12 +90,12 @@ actions:
 
   - function: $in(measured_value_raw)
     name: encode_measured_value
-    description: Matter TemperatureMeasurement encodes 0.01 °C units.
+    description: Matter TemperatureMeasurement encodes 0.01 degC units.
     call: int(round($in(room_temperature_c) * 100.0))
 
   - function: $in(heating_setpoint_raw)
     name: encode_heating_setpoint
-    description: Matter Thermostat setpoint in 0.01 °C units.
+    description: Matter Thermostat setpoint in 0.01 degC units.
     call: int(round($in(room_setpoint_c) * 100.0))
 
   - function: $in(hvac_mode_code)

--- a/library/domains/building/zone/generic/lighting_zone__knx.yaml
+++ b/library/domains/building/zone/generic/lighting_zone__knx.yaml
@@ -20,22 +20,55 @@ meta_parameters:
     default: "1"
 
 attributes:
-  k__zone_state: automatic        # automatic/manual/off
-  k__scene_active: default
-  k__occupancy_detected: 1
-  k__daylight_lux: 280.0
+  k__zone_state:
+    type: str
+    default: "automatic"
+  k__scene_active:
+    type: str
+    default: "default"
+  k__occupancy_detected:
+    type: int
+    default: 1
+  k__daylight_lux:
+    type: float
+    default: 280.0
+    unit: lx
 
-  circuit_a_level_percent: 65.0
-  k__circuit_a_target_percent: 70.0
-  circuit_b_level_percent: 25.0
-  k__circuit_b_target_percent: 30.0
+  circuit_a_level_percent:
+    type: float
+    default: 65.0
+    unit: percent
+  k__circuit_a_target_percent:
+    type: float
+    default: 70.0
+    unit: percent
+  circuit_b_level_percent:
+    type: float
+    default: 25.0
+    unit: percent
+  k__circuit_b_target_percent:
+    type: float
+    default: 30.0
+    unit: percent
 
-  k__emergency_override: 0
-  alarm_emergency: 0
-  alarm_failure: 0
+  k__emergency_override:
+    type: int
+    default: 0
+  alarm_emergency:
+    type: int
+    default: 0
+  alarm_failure:
+    type: int
+    default: 0
 
-  energy_today_kwh: 4.2
-  cycle_time_s: 0.5
+  energy_today_kwh:
+    type: float
+    default: 4.2
+    unit: kWh
+  cycle_time_s:
+    type: float
+    default: 0.5
+    unit: s
 
 actions:
   - function: $in(circuit_a_level_percent)
@@ -155,6 +188,8 @@ communication:
 
 scenarios:
   workday_scene:
+    display_name: "Workday Scene"
+    description: Apply normal automatic workday lighting targets.
     duration: 15.0
     overrides:
       $in(k__zone_state): automatic
@@ -163,6 +198,8 @@ scenarios:
       $in(k__circuit_b_target_percent): 40.0
 
   cleaning_scene:
+    display_name: "Cleaning Scene"
+    description: Override the zone into a brighter manual cleaning scene.
     duration: 10.0
     overrides:
       $in(k__zone_state): manual
@@ -171,6 +208,8 @@ scenarios:
       $in(k__circuit_b_target_percent): 80.0
 
   night_shutdown:
+    display_name: "Night Shutdown"
+    description: Turn the zone off and clear occupancy for night operation.
     duration: 25.0
     overrides:
       $in(k__zone_state): off

--- a/library/domains/energy/meter/abb/abb_d13_15__modbus.yaml
+++ b/library/domains/energy/meter/abb/abb_d13_15__modbus.yaml
@@ -17,80 +17,194 @@ meta_parameters:
 
 attributes:
   # Phase-to-neutral voltages (V)
-  k__voltage_l1_n_v: 230.0
-  k__voltage_l2_n_v: 229.5
-  k__voltage_l3_n_v: 231.0
-
-  # Line-to-line voltages (V)
-  voltage_l1_l2_v: 0.0
-  voltage_l2_l3_v: 0.0
-  voltage_l1_l3_v: 0.0
-
-  # Phase currents (A)
-  k__current_l1_a: 12.0
-  k__current_l2_a: 10.5
-  k__current_l3_a: 11.2
-  current_n_a: 0.0
-
-  # Power + power factor
-  k__power_factor: 0.96
-  power_factor_leading: 0
-  power_factor_l1: 0.0
-  power_factor_l2: 0.0
-  power_factor_l3: 0.0
-
-  active_power_l1_w: 0.0
-  active_power_l2_w: 0.0
-  active_power_l3_w: 0.0
-  k__active_power_total_w: 0.0
-
-  reactive_power_l1_var: 0.0
-  reactive_power_l2_var: 0.0
-  reactive_power_l3_var: 0.0
-  k__reactive_power_total_var: 0.0
-
-  apparent_power_l1_va: 0.0
-  apparent_power_l2_va: 0.0
-  apparent_power_l3_va: 0.0
-  k__apparent_power_total_va: 0.0
-
-  # Frequency (Hz)
-  k__frequency_hz: 50.0
-
-  # Raw register values (Modbus holding registers)
-  voltage_l1_n_raw: 0
-  voltage_l2_n_raw: 0
-  voltage_l3_n_raw: 0
-  voltage_l1_l2_raw: 0
-  voltage_l2_l3_raw: 0
-  voltage_l1_l3_raw: 0
-
-  current_l1_raw: 0
-  current_l2_raw: 0
-  current_l3_raw: 0
-  current_n_raw: 0
-
-  active_power_total_raw: 0
-  active_power_l1_raw: 0
-  active_power_l2_raw: 0
-  active_power_l3_raw: 0
-
-  reactive_power_total_raw: 0
-  reactive_power_l1_raw: 0
-  reactive_power_l2_raw: 0
-  reactive_power_l3_raw: 0
-
-  apparent_power_total_raw: 0
-  apparent_power_l1_raw: 0
-  apparent_power_l2_raw: 0
-  apparent_power_l3_raw: 0
-
-  frequency_raw: 0
-  power_factor_total_raw: 0
-  power_factor_l1_raw: 0
-  power_factor_l2_raw: 0
-  power_factor_l3_raw: 0
-
+  k__voltage_l1_n_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__voltage_l2_n_v:
+    type: float
+    default: 229.5
+    unit: V
+  k__voltage_l3_n_v:
+    type: float
+    default: 231.0
+    unit: V
+  voltage_l1_l2_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l2_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l1_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  k__current_l1_a:
+    type: float
+    default: 12.0
+    unit: A
+  k__current_l2_a:
+    type: float
+    default: 10.5
+    unit: A
+  k__current_l3_a:
+    type: float
+    default: 11.2
+    unit: A
+  current_n_a:
+    type: float
+    default: 0.0
+    unit: A
+  k__power_factor:
+    type: float
+    default: 0.96
+  power_factor_leading:
+    type: int
+    default: 0
+  power_factor_l1:
+    type: float
+    default: 0.0
+  power_factor_l2:
+    type: float
+    default: 0.0
+  power_factor_l3:
+    type: float
+    default: 0.0
+  active_power_l1_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_l2_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_l3_w:
+    type: float
+    default: 0.0
+    unit: W
+  k__active_power_total_w:
+    type: float
+    default: 0.0
+    unit: W
+  reactive_power_l1_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_l2_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_l3_var:
+    type: float
+    default: 0.0
+    unit: var
+  k__reactive_power_total_var:
+    type: float
+    default: 0.0
+    unit: var
+  apparent_power_l1_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_l2_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_l3_va:
+    type: float
+    default: 0.0
+    unit: VA
+  k__apparent_power_total_va:
+    type: float
+    default: 0.0
+    unit: VA
+  k__frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  voltage_l1_n_raw:
+    type: int
+    default: 0
+  voltage_l2_n_raw:
+    type: int
+    default: 0
+  voltage_l3_n_raw:
+    type: int
+    default: 0
+  voltage_l1_l2_raw:
+    type: int
+    default: 0
+  voltage_l2_l3_raw:
+    type: int
+    default: 0
+  voltage_l1_l3_raw:
+    type: int
+    default: 0
+  current_l1_raw:
+    type: int
+    default: 0
+  current_l2_raw:
+    type: int
+    default: 0
+  current_l3_raw:
+    type: int
+    default: 0
+  current_n_raw:
+    type: int
+    default: 0
+  active_power_total_raw:
+    type: int
+    default: 0
+  active_power_l1_raw:
+    type: int
+    default: 0
+  active_power_l2_raw:
+    type: int
+    default: 0
+  active_power_l3_raw:
+    type: int
+    default: 0
+  reactive_power_total_raw:
+    type: int
+    default: 0
+  reactive_power_l1_raw:
+    type: int
+    default: 0
+  reactive_power_l2_raw:
+    type: int
+    default: 0
+  reactive_power_l3_raw:
+    type: int
+    default: 0
+  apparent_power_total_raw:
+    type: int
+    default: 0
+  apparent_power_l1_raw:
+    type: int
+    default: 0
+  apparent_power_l2_raw:
+    type: int
+    default: 0
+  apparent_power_l3_raw:
+    type: int
+    default: 0
+  frequency_raw:
+    type: int
+    default: 0
+  power_factor_total_raw:
+    type: int
+    default: 0
+  power_factor_l1_raw:
+    type: int
+    default: 0
+  power_factor_l2_raw:
+    type: int
+    default: 0
+  power_factor_l3_raw:
+    type: int
+    default: 0
 actions:
   - function: $in(voltage_l1_l2_v)
     name: compute_voltage_l1_l2
@@ -170,30 +284,22 @@ actions:
   - function: $in(reactive_power_l1_var)
     name: compute_reactive_power_l1
     description: Phase L1 reactive power (magnitude from S and P).
-    call: (
-          max(0.0, ($in(apparent_power_l1_va) ** 2) - ($in(active_power_l1_w) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(apparent_power_l1_va) ** 2) - ($in(active_power_l1_w) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(reactive_power_l2_var)
     name: compute_reactive_power_l2
     description: Phase L2 reactive power (magnitude from S and P).
-    call: (
-          max(0.0, ($in(apparent_power_l2_va) ** 2) - ($in(active_power_l2_w) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(apparent_power_l2_va) ** 2) - ($in(active_power_l2_w) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(reactive_power_l3_var)
     name: compute_reactive_power_l3
     description: Phase L3 reactive power (magnitude from S and P).
-    call: (
-          max(0.0, ($in(apparent_power_l3_va) ** 2) - ($in(active_power_l3_w) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(apparent_power_l3_va) ** 2) - ($in(active_power_l3_w) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(k__reactive_power_total_var)
     name: compute_reactive_power_total
     description: Total reactive power (magnitude from S and P).
-    call: (
-          max(0.0, ($in(k__apparent_power_total_va) ** 2) - ($in(k__active_power_total_w) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(k__apparent_power_total_va) ** 2) - ($in(k__active_power_total_w) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(voltage_l1_n_raw)
     name: encode_voltage_l1_n
@@ -338,46 +444,47 @@ communication:
       zero_fill: true
       mapping:
         # Voltages (0.1 V resolution, unsigned 32-bit)
-        voltage_l1_n_raw:  { address: [23296,23297], group: h_r, type: uint_32 }
-        voltage_l2_n_raw:  { address: [23298,23299], group: h_r, type: uint_32 }
-        voltage_l3_n_raw:  { address: [23300,23301], group: h_r, type: uint_32 }
-        voltage_l1_l2_raw: { address: [23302,23303], group: h_r, type: uint_32 }
-        voltage_l2_l3_raw: { address: [23304,23305], group: h_r, type: uint_32 }
-        voltage_l1_l3_raw: { address: [23306,23307], group: h_r, type: uint_32 }
+        voltage_l1_n_raw: {address: [23296, 23297], group: h_r, type: uint_32}
+        voltage_l2_n_raw: {address: [23298, 23299], group: h_r, type: uint_32}
+        voltage_l3_n_raw: {address: [23300, 23301], group: h_r, type: uint_32}
+        voltage_l1_l2_raw: {address: [23302, 23303], group: h_r, type: uint_32}
+        voltage_l2_l3_raw: {address: [23304, 23305], group: h_r, type: uint_32}
+        voltage_l1_l3_raw: {address: [23306, 23307], group: h_r, type: uint_32}
 
         # Currents (0.01 A resolution, unsigned 32-bit)
-        current_l1_raw: { address: [23308,23309], group: h_r, type: uint_32 }
-        current_l2_raw: { address: [23310,23311], group: h_r, type: uint_32 }
-        current_l3_raw: { address: [23312,23313], group: h_r, type: uint_32 }
-        current_n_raw:  { address: [23314,23315], group: h_r, type: uint_32 }
+        current_l1_raw: {address: [23308, 23309], group: h_r, type: uint_32}
+        current_l2_raw: {address: [23310, 23311], group: h_r, type: uint_32}
+        current_l3_raw: {address: [23312, 23313], group: h_r, type: uint_32}
+        current_n_raw: {address: [23314, 23315], group: h_r, type: uint_32}
 
         # Active power (0.01 W resolution, signed 32-bit stored as two's complement)
-        active_power_total_raw: { address: [23316,23317], group: h_r, type: uint_32 }
-        active_power_l1_raw:    { address: [23318,23319], group: h_r, type: uint_32 }
-        active_power_l2_raw:    { address: [23320,23321], group: h_r, type: uint_32 }
-        active_power_l3_raw:    { address: [23322,23323], group: h_r, type: uint_32 }
+        active_power_total_raw: {address: [23316, 23317], group: h_r, type: uint_32}
+        active_power_l1_raw: {address: [23318, 23319], group: h_r, type: uint_32}
+        active_power_l2_raw: {address: [23320, 23321], group: h_r, type: uint_32}
+        active_power_l3_raw: {address: [23322, 23323], group: h_r, type: uint_32}
 
         # Reactive power (0.01 var resolution, signed 32-bit stored as two's complement)
-        reactive_power_total_raw: { address: [23324,23325], group: h_r, type: uint_32 }
-        reactive_power_l1_raw:    { address: [23326,23327], group: h_r, type: uint_32 }
-        reactive_power_l2_raw:    { address: [23328,23329], group: h_r, type: uint_32 }
-        reactive_power_l3_raw:    { address: [23330,23331], group: h_r, type: uint_32 }
+        reactive_power_total_raw: {address: [23324, 23325], group: h_r, type: uint_32}
+        reactive_power_l1_raw: {address: [23326, 23327], group: h_r, type: uint_32}
+        reactive_power_l2_raw: {address: [23328, 23329], group: h_r, type: uint_32}
+        reactive_power_l3_raw: {address: [23330, 23331], group: h_r, type: uint_32}
 
         # Apparent power (0.01 VA resolution, signed 32-bit stored as two's complement)
-        apparent_power_total_raw: { address: [23332,23333], group: h_r, type: uint_32 }
-        apparent_power_l1_raw:    { address: [23334,23335], group: h_r, type: uint_32 }
-        apparent_power_l2_raw:    { address: [23336,23337], group: h_r, type: uint_32 }
-        apparent_power_l3_raw:    { address: [23338,23339], group: h_r, type: uint_32 }
+        apparent_power_total_raw: {address: [23332, 23333], group: h_r, type: uint_32}
+        apparent_power_l1_raw: {address: [23334, 23335], group: h_r, type: uint_32}
+        apparent_power_l2_raw: {address: [23336, 23337], group: h_r, type: uint_32}
+        apparent_power_l3_raw: {address: [23338, 23339], group: h_r, type: uint_32}
 
         # Frequency + power factor
-        frequency_raw:         { address: [23340,23340], group: h_r, type: uint_16 }
-        power_factor_total_raw: { address: [23354,23354], group: h_r, type: uint_16 }
-        power_factor_l1_raw:    { address: [23355,23355], group: h_r, type: uint_16 }
-        power_factor_l2_raw:    { address: [23356,23356], group: h_r, type: uint_16 }
-        power_factor_l3_raw:    { address: [23357,23357], group: h_r, type: uint_16 }
+        frequency_raw: {address: [23340, 23340], group: h_r, type: uint_16}
+        power_factor_total_raw: {address: [23354, 23354], group: h_r, type: uint_16}
+        power_factor_l1_raw: {address: [23355, 23355], group: h_r, type: uint_16}
+        power_factor_l2_raw: {address: [23356, 23356], group: h_r, type: uint_16}
+        power_factor_l3_raw: {address: [23357, 23357], group: h_r, type: uint_16}
 
 scenarios:
   peak_demand:
+    display_name: Peak Demand
     description: High load with balanced phases and near-unity power factor.
     duration: 30.0
     overrides:
@@ -388,6 +495,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   pv_export:
+    display_name: PV Export
     description: Simulated PV export using negative phase currents.
     duration: 30.0
     overrides:
@@ -398,6 +506,7 @@ scenarios:
       $in(power_factor_leading): 1
 
   voltage_sag:
+    display_name: Voltage Sag
     description: Phase-to-neutral voltage sag across all phases.
     duration: 30.0
     overrides:
@@ -406,6 +515,7 @@ scenarios:
       $in(k__voltage_l3_n_v): 210.0
 
   frequency_drift:
+    display_name: Frequency Drift
     description: Off-nominal grid frequency condition.
     duration: 20.0
     overrides:

--- a/library/domains/energy/meter/carlo_gavazzi/carlo_gavazzi_em24__modbus.yaml
+++ b/library/domains/energy/meter/carlo_gavazzi/carlo_gavazzi_em24__modbus.yaml
@@ -17,90 +17,222 @@ meta_parameters:
 
 attributes:
   # Phase-to-neutral voltages (V)
-  k__voltage_l1_n_v: 230.0
-  k__voltage_l2_n_v: 231.0
-  k__voltage_l3_n_v: 229.5
-
-  # Phase currents (A)
-  k__current_l1_a: 8.5
-  k__current_l2_a: 8.1
-  k__current_l3_a: 8.3
-
-  # Per-phase power factor inputs
-  k__power_factor_l1: 0.96
-  k__power_factor_l2: 0.95
-  k__power_factor_l3: 0.97
-
-  # Frequency (Hz)
-  k__frequency_hz: 50.0
-
-  # Derived line-to-line voltages (V)
-  voltage_l1_l2_v: 0.0
-  voltage_l2_l3_v: 0.0
-  voltage_l3_l1_v: 0.0
-  voltage_ln_sum_v: 0.0
-  voltage_ll_sum_v: 0.0
-
-  # Power (W/VA/VAR)
-  active_power_l1_w: 0.0
-  active_power_l2_w: 0.0
-  active_power_l3_w: 0.0
-  active_power_total_w: 0.0
-
-  apparent_power_l1_va: 0.0
-  apparent_power_l2_va: 0.0
-  apparent_power_l3_va: 0.0
-  apparent_power_total_va: 0.0
-
-  reactive_power_l1_var: 0.0
-  reactive_power_l2_var: 0.0
-  reactive_power_l3_var: 0.0
-  reactive_power_total_var: 0.0
-
-  power_factor_total: 0.0
-
-  # Energy totals (kWh)
-  energy_import_total_kwh: 0.0
-  energy_export_total_kwh: 0.0
-
-  # Phase sequence (123 for L1-L2-L3, 132 for L1-L3-L2)
-  phase_sequence: 123
-
-  _cycle_time_s: 1.0
-
-  # Raw Modbus register payloads (scaled integer values)
-  _v_l1_n_raw: 0
-  _v_l2_n_raw: 0
-  _v_l3_n_raw: 0
-  _v_l1_l2_raw: 0
-  _v_l2_l3_raw: 0
-  _v_l3_l1_raw: 0
-  _a_l1_raw: 0
-  _a_l2_raw: 0
-  _a_l3_raw: 0
-  _w_l1_raw: 0
-  _w_l2_raw: 0
-  _w_l3_raw: 0
-  _va_l1_raw: 0
-  _va_l2_raw: 0
-  _va_l3_raw: 0
-  _var_l1_raw: 0
-  _var_l2_raw: 0
-  _var_l3_raw: 0
-  _v_ln_sum_raw: 0
-  _v_ll_sum_raw: 0
-  _w_sum_raw: 0
-  _va_sum_raw: 0
-  _var_sum_raw: 0
-  _pf_l1_raw: 0
-  _pf_l2_raw: 0
-  _pf_l3_raw: 0
-  _pf_sum_raw: 0
-  _phase_sequence_raw: 123
-  _hz_raw: 0
-  _kwh_import_raw: 0
-  _kwh_export_raw: 0
-
+  k__voltage_l1_n_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__voltage_l2_n_v:
+    type: float
+    default: 231.0
+    unit: V
+  k__voltage_l3_n_v:
+    type: float
+    default: 229.5
+    unit: V
+  k__current_l1_a:
+    type: float
+    default: 8.5
+    unit: A
+  k__current_l2_a:
+    type: float
+    default: 8.1
+    unit: A
+  k__current_l3_a:
+    type: float
+    default: 8.3
+    unit: A
+  k__power_factor_l1:
+    type: float
+    default: 0.96
+  k__power_factor_l2:
+    type: float
+    default: 0.95
+  k__power_factor_l3:
+    type: float
+    default: 0.97
+  k__frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  voltage_l1_l2_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l2_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l3_l1_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_ln_sum_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_ll_sum_v:
+    type: float
+    default: 0.0
+    unit: V
+  active_power_l1_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_l2_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_l3_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_total_w:
+    type: float
+    default: 0.0
+    unit: W
+  apparent_power_l1_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_l2_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_l3_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_total_va:
+    type: float
+    default: 0.0
+    unit: VA
+  reactive_power_l1_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_l2_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_l3_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_total_var:
+    type: float
+    default: 0.0
+    unit: var
+  power_factor_total:
+    type: float
+    default: 0.0
+  energy_import_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  energy_export_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  phase_sequence:
+    type: int
+    default: 123
+  _cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
+  _v_l1_n_raw:
+    type: int
+    default: 0
+  _v_l2_n_raw:
+    type: int
+    default: 0
+  _v_l3_n_raw:
+    type: int
+    default: 0
+  _v_l1_l2_raw:
+    type: int
+    default: 0
+  _v_l2_l3_raw:
+    type: int
+    default: 0
+  _v_l3_l1_raw:
+    type: int
+    default: 0
+  _a_l1_raw:
+    type: int
+    default: 0
+  _a_l2_raw:
+    type: int
+    default: 0
+  _a_l3_raw:
+    type: int
+    default: 0
+  _w_l1_raw:
+    type: int
+    default: 0
+  _w_l2_raw:
+    type: int
+    default: 0
+  _w_l3_raw:
+    type: int
+    default: 0
+  _va_l1_raw:
+    type: int
+    default: 0
+  _va_l2_raw:
+    type: int
+    default: 0
+  _va_l3_raw:
+    type: int
+    default: 0
+  _var_l1_raw:
+    type: int
+    default: 0
+  _var_l2_raw:
+    type: int
+    default: 0
+  _var_l3_raw:
+    type: int
+    default: 0
+  _v_ln_sum_raw:
+    type: int
+    default: 0
+  _v_ll_sum_raw:
+    type: int
+    default: 0
+  _w_sum_raw:
+    type: int
+    default: 0
+  _va_sum_raw:
+    type: int
+    default: 0
+  _var_sum_raw:
+    type: int
+    default: 0
+  _pf_l1_raw:
+    type: int
+    default: 0
+  _pf_l2_raw:
+    type: int
+    default: 0
+  _pf_l3_raw:
+    type: int
+    default: 0
+  _pf_sum_raw:
+    type: int
+    default: 0
+  _phase_sequence_raw:
+    type: int
+    default: 123
+  _hz_raw:
+    type: int
+    default: 0
+  _kwh_import_raw:
+    type: int
+    default: 0
+  _kwh_export_raw:
+    type: int
+    default: 0
 actions:
   - function: $in(voltage_l1_l2_v)
     name: compute_voltage_l1_l2
@@ -316,50 +448,51 @@ communication:
       zero_fill: true
       mapping:
         # Voltages (V) -> scaled by 10
-        _v_l1_n_raw:   { address: [0,1],   group: i_r, type: uint_32 }
-        _v_l2_n_raw:   { address: [2,3],   group: i_r, type: uint_32 }
-        _v_l3_n_raw:   { address: [4,5],   group: i_r, type: uint_32 }
-        _v_l1_l2_raw:  { address: [6,7],   group: i_r, type: uint_32 }
-        _v_l2_l3_raw:  { address: [8,9],   group: i_r, type: uint_32 }
-        _v_l3_l1_raw:  { address: [10,11], group: i_r, type: uint_32 }
+        _v_l1_n_raw: {address: [0, 1], group: i_r, type: uint_32}
+        _v_l2_n_raw: {address: [2, 3], group: i_r, type: uint_32}
+        _v_l3_n_raw: {address: [4, 5], group: i_r, type: uint_32}
+        _v_l1_l2_raw: {address: [6, 7], group: i_r, type: uint_32}
+        _v_l2_l3_raw: {address: [8, 9], group: i_r, type: uint_32}
+        _v_l3_l1_raw: {address: [10, 11], group: i_r, type: uint_32}
 
         # Currents (A) -> scaled by 1000
-        _a_l1_raw:     { address: [12,13], group: i_r, type: uint_32 }
-        _a_l2_raw:     { address: [14,15], group: i_r, type: uint_32 }
-        _a_l3_raw:     { address: [16,17], group: i_r, type: uint_32 }
+        _a_l1_raw: {address: [12, 13], group: i_r, type: uint_32}
+        _a_l2_raw: {address: [14, 15], group: i_r, type: uint_32}
+        _a_l3_raw: {address: [16, 17], group: i_r, type: uint_32}
 
         # Power (W/VA/VAR) -> scaled by 10
-        _w_l1_raw:     { address: [18,19], group: i_r, type: uint_32 }
-        _w_l2_raw:     { address: [20,21], group: i_r, type: uint_32 }
-        _w_l3_raw:     { address: [22,23], group: i_r, type: uint_32 }
-        _va_l1_raw:    { address: [24,25], group: i_r, type: uint_32 }
-        _va_l2_raw:    { address: [26,27], group: i_r, type: uint_32 }
-        _va_l3_raw:    { address: [28,29], group: i_r, type: uint_32 }
-        _var_l1_raw:   { address: [30,31], group: i_r, type: uint_32 }
-        _var_l2_raw:   { address: [32,33], group: i_r, type: uint_32 }
-        _var_l3_raw:   { address: [34,35], group: i_r, type: uint_32 }
+        _w_l1_raw: {address: [18, 19], group: i_r, type: uint_32}
+        _w_l2_raw: {address: [20, 21], group: i_r, type: uint_32}
+        _w_l3_raw: {address: [22, 23], group: i_r, type: uint_32}
+        _va_l1_raw: {address: [24, 25], group: i_r, type: uint_32}
+        _va_l2_raw: {address: [26, 27], group: i_r, type: uint_32}
+        _va_l3_raw: {address: [28, 29], group: i_r, type: uint_32}
+        _var_l1_raw: {address: [30, 31], group: i_r, type: uint_32}
+        _var_l2_raw: {address: [32, 33], group: i_r, type: uint_32}
+        _var_l3_raw: {address: [34, 35], group: i_r, type: uint_32}
 
         # Sums
-        _v_ln_sum_raw: { address: [36,37], group: i_r, type: uint_32 }
-        _v_ll_sum_raw: { address: [38,39], group: i_r, type: uint_32 }
-        _w_sum_raw:    { address: [40,41], group: i_r, type: uint_32 }
-        _va_sum_raw:   { address: [42,43], group: i_r, type: uint_32 }
-        _var_sum_raw:  { address: [44,45], group: i_r, type: uint_32 }
+        _v_ln_sum_raw: {address: [36, 37], group: i_r, type: uint_32}
+        _v_ll_sum_raw: {address: [38, 39], group: i_r, type: uint_32}
+        _w_sum_raw: {address: [40, 41], group: i_r, type: uint_32}
+        _va_sum_raw: {address: [42, 43], group: i_r, type: uint_32}
+        _var_sum_raw: {address: [44, 45], group: i_r, type: uint_32}
 
         # Power factor + phase sequence + frequency
-        _pf_l1_raw:         { address: [46,46], group: i_r, type: uint_16 }
-        _pf_l2_raw:         { address: [47,47], group: i_r, type: uint_16 }
-        _pf_l3_raw:         { address: [48,48], group: i_r, type: uint_16 }
-        _pf_sum_raw:        { address: [49,49], group: i_r, type: uint_16 }
-        _phase_sequence_raw: { address: [50,50], group: i_r, type: uint_16 }
-        _hz_raw:            { address: [51,51], group: i_r, type: uint_16 }
+        _pf_l1_raw: {address: [46, 46], group: i_r, type: uint_16}
+        _pf_l2_raw: {address: [47, 47], group: i_r, type: uint_16}
+        _pf_l3_raw: {address: [48, 48], group: i_r, type: uint_16}
+        _pf_sum_raw: {address: [49, 49], group: i_r, type: uint_16}
+        _phase_sequence_raw: {address: [50, 50], group: i_r, type: uint_16}
+        _hz_raw: {address: [51, 51], group: i_r, type: uint_16}
 
         # Energy totals (kWh) -> scaled by 10
-        _kwh_import_raw: { address: [52,53], group: i_r, type: uint_32 }
-        _kwh_export_raw: { address: [78,79], group: i_r, type: uint_32 }
+        _kwh_import_raw: {address: [52, 53], group: i_r, type: uint_32}
+        _kwh_export_raw: {address: [78, 79], group: i_r, type: uint_32}
 
 scenarios:
   balanced_load:
+    display_name: Balanced Load
     description: Balanced three-phase load near nominal voltage.
     duration: 30.0
     overrides:
@@ -374,6 +507,7 @@ scenarios:
       $in(k__power_factor_l3): 0.98
 
   inductive_load:
+    display_name: Inductive Load
     description: Lower power factor across all phases to mimic inductive loads.
     duration: 30.0
     overrides:
@@ -382,6 +516,7 @@ scenarios:
       $in(k__power_factor_l3): 0.72
 
   pv_export:
+    display_name: PV Export
     description: Negative phase currents to simulate PV export.
     duration: 30.0
     overrides:

--- a/library/domains/energy/meter/eastron/eastron_sdm630__modbus.yaml
+++ b/library/domains/energy/meter/eastron/eastron_sdm630__modbus.yaml
@@ -16,58 +16,134 @@ meta_parameters:
 
 attributes:
   # Phase-to-neutral voltages (V)
-  k__voltage_l1_n_v: 230.0
-  k__voltage_l2_n_v: 231.0
-  k__voltage_l3_n_v: 229.5
-
-  # Phase currents (A)
-  k__current_l1_a: 8.5
-  k__current_l2_a: 8.1
-  k__current_l3_a: 8.3
-
-  # Per-phase power factor inputs
-  k__power_factor_l1: 0.96
-  k__power_factor_l2: 0.95
-  k__power_factor_l3: 0.97
-
-  # Frequency (Hz)
-  k__frequency_hz: 50.0
-
-  # Line-to-line and average voltages (V)
-  voltage_l1_l2_v: 0.0
-  voltage_l2_l3_v: 0.0
-  voltage_l3_l1_v: 0.0
-  voltage_ln_avg_v: 0.0
-  voltage_ll_avg_v: 0.0
-
-  # Current summaries (A)
-  current_avg_a: 0.0
-  current_sum_a: 0.0
-
-  # Power (W/VA/VAR)
-  active_power_l1_w: 0.0
-  active_power_l2_w: 0.0
-  active_power_l3_w: 0.0
-  active_power_total_w: 0.0
-
-  apparent_power_l1_va: 0.0
-  apparent_power_l2_va: 0.0
-  apparent_power_l3_va: 0.0
-  apparent_power_total_va: 0.0
-
-  reactive_power_l1_var: 0.0
-  reactive_power_l2_var: 0.0
-  reactive_power_l3_var: 0.0
-  reactive_power_total_var: 0.0
-
-  power_factor_total: 0.0
-
-  # Energy totals (kWh)
-  energy_import_total_kwh: 0.0
-  energy_export_total_kwh: 0.0
-
-  _cycle_time_s: 1.0
-
+  k__voltage_l1_n_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__voltage_l2_n_v:
+    type: float
+    default: 231.0
+    unit: V
+  k__voltage_l3_n_v:
+    type: float
+    default: 229.5
+    unit: V
+  k__current_l1_a:
+    type: float
+    default: 8.5
+    unit: A
+  k__current_l2_a:
+    type: float
+    default: 8.1
+    unit: A
+  k__current_l3_a:
+    type: float
+    default: 8.3
+    unit: A
+  k__power_factor_l1:
+    type: float
+    default: 0.96
+  k__power_factor_l2:
+    type: float
+    default: 0.95
+  k__power_factor_l3:
+    type: float
+    default: 0.97
+  k__frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  voltage_l1_l2_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l2_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l3_l1_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_ln_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_ll_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  current_avg_a:
+    type: float
+    default: 0.0
+    unit: A
+  current_sum_a:
+    type: float
+    default: 0.0
+    unit: A
+  active_power_l1_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_l2_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_l3_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_total_w:
+    type: float
+    default: 0.0
+    unit: W
+  apparent_power_l1_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_l2_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_l3_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_total_va:
+    type: float
+    default: 0.0
+    unit: VA
+  reactive_power_l1_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_l2_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_l3_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_total_var:
+    type: float
+    default: 0.0
+    unit: var
+  power_factor_total:
+    type: float
+    default: 0.0
+  energy_import_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  energy_export_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  _cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 actions:
   - function: $in(voltage_l1_l2_v)
     name: compute_voltage_l1_l2
@@ -137,23 +213,17 @@ actions:
   - function: $in(reactive_power_l1_var)
     name: compute_reactive_power_l1
     description: Phase L1 reactive power (VAr).
-    call: (
-          max(0.0, ($in(apparent_power_l1_va) ** 2) - ($in(active_power_l1_w) ** 2)) ** 0.5
-        ) * (-1.0 if $in(k__power_factor_l1) < 0 else 1.0)
+    call: ( max(0.0, ($in(apparent_power_l1_va) ** 2) - ($in(active_power_l1_w) ** 2)) ** 0.5 ) * (-1.0 if $in(k__power_factor_l1) < 0 else 1.0)
 
   - function: $in(reactive_power_l2_var)
     name: compute_reactive_power_l2
     description: Phase L2 reactive power (VAr).
-    call: (
-          max(0.0, ($in(apparent_power_l2_va) ** 2) - ($in(active_power_l2_w) ** 2)) ** 0.5
-        ) * (-1.0 if $in(k__power_factor_l2) < 0 else 1.0)
+    call: ( max(0.0, ($in(apparent_power_l2_va) ** 2) - ($in(active_power_l2_w) ** 2)) ** 0.5 ) * (-1.0 if $in(k__power_factor_l2) < 0 else 1.0)
 
   - function: $in(reactive_power_l3_var)
     name: compute_reactive_power_l3
     description: Phase L3 reactive power (VAr).
-    call: (
-          max(0.0, ($in(apparent_power_l3_va) ** 2) - ($in(active_power_l3_w) ** 2)) ** 0.5
-        ) * (-1.0 if $in(k__power_factor_l3) < 0 else 1.0)
+    call: ( max(0.0, ($in(apparent_power_l3_va) ** 2) - ($in(active_power_l3_w) ** 2)) ** 0.5 ) * (-1.0 if $in(k__power_factor_l3) < 0 else 1.0)
 
   - function: $in(active_power_total_w)
     name: compute_active_power_total
@@ -173,11 +243,7 @@ actions:
   - function: $in(power_factor_total)
     name: compute_power_factor_total
     description: Total power factor derived from active/apparent power.
-    call: (
-          $in(active_power_total_w) / $in(apparent_power_total_va)
-          if abs($in(apparent_power_total_va)) > 0.0001
-          else 0.0
-        )
+    call: ( $in(active_power_total_w) / $in(apparent_power_total_va) if abs($in(apparent_power_total_va)) > 0.0001 else 0.0 )
 
   - function: $in(energy_import_total_kwh)
     name: integrate_energy_import
@@ -197,53 +263,54 @@ communication:
       zero_fill: true
       mapping:
         # Phase-to-neutral voltages (V)
-        k__voltage_l1_n_v: { address: [0,1], group: i_r, type: float }
-        k__voltage_l2_n_v: { address: [2,3], group: i_r, type: float }
-        k__voltage_l3_n_v: { address: [4,5], group: i_r, type: float }
+        k__voltage_l1_n_v: {address: [0, 1], group: i_r, type: float}
+        k__voltage_l2_n_v: {address: [2, 3], group: i_r, type: float}
+        k__voltage_l3_n_v: {address: [4, 5], group: i_r, type: float}
 
         # Phase currents (A)
-        k__current_l1_a: { address: [6,7], group: i_r, type: float }
-        k__current_l2_a: { address: [8,9], group: i_r, type: float }
-        k__current_l3_a: { address: [10,11], group: i_r, type: float }
+        k__current_l1_a: {address: [6, 7], group: i_r, type: float}
+        k__current_l2_a: {address: [8, 9], group: i_r, type: float}
+        k__current_l3_a: {address: [10, 11], group: i_r, type: float}
 
         # Per-phase power (W/VA/VAR)
-        active_power_l1_w: { address: [12,13], group: i_r, type: float }
-        active_power_l2_w: { address: [14,15], group: i_r, type: float }
-        active_power_l3_w: { address: [16,17], group: i_r, type: float }
-        apparent_power_l1_va: { address: [18,19], group: i_r, type: float }
-        apparent_power_l2_va: { address: [20,21], group: i_r, type: float }
-        apparent_power_l3_va: { address: [22,23], group: i_r, type: float }
-        reactive_power_l1_var: { address: [24,25], group: i_r, type: float }
-        reactive_power_l2_var: { address: [26,27], group: i_r, type: float }
-        reactive_power_l3_var: { address: [28,29], group: i_r, type: float }
+        active_power_l1_w: {address: [12, 13], group: i_r, type: float}
+        active_power_l2_w: {address: [14, 15], group: i_r, type: float}
+        active_power_l3_w: {address: [16, 17], group: i_r, type: float}
+        apparent_power_l1_va: {address: [18, 19], group: i_r, type: float}
+        apparent_power_l2_va: {address: [20, 21], group: i_r, type: float}
+        apparent_power_l3_va: {address: [22, 23], group: i_r, type: float}
+        reactive_power_l1_var: {address: [24, 25], group: i_r, type: float}
+        reactive_power_l2_var: {address: [26, 27], group: i_r, type: float}
+        reactive_power_l3_var: {address: [28, 29], group: i_r, type: float}
 
         # Per-phase power factor
-        k__power_factor_l1: { address: [30,31], group: i_r, type: float }
-        k__power_factor_l2: { address: [32,33], group: i_r, type: float }
-        k__power_factor_l3: { address: [34,35], group: i_r, type: float }
+        k__power_factor_l1: {address: [30, 31], group: i_r, type: float}
+        k__power_factor_l2: {address: [32, 33], group: i_r, type: float}
+        k__power_factor_l3: {address: [34, 35], group: i_r, type: float}
 
         # Averages and totals
-        voltage_ln_avg_v: { address: [42,43], group: i_r, type: float }
-        current_avg_a: { address: [46,47], group: i_r, type: float }
-        current_sum_a: { address: [48,49], group: i_r, type: float }
-        active_power_total_w: { address: [52,53], group: i_r, type: float }
-        apparent_power_total_va: { address: [56,57], group: i_r, type: float }
-        reactive_power_total_var: { address: [60,61], group: i_r, type: float }
-        power_factor_total: { address: [62,63], group: i_r, type: float }
+        voltage_ln_avg_v: {address: [42, 43], group: i_r, type: float}
+        current_avg_a: {address: [46, 47], group: i_r, type: float}
+        current_sum_a: {address: [48, 49], group: i_r, type: float}
+        active_power_total_w: {address: [52, 53], group: i_r, type: float}
+        apparent_power_total_va: {address: [56, 57], group: i_r, type: float}
+        reactive_power_total_var: {address: [60, 61], group: i_r, type: float}
+        power_factor_total: {address: [62, 63], group: i_r, type: float}
 
         # Frequency and energy totals
-        k__frequency_hz: { address: [70,71], group: i_r, type: float }
-        energy_import_total_kwh: { address: [72,73], group: i_r, type: float }
-        energy_export_total_kwh: { address: [74,75], group: i_r, type: float }
+        k__frequency_hz: {address: [70, 71], group: i_r, type: float}
+        energy_import_total_kwh: {address: [72, 73], group: i_r, type: float}
+        energy_export_total_kwh: {address: [74, 75], group: i_r, type: float}
 
         # Line-to-line voltages (V)
-        voltage_l1_l2_v: { address: [200,201], group: i_r, type: float }
-        voltage_l2_l3_v: { address: [202,203], group: i_r, type: float }
-        voltage_l3_l1_v: { address: [204,205], group: i_r, type: float }
-        voltage_ll_avg_v: { address: [206,207], group: i_r, type: float }
+        voltage_l1_l2_v: {address: [200, 201], group: i_r, type: float}
+        voltage_l2_l3_v: {address: [202, 203], group: i_r, type: float}
+        voltage_l3_l1_v: {address: [204, 205], group: i_r, type: float}
+        voltage_ll_avg_v: {address: [206, 207], group: i_r, type: float}
 
 scenarios:
   balanced_load:
+    display_name: Balanced Load
     description: Balanced three-phase load near nominal voltage.
     duration: 30.0
     overrides:
@@ -258,6 +325,7 @@ scenarios:
       $in(k__power_factor_l3): 0.98
 
   inductive_load:
+    display_name: Inductive Load
     description: Lower power factor across all phases to mimic inductive loads.
     duration: 30.0
     overrides:
@@ -266,6 +334,7 @@ scenarios:
       $in(k__power_factor_l3): 0.72
 
   pv_export:
+    display_name: PV Export
     description: Negative phase currents to simulate PV export.
     duration: 30.0
     overrides:
@@ -277,6 +346,7 @@ scenarios:
       $in(k__power_factor_l3): 0.99
 
   voltage_sag:
+    display_name: Voltage Sag
     description: Phase-to-neutral voltage sag across all phases.
     duration: 30.0
     overrides:
@@ -285,6 +355,7 @@ scenarios:
       $in(k__voltage_l3_n_v): 210.0
 
   frequency_drift:
+    display_name: Frequency Drift
     description: Off-nominal grid frequency condition.
     duration: 20.0
     overrides:

--- a/library/domains/energy/meter/eaton/eaton_pxm2000__modbus.yaml
+++ b/library/domains/energy/meter/eaton/eaton_pxm2000__modbus.yaml
@@ -16,76 +16,160 @@ meta_parameters:
 
 attributes:
   # Line-to-line voltages (V)
-  k__voltage_l1_l2_v: 400.0
-  k__voltage_l2_l3_v: 401.0
-  k__voltage_l3_l1_v: 399.0
-  voltage_ll_avg_v: 0.0
-
-  # Line-to-neutral voltages (V)
-  k__voltage_l1_n_v: 230.0
-  k__voltage_l2_n_v: 231.0
-  k__voltage_l3_n_v: 229.5
-  voltage_ln_avg_v: 0.0
-
-  # Currents (A)
-  k__current_l1_a: 12.0
-  k__current_l2_a: 11.5
-  k__current_l3_a: 11.8
-  current_neutral_a: 0.0
-  current_avg_a: 0.0
-
-  # Power (W/var/VA)
-  active_power_l1_w: 0.0
-  active_power_l2_w: 0.0
-  active_power_l3_w: 0.0
-  active_power_total_w: 0.0
-  apparent_power_l1_va: 0.0
-  apparent_power_l2_va: 0.0
-  apparent_power_l3_va: 0.0
-  apparent_power_total_va: 0.0
-  reactive_power_l1_var: 0.0
-  reactive_power_l2_var: 0.0
-  reactive_power_l3_var: 0.0
-  reactive_power_total_var: 0.0
-
-  # Power factor
-  k__power_factor_l1: 0.98
-  k__power_factor_l2: 0.97
-  k__power_factor_l3: 0.99
-  power_factor_total: 0.0
-
-  # Frequency (Hz)
-  k__frequency_hz: 50.0
-
-  # Energy totals (Wh/varh/VAh)
-  energy_import_total_wh: 0.0
-  energy_export_total_wh: 0.0
-  energy_net_total_wh: 0.0
-  reactive_energy_leading_varh: 0.0
-  reactive_energy_lagging_varh: 0.0
-  reactive_energy_net_varh: 0.0
-  apparent_energy_total_vah: 0.0
-
-  _cycle_time_s: 1.0
-
+  k__voltage_l1_l2_v:
+    type: float
+    default: 400.0
+    unit: V
+  k__voltage_l2_l3_v:
+    type: float
+    default: 401.0
+    unit: V
+  k__voltage_l3_l1_v:
+    type: float
+    default: 399.0
+    unit: V
+  voltage_ll_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  k__voltage_l1_n_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__voltage_l2_n_v:
+    type: float
+    default: 231.0
+    unit: V
+  k__voltage_l3_n_v:
+    type: float
+    default: 229.5
+    unit: V
+  voltage_ln_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  k__current_l1_a:
+    type: float
+    default: 12.0
+    unit: A
+  k__current_l2_a:
+    type: float
+    default: 11.5
+    unit: A
+  k__current_l3_a:
+    type: float
+    default: 11.8
+    unit: A
+  current_neutral_a:
+    type: float
+    default: 0.0
+    unit: A
+  current_avg_a:
+    type: float
+    default: 0.0
+    unit: A
+  active_power_l1_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_l2_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_l3_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_total_w:
+    type: float
+    default: 0.0
+    unit: W
+  apparent_power_l1_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_l2_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_l3_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_total_va:
+    type: float
+    default: 0.0
+    unit: VA
+  reactive_power_l1_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_l2_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_l3_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_total_var:
+    type: float
+    default: 0.0
+    unit: var
+  k__power_factor_l1:
+    type: float
+    default: 0.98
+  k__power_factor_l2:
+    type: float
+    default: 0.97
+  k__power_factor_l3:
+    type: float
+    default: 0.99
+  power_factor_total:
+    type: float
+    default: 0.0
+  k__frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  energy_import_total_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  energy_export_total_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  energy_net_total_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  reactive_energy_leading_varh:
+    type: float
+    default: 0.0
+  reactive_energy_lagging_varh:
+    type: float
+    default: 0.0
+  reactive_energy_net_varh:
+    type: float
+    default: 0.0
+  apparent_energy_total_vah:
+    type: float
+    default: 0.0
+  _cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 actions:
   - function: $in(voltage_ll_avg_v)
     name: compute_voltage_ll_avg
     description: Average line-to-line voltage.
-    call: (
-          $in(k__voltage_l1_l2_v)
-          + $in(k__voltage_l2_l3_v)
-          + $in(k__voltage_l3_l1_v)
-        ) / 3.0
+    call: ( $in(k__voltage_l1_l2_v) + $in(k__voltage_l2_l3_v) + $in(k__voltage_l3_l1_v) ) / 3.0
 
   - function: $in(voltage_ln_avg_v)
     name: compute_voltage_ln_avg
     description: Average line-to-neutral voltage.
-    call: (
-          $in(k__voltage_l1_n_v)
-          + $in(k__voltage_l2_n_v)
-          + $in(k__voltage_l3_n_v)
-        ) / 3.0
+    call: ( $in(k__voltage_l1_n_v) + $in(k__voltage_l2_n_v) + $in(k__voltage_l3_n_v) ) / 3.0
 
   - function: $in(current_avg_a)
     name: compute_current_avg
@@ -155,10 +239,7 @@ actions:
   - function: $in(power_factor_total)
     name: compute_power_factor_total
     description: Total apparent power factor.
-    call: (
-          $in(active_power_total_w) / $in(apparent_power_total_va)
-          if $in(apparent_power_total_va) else 0.0
-        )
+    call: ( $in(active_power_total_w) / $in(apparent_power_total_va) if $in(apparent_power_total_va) else 0.0 )
 
   - function: $in(energy_import_total_wh)
     name: integrate_energy_import
@@ -213,62 +294,63 @@ communication:
       zero_fill: true
       mapping:
         # Line-to-line voltages (V) Float32
-        k__voltage_l1_l2_v: { address: [4002, 4003], group: h_r, type: float }
-        k__voltage_l2_l3_v: { address: [4004, 4005], group: h_r, type: float }
-        k__voltage_l3_l1_v: { address: [4006, 4007], group: h_r, type: float }
-        voltage_ll_avg_v:   { address: [4008, 4009], group: h_r, type: float }
+        k__voltage_l1_l2_v: {address: [4002, 4003], group: h_r, type: float}
+        k__voltage_l2_l3_v: {address: [4004, 4005], group: h_r, type: float}
+        k__voltage_l3_l1_v: {address: [4006, 4007], group: h_r, type: float}
+        voltage_ll_avg_v: {address: [4008, 4009], group: h_r, type: float}
 
         # Line-to-neutral voltages (V) Float32
-        k__voltage_l1_n_v: { address: [4010, 4011], group: h_r, type: float }
-        k__voltage_l2_n_v: { address: [4012, 4013], group: h_r, type: float }
-        k__voltage_l3_n_v: { address: [4014, 4015], group: h_r, type: float }
-        voltage_ln_avg_v:   { address: [4016, 4017], group: h_r, type: float }
+        k__voltage_l1_n_v: {address: [4010, 4011], group: h_r, type: float}
+        k__voltage_l2_n_v: {address: [4012, 4013], group: h_r, type: float}
+        k__voltage_l3_n_v: {address: [4014, 4015], group: h_r, type: float}
+        voltage_ln_avg_v: {address: [4016, 4017], group: h_r, type: float}
 
         # Currents (A) Float32
-        k__current_l1_a:  { address: [5002, 5003], group: h_r, type: float }
-        k__current_l2_a:  { address: [5004, 5005], group: h_r, type: float }
-        k__current_l3_a:  { address: [5006, 5007], group: h_r, type: float }
-        current_neutral_a: { address: [5010, 5011], group: h_r, type: float }
-        current_avg_a:     { address: [5012, 5013], group: h_r, type: float }
+        k__current_l1_a: {address: [5002, 5003], group: h_r, type: float}
+        k__current_l2_a: {address: [5004, 5005], group: h_r, type: float}
+        k__current_l3_a: {address: [5006, 5007], group: h_r, type: float}
+        current_neutral_a: {address: [5010, 5011], group: h_r, type: float}
+        current_avg_a: {address: [5012, 5013], group: h_r, type: float}
 
         # Active power (W) Float32
-        active_power_l1_w:  { address: [6000, 6001], group: h_r, type: float }
-        active_power_l2_w:  { address: [6002, 6003], group: h_r, type: float }
-        active_power_l3_w:  { address: [6004, 6005], group: h_r, type: float }
-        active_power_total_w: { address: [6006, 6007], group: h_r, type: float }
+        active_power_l1_w: {address: [6000, 6001], group: h_r, type: float}
+        active_power_l2_w: {address: [6002, 6003], group: h_r, type: float}
+        active_power_l3_w: {address: [6004, 6005], group: h_r, type: float}
+        active_power_total_w: {address: [6006, 6007], group: h_r, type: float}
 
         # Apparent power (VA) Float32
-        apparent_power_l1_va: { address: [6064, 6065], group: h_r, type: float }
-        apparent_power_l2_va: { address: [6066, 6067], group: h_r, type: float }
-        apparent_power_l3_va: { address: [6068, 6069], group: h_r, type: float }
-        apparent_power_total_va: { address: [6070, 6071], group: h_r, type: float }
+        apparent_power_l1_va: {address: [6064, 6065], group: h_r, type: float}
+        apparent_power_l2_va: {address: [6066, 6067], group: h_r, type: float}
+        apparent_power_l3_va: {address: [6068, 6069], group: h_r, type: float}
+        apparent_power_total_va: {address: [6070, 6071], group: h_r, type: float}
 
         # Reactive power (var) Float32
-        reactive_power_l1_var: { address: [6128, 6129], group: h_r, type: float }
-        reactive_power_l2_var: { address: [6130, 6131], group: h_r, type: float }
-        reactive_power_l3_var: { address: [6132, 6133], group: h_r, type: float }
-        reactive_power_total_var: { address: [6134, 6135], group: h_r, type: float }
+        reactive_power_l1_var: {address: [6128, 6129], group: h_r, type: float}
+        reactive_power_l2_var: {address: [6130, 6131], group: h_r, type: float}
+        reactive_power_l3_var: {address: [6132, 6133], group: h_r, type: float}
+        reactive_power_total_var: {address: [6134, 6135], group: h_r, type: float}
 
         # Power factor Float32
-        k__power_factor_l1: { address: [6212, 6213], group: h_r, type: float }
-        k__power_factor_l2: { address: [6214, 6215], group: h_r, type: float }
-        k__power_factor_l3: { address: [6216, 6217], group: h_r, type: float }
-        power_factor_total: { address: [6220, 6221], group: h_r, type: float }
+        k__power_factor_l1: {address: [6212, 6213], group: h_r, type: float}
+        k__power_factor_l2: {address: [6214, 6215], group: h_r, type: float}
+        k__power_factor_l3: {address: [6216, 6217], group: h_r, type: float}
+        power_factor_total: {address: [6220, 6221], group: h_r, type: float}
 
         # Energy totals (Wh/varh/VAh) Float32
-        energy_import_total_wh: { address: [7004, 7005], group: h_r, type: float }
-        energy_export_total_wh: { address: [7006, 7007], group: h_r, type: float }
-        energy_net_total_wh: { address: [7008, 7009], group: h_r, type: float }
-        reactive_energy_leading_varh: { address: [7010, 7011], group: h_r, type: float }
-        reactive_energy_lagging_varh: { address: [7012, 7013], group: h_r, type: float }
-        reactive_energy_net_varh: { address: [7014, 7015], group: h_r, type: float }
-        apparent_energy_total_vah: { address: [7016, 7017], group: h_r, type: float }
+        energy_import_total_wh: {address: [7004, 7005], group: h_r, type: float}
+        energy_export_total_wh: {address: [7006, 7007], group: h_r, type: float}
+        energy_net_total_wh: {address: [7008, 7009], group: h_r, type: float}
+        reactive_energy_leading_varh: {address: [7010, 7011], group: h_r, type: float}
+        reactive_energy_lagging_varh: {address: [7012, 7013], group: h_r, type: float}
+        reactive_energy_net_varh: {address: [7014, 7015], group: h_r, type: float}
+        apparent_energy_total_vah: {address: [7016, 7017], group: h_r, type: float}
 
         # Frequency (Hz) Float32
-        k__frequency_hz: { address: [11000, 11001], group: h_r, type: float }
+        k__frequency_hz: {address: [11000, 11001], group: h_r, type: float}
 
 scenarios:
   peak_demand:
+    display_name: Peak Demand
     description: High load with balanced phases and near-unity power factor.
     duration: 30.0
     overrides:
@@ -280,6 +362,7 @@ scenarios:
       $in(k__power_factor_l3): 0.98
 
   pv_export:
+    display_name: PV Export
     description: Simulated export with leading power factor.
     duration: 30.0
     overrides:
@@ -291,6 +374,7 @@ scenarios:
       $in(k__power_factor_l3): 0.99
 
   voltage_sag:
+    display_name: Voltage Sag
     description: Phase-to-neutral voltage sag across all phases.
     duration: 30.0
     overrides:
@@ -299,6 +383,7 @@ scenarios:
       $in(k__voltage_l3_n_v): 210.0
 
   frequency_drift:
+    display_name: Frequency Drift
     description: Off-nominal grid frequency condition.
     duration: 20.0
     overrides:

--- a/library/domains/energy/meter/schneider/energy_meter_iem3000__modbus.yaml
+++ b/library/domains/energy/meter/schneider/energy_meter_iem3000__modbus.yaml
@@ -18,42 +18,99 @@ meta_parameters:
 
 attributes:
   # Phase currents (A)
-  k__current_l1_a: 12.0
-  k__current_l2_a: 10.5
-  k__current_l3_a: 11.2
-  current_avg_a: 0.0
-
-  # Phase-to-neutral voltages (V)
-  k__voltage_l1_n_v: 230.0
-  k__voltage_l2_n_v: 229.5
-  k__voltage_l3_n_v: 231.0
-  voltage_ln_avg_v: 0.0
-
-  # Line-to-line voltages (V) (derived from L-N; suitable for demo dashboards)
-  voltage_l1_l2_v: 0.0
-  voltage_l2_l3_v: 0.0
-  voltage_l3_l1_v: 0.0
-  voltage_ll_avg_v: 0.0
-
-  # Power (kW/kVAR/kVA)
-  k__power_factor: 0.95
-  power_factor_leading: 0
-  active_power_l1_kw: 0.0
-  active_power_l2_kw: 0.0
-  active_power_l3_kw: 0.0
-  k__active_power_total_kw: 0.0
-  k__reactive_power_total_kvar: 0.0
-  k__apparent_power_total_kva: 0.0
-
-  # Frequency (Hz)
-  k__frequency_hz: 50.0
-
-  # Cumulative energy (kWh)
-  k__energy_import_total_kwh: 0.0
-  k__energy_export_total_kwh: 0.0
-
-  _cycle_time_s: 1.0
-
+  k__current_l1_a:
+    type: float
+    default: 12.0
+    unit: A
+  k__current_l2_a:
+    type: float
+    default: 10.5
+    unit: A
+  k__current_l3_a:
+    type: float
+    default: 11.2
+    unit: A
+  current_avg_a:
+    type: float
+    default: 0.0
+    unit: A
+  k__voltage_l1_n_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__voltage_l2_n_v:
+    type: float
+    default: 229.5
+    unit: V
+  k__voltage_l3_n_v:
+    type: float
+    default: 231.0
+    unit: V
+  voltage_ln_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l1_l2_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l2_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l3_l1_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_ll_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  k__power_factor:
+    type: float
+    default: 0.95
+  power_factor_leading:
+    type: int
+    default: 0
+  active_power_l1_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  active_power_l2_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  active_power_l3_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  k__active_power_total_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  k__reactive_power_total_kvar:
+    type: float
+    default: 0.0
+  k__apparent_power_total_kva:
+    type: float
+    default: 0.0
+    unit: kVA
+  k__frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  k__energy_import_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  k__energy_export_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  _cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 actions:
   - function: $in(current_avg_a)
     name: compute_current_avg
@@ -88,12 +145,7 @@ actions:
   - function: $in(k__apparent_power_total_kva)
     name: compute_apparent_power
     description: Total apparent power (sum of per-phase V*I).
-    call: 1e-3
-         * (
-             $in(k__voltage_l1_n_v) * $in(k__current_l1_a)
-             + $in(k__voltage_l2_n_v) * $in(k__current_l2_a)
-             + $in(k__voltage_l3_n_v) * $in(k__current_l3_a)
-           )
+    call: 1e-3 * ( $in(k__voltage_l1_n_v) * $in(k__current_l1_a) + $in(k__voltage_l2_n_v) * $in(k__current_l2_a) + $in(k__voltage_l3_n_v) * $in(k__current_l3_a) )
 
   - function: $in(active_power_l1_kw)
     name: compute_active_power_l1
@@ -118,9 +170,7 @@ actions:
   - function: $in(k__reactive_power_total_kvar)
     name: compute_reactive_power_total
     description: Approximate total reactive power magnitude from active/apparent power.
-    call: (
-          max(0.0, ($in(k__apparent_power_total_kva) ** 2) - ($in(k__active_power_total_kw) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(k__apparent_power_total_kva) ** 2) - ($in(k__active_power_total_kw) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(k__energy_import_total_kwh)
     name: integrate_energy_import
@@ -140,41 +190,42 @@ communication:
       zero_fill: true
       mapping:
         # Currents (A) Float32
-        k__current_l1_a:     { address: [3000,3001], group: i_r, type: float }
-        k__current_l2_a:     { address: [3002,3003], group: i_r, type: float }
-        k__current_l3_a:     { address: [3004,3005], group: i_r, type: float }
-        current_avg_a:       { address: [3010,3011], group: i_r, type: float }
+        k__current_l1_a: {address: [3000, 3001], group: i_r, type: float}
+        k__current_l2_a: {address: [3002, 3003], group: i_r, type: float}
+        k__current_l3_a: {address: [3004, 3005], group: i_r, type: float}
+        current_avg_a: {address: [3010, 3011], group: i_r, type: float}
 
         # Voltages (V) Float32
-        voltage_l1_l2_v:     { address: [3020,3021], group: i_r, type: float }
-        voltage_l2_l3_v:     { address: [3022,3023], group: i_r, type: float }
-        voltage_l3_l1_v:     { address: [3024,3025], group: i_r, type: float }
-        voltage_ll_avg_v:    { address: [3026,3027], group: i_r, type: float }
-        k__voltage_l1_n_v:   { address: [3028,3029], group: i_r, type: float }
-        k__voltage_l2_n_v:   { address: [3030,3031], group: i_r, type: float }
-        k__voltage_l3_n_v:   { address: [3032,3033], group: i_r, type: float }
-        voltage_ln_avg_v:    { address: [3036,3037], group: i_r, type: float }
+        voltage_l1_l2_v: {address: [3020, 3021], group: i_r, type: float}
+        voltage_l2_l3_v: {address: [3022, 3023], group: i_r, type: float}
+        voltage_l3_l1_v: {address: [3024, 3025], group: i_r, type: float}
+        voltage_ll_avg_v: {address: [3026, 3027], group: i_r, type: float}
+        k__voltage_l1_n_v: {address: [3028, 3029], group: i_r, type: float}
+        k__voltage_l2_n_v: {address: [3030, 3031], group: i_r, type: float}
+        k__voltage_l3_n_v: {address: [3032, 3033], group: i_r, type: float}
+        voltage_ln_avg_v: {address: [3036, 3037], group: i_r, type: float}
 
         # Active power (kW) Float32
-        active_power_l1_kw:  { address: [3054,3055], group: i_r, type: float }
-        active_power_l2_kw:  { address: [3056,3057], group: i_r, type: float }
-        active_power_l3_kw:  { address: [3058,3059], group: i_r, type: float }
-        k__active_power_total_kw: { address: [3060,3061], group: i_r, type: float }
+        active_power_l1_kw: {address: [3054, 3055], group: i_r, type: float}
+        active_power_l2_kw: {address: [3056, 3057], group: i_r, type: float}
+        active_power_l3_kw: {address: [3058, 3059], group: i_r, type: float}
+        k__active_power_total_kw: {address: [3060, 3061], group: i_r, type: float}
 
         # Optional power quality (kVAR/kVA) Float32
-        k__reactive_power_total_kvar: { address: [3068,3069], group: i_r, type: float }
-        k__apparent_power_total_kva:  { address: [3076,3077], group: i_r, type: float }
+        k__reactive_power_total_kvar: {address: [3068, 3069], group: i_r, type: float}
+        k__apparent_power_total_kva: {address: [3076, 3077], group: i_r, type: float}
 
         # Power factor + frequency Float32
-        k__power_factor:     { address: [3084,3085], group: i_r, type: float }
-        k__frequency_hz:     { address: [3110,3111], group: i_r, type: float }
+        k__power_factor: {address: [3084, 3085], group: i_r, type: float}
+        k__frequency_hz: {address: [3110, 3111], group: i_r, type: float}
 
         # Energy totals (kWh) Float32
-        k__energy_import_total_kwh: { address: [45100,45101], group: h_r, type: float }
-        k__energy_export_total_kwh: { address: [45102,45103], group: h_r, type: float }
+        k__energy_import_total_kwh: {address: [45100, 45101], group: h_r, type: float}
+        k__energy_export_total_kwh: {address: [45102, 45103], group: h_r, type: float}
 
 scenarios:
   peak_demand:
+    display_name: Peak Demand
     description: High load with balanced phases and near-unity power factor.
     duration: 30.0
     overrides:
@@ -185,6 +236,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   pv_export:
+    display_name: PV Export
     description: Simulated PV export using negative phase currents.
     duration: 30.0
     overrides:
@@ -195,6 +247,7 @@ scenarios:
       $in(power_factor_leading): 1
 
   low_power_factor_lagging:
+    display_name: Low Power Factor Lagging
     description: Inductive load with low power factor.
     duration: 45.0
     overrides:
@@ -202,6 +255,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   voltage_sag:
+    display_name: Voltage Sag
     description: Phase-to-neutral voltage sag across all phases.
     duration: 30.0
     overrides:
@@ -210,6 +264,7 @@ scenarios:
       $in(k__voltage_l3_n_v): 210.0
 
   frequency_drift:
+    display_name: Frequency Drift
     description: Off-nominal grid frequency condition.
     duration: 20.0
     overrides:

--- a/library/domains/energy/meter/schneider/schneider_em4200__modbus.yaml
+++ b/library/domains/energy/meter/schneider/schneider_em4200__modbus.yaml
@@ -17,38 +17,83 @@ meta_parameters:
 
 attributes:
   # Phase currents (A)
-  k__current_l1_a: 12.0
-  k__current_l2_a: 10.5
-  k__current_l3_a: 11.2
-  current_avg_a: 0.0
-
-  # Phase-to-neutral voltages (V)
-  k__voltage_l1_n_v: 230.0
-  k__voltage_l2_n_v: 229.5
-  k__voltage_l3_n_v: 231.0
-  voltage_ln_avg_v: 0.0
-
-  # Line-to-line voltages (V) (derived from L-N; suitable for demo dashboards)
-  voltage_l1_l2_v: 0.0
-  voltage_l2_l3_v: 0.0
-  voltage_l3_l1_v: 0.0
-  voltage_ll_avg_v: 0.0
-
-  # Power (kW/kVAR/kVA)
-  k__power_factor: 0.96
-  power_factor_leading: 0
-  k__active_power_total_kw: 0.0
-  k__reactive_power_total_kvar: 0.0
-  k__apparent_power_total_kva: 0.0
-
-  # Frequency (Hz)
-  k__frequency_hz: 50.0
-
-  # Cumulative energy (kWh)
-  k__energy_total_kwh: 0.0
-
-  _cycle_time_s: 1.0
-
+  k__current_l1_a:
+    type: float
+    default: 12.0
+    unit: A
+  k__current_l2_a:
+    type: float
+    default: 10.5
+    unit: A
+  k__current_l3_a:
+    type: float
+    default: 11.2
+    unit: A
+  current_avg_a:
+    type: float
+    default: 0.0
+    unit: A
+  k__voltage_l1_n_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__voltage_l2_n_v:
+    type: float
+    default: 229.5
+    unit: V
+  k__voltage_l3_n_v:
+    type: float
+    default: 231.0
+    unit: V
+  voltage_ln_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l1_l2_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l2_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l3_l1_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_ll_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  k__power_factor:
+    type: float
+    default: 0.96
+  power_factor_leading:
+    type: int
+    default: 0
+  k__active_power_total_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  k__reactive_power_total_kvar:
+    type: float
+    default: 0.0
+  k__apparent_power_total_kva:
+    type: float
+    default: 0.0
+    unit: kVA
+  k__frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  k__energy_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  _cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 actions:
   - function: $in(current_avg_a)
     name: compute_current_avg
@@ -83,12 +128,7 @@ actions:
   - function: $in(k__apparent_power_total_kva)
     name: compute_apparent_power
     description: Total apparent power (sum of per-phase V*I).
-    call: 1e-3
-         * (
-             $in(k__voltage_l1_n_v) * $in(k__current_l1_a)
-             + $in(k__voltage_l2_n_v) * $in(k__current_l2_a)
-             + $in(k__voltage_l3_n_v) * $in(k__current_l3_a)
-           )
+    call: 1e-3 * ( $in(k__voltage_l1_n_v) * $in(k__current_l1_a) + $in(k__voltage_l2_n_v) * $in(k__current_l2_a) + $in(k__voltage_l3_n_v) * $in(k__current_l3_a) )
 
   - function: $in(k__active_power_total_kw)
     name: compute_active_power_total
@@ -98,9 +138,7 @@ actions:
   - function: $in(k__reactive_power_total_kvar)
     name: compute_reactive_power_total
     description: Approximate total reactive power magnitude from active/apparent power.
-    call: (
-          max(0.0, ($in(k__apparent_power_total_kva) ** 2) - ($in(k__active_power_total_kw) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(k__apparent_power_total_kva) ** 2) - ($in(k__active_power_total_kw) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(k__energy_total_kwh)
     name: integrate_energy_total
@@ -115,39 +153,40 @@ communication:
       zero_fill: true
       mapping:
         # Energy totals (kWh) Float32
-        k__energy_total_kwh:     { address: [257,258], group: h_r, type: float }
+        k__energy_total_kwh: {address: [257, 258], group: h_r, type: float}
 
         # Power totals (kW/kVAR/kVA) Float32
-        k__active_power_total_kw:    { address: [261,262], group: i_r, type: float }
-        k__reactive_power_total_kvar: { address: [263,264], group: i_r, type: float }
-        k__apparent_power_total_kva:  { address: [265,266], group: i_r, type: float }
-        k__power_factor:             { address: [267,268], group: i_r, type: float }
+        k__active_power_total_kw: {address: [261, 262], group: i_r, type: float}
+        k__reactive_power_total_kvar: {address: [263, 264], group: i_r, type: float}
+        k__apparent_power_total_kva: {address: [265, 266], group: i_r, type: float}
+        k__power_factor: {address: [267, 268], group: i_r, type: float}
 
         # Voltage + current averages Float32
-        voltage_ll_avg_v:        { address: [269,270], group: i_r, type: float }
-        voltage_ln_avg_v:        { address: [271,272], group: i_r, type: float }
-        current_avg_a:           { address: [273,274], group: i_r, type: float }
+        voltage_ll_avg_v: {address: [269, 270], group: i_r, type: float}
+        voltage_ln_avg_v: {address: [271, 272], group: i_r, type: float}
+        current_avg_a: {address: [273, 274], group: i_r, type: float}
 
         # Line-line voltages (V) Float32
-        voltage_l1_l2_v:         { address: [287,288], group: i_r, type: float }
-        voltage_l2_l3_v:         { address: [289,290], group: i_r, type: float }
-        voltage_l3_l1_v:         { address: [291,292], group: i_r, type: float }
+        voltage_l1_l2_v: {address: [287, 288], group: i_r, type: float}
+        voltage_l2_l3_v: {address: [289, 290], group: i_r, type: float}
+        voltage_l3_l1_v: {address: [291, 292], group: i_r, type: float}
 
         # Phase-to-neutral voltages (V) Float32
-        k__voltage_l1_n_v:       { address: [293,294], group: i_r, type: float }
-        k__voltage_l2_n_v:       { address: [295,296], group: i_r, type: float }
-        k__voltage_l3_n_v:       { address: [297,298], group: i_r, type: float }
+        k__voltage_l1_n_v: {address: [293, 294], group: i_r, type: float}
+        k__voltage_l2_n_v: {address: [295, 296], group: i_r, type: float}
+        k__voltage_l3_n_v: {address: [297, 298], group: i_r, type: float}
 
         # Frequency (Hz) Float32
-        k__frequency_hz:         { address: [1557,1558], group: i_r, type: float }
+        k__frequency_hz: {address: [1557, 1558], group: i_r, type: float}
 
         # Phase currents (A) Float32
-        k__current_l1_a:         { address: [2705,2706], group: i_r, type: float }
-        k__current_l2_a:         { address: [2707,2708], group: i_r, type: float }
-        k__current_l3_a:         { address: [2709,2710], group: i_r, type: float }
+        k__current_l1_a: {address: [2705, 2706], group: i_r, type: float}
+        k__current_l2_a: {address: [2707, 2708], group: i_r, type: float}
+        k__current_l3_a: {address: [2709, 2710], group: i_r, type: float}
 
 scenarios:
   peak_demand:
+    display_name: Peak Demand
     description: High load with balanced phases and near-unity power factor.
     duration: 30.0
     overrides:
@@ -158,6 +197,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   pv_export:
+    display_name: PV Export
     description: Simulated PV export using negative phase currents.
     duration: 30.0
     overrides:
@@ -168,6 +208,7 @@ scenarios:
       $in(power_factor_leading): 1
 
   low_power_factor_lagging:
+    display_name: Low Power Factor Lagging
     description: Inductive load with low power factor.
     duration: 45.0
     overrides:

--- a/library/domains/energy/meter/schneider/schneider_pm3200__modbus.yaml
+++ b/library/domains/energy/meter/schneider/schneider_pm3200__modbus.yaml
@@ -16,52 +16,128 @@ meta_parameters:
 
 attributes:
   # Phase currents (A)
-  k__current_l1_a: 12.0
-  k__current_l2_a: 10.5
-  k__current_l3_a: 11.2
-  k__current_neutral_a: 0.4
-  current_avg_a: 0.0
-
-  # Phase-to-neutral voltages (V)
-  k__voltage_l1_n_v: 230.0
-  k__voltage_l2_n_v: 229.5
-  k__voltage_l3_n_v: 231.0
-  voltage_ln_avg_v: 0.0
-
-  # Line-to-line voltages (V) (derived from L-N; balanced phasor assumption)
-  voltage_l1_l2_v: 0.0
-  voltage_l2_l3_v: 0.0
-  voltage_l3_l1_v: 0.0
-  voltage_ll_avg_v: 0.0
-
-  # Power (kW/kVAR/kVA)
-  k__power_factor: 0.95
-  power_factor_leading: 0
-  active_power_l1_kw: 0.0
-  active_power_l2_kw: 0.0
-  active_power_l3_kw: 0.0
-  reactive_power_l1_kvar: 0.0
-  reactive_power_l2_kvar: 0.0
-  reactive_power_l3_kvar: 0.0
-  apparent_power_l1_kva: 0.0
-  apparent_power_l2_kva: 0.0
-  apparent_power_l3_kva: 0.0
-  k__active_power_total_kw: 0.0
-  k__reactive_power_total_kvar: 0.0
-  k__apparent_power_total_kva: 0.0
-
-  # Frequency (Hz)
-  k__frequency_hz: 50.0
-
-  # Meter temperature (C)
-  temperature_c: 34.0
-
-  # Cumulative energy (Wh)
-  energy_import_total_wh: 0.0
-  energy_export_total_wh: 0.0
-
-  _cycle_time_s: 1.0
-
+  k__current_l1_a:
+    type: float
+    default: 12.0
+    unit: A
+  k__current_l2_a:
+    type: float
+    default: 10.5
+    unit: A
+  k__current_l3_a:
+    type: float
+    default: 11.2
+    unit: A
+  k__current_neutral_a:
+    type: float
+    default: 0.4
+    unit: A
+  current_avg_a:
+    type: float
+    default: 0.0
+    unit: A
+  k__voltage_l1_n_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__voltage_l2_n_v:
+    type: float
+    default: 229.5
+    unit: V
+  k__voltage_l3_n_v:
+    type: float
+    default: 231.0
+    unit: V
+  voltage_ln_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l1_l2_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l2_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l3_l1_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_ll_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  k__power_factor:
+    type: float
+    default: 0.95
+  power_factor_leading:
+    type: int
+    default: 0
+  active_power_l1_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  active_power_l2_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  active_power_l3_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  reactive_power_l1_kvar:
+    type: float
+    default: 0.0
+  reactive_power_l2_kvar:
+    type: float
+    default: 0.0
+  reactive_power_l3_kvar:
+    type: float
+    default: 0.0
+  apparent_power_l1_kva:
+    type: float
+    default: 0.0
+    unit: kVA
+  apparent_power_l2_kva:
+    type: float
+    default: 0.0
+    unit: kVA
+  apparent_power_l3_kva:
+    type: float
+    default: 0.0
+    unit: kVA
+  k__active_power_total_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  k__reactive_power_total_kvar:
+    type: float
+    default: 0.0
+  k__apparent_power_total_kva:
+    type: float
+    default: 0.0
+    unit: kVA
+  k__frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  temperature_c:
+    type: float
+    default: 34.0
+    unit: degC
+  energy_import_total_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  energy_export_total_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  _cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 actions:
   - function: $in(current_avg_a)
     name: compute_current_avg
@@ -136,23 +212,17 @@ actions:
   - function: $in(reactive_power_l1_kvar)
     name: compute_reactive_power_l1
     description: Phase L1 reactive power magnitude.
-    call: (
-          max(0.0, ($in(apparent_power_l1_kva) ** 2) - ($in(active_power_l1_kw) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(apparent_power_l1_kva) ** 2) - ($in(active_power_l1_kw) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(reactive_power_l2_kvar)
     name: compute_reactive_power_l2
     description: Phase L2 reactive power magnitude.
-    call: (
-          max(0.0, ($in(apparent_power_l2_kva) ** 2) - ($in(active_power_l2_kw) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(apparent_power_l2_kva) ** 2) - ($in(active_power_l2_kw) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(reactive_power_l3_kvar)
     name: compute_reactive_power_l3
     description: Phase L3 reactive power magnitude.
-    call: (
-          max(0.0, ($in(apparent_power_l3_kva) ** 2) - ($in(active_power_l3_kw) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(apparent_power_l3_kva) ** 2) - ($in(active_power_l3_kw) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(k__reactive_power_total_kvar)
     name: compute_reactive_power_total
@@ -162,14 +232,12 @@ actions:
   - function: $in(energy_import_total_wh)
     name: integrate_energy_import
     description: Integrate imported energy (Wh) from total active power (kW).
-    call: $in(energy_import_total_wh)
-         + max(0.0, $in(k__active_power_total_kw)) * 1000.0 * $in(_cycle_time_s) / 3600.0
+    call: $in(energy_import_total_wh) + max(0.0, $in(k__active_power_total_kw)) * 1000.0 * $in(_cycle_time_s) / 3600.0
 
   - function: $in(energy_export_total_wh)
     name: integrate_energy_export
     description: Integrate exported energy (Wh) from total active power (kW).
-    call: $in(energy_export_total_wh)
-         + max(0.0, -$in(k__active_power_total_kw)) * 1000.0 * $in(_cycle_time_s) / 3600.0
+    call: $in(energy_export_total_wh) + max(0.0, -$in(k__active_power_total_kw)) * 1000.0 * $in(_cycle_time_s) / 3600.0
 
 communication:
   - modbus_slave:
@@ -179,53 +247,54 @@ communication:
       zero_fill: true
       mapping:
         # Currents (A) Float32
-        k__current_l1_a:     { address: [3000,3001], group: i_r, type: float }
-        k__current_l2_a:     { address: [3002,3003], group: i_r, type: float }
-        k__current_l3_a:     { address: [3004,3005], group: i_r, type: float }
-        k__current_neutral_a: { address: [3006,3007], group: i_r, type: float }
-        current_avg_a:       { address: [3010,3011], group: i_r, type: float }
+        k__current_l1_a: {address: [3000, 3001], group: i_r, type: float}
+        k__current_l2_a: {address: [3002, 3003], group: i_r, type: float}
+        k__current_l3_a: {address: [3004, 3005], group: i_r, type: float}
+        k__current_neutral_a: {address: [3006, 3007], group: i_r, type: float}
+        current_avg_a: {address: [3010, 3011], group: i_r, type: float}
 
         # Voltages (V) Float32
-        voltage_l1_l2_v:     { address: [3020,3021], group: i_r, type: float }
-        voltage_l2_l3_v:     { address: [3022,3023], group: i_r, type: float }
-        voltage_l3_l1_v:     { address: [3024,3025], group: i_r, type: float }
-        voltage_ll_avg_v:    { address: [3026,3027], group: i_r, type: float }
-        k__voltage_l1_n_v:   { address: [3028,3029], group: i_r, type: float }
-        k__voltage_l2_n_v:   { address: [3030,3031], group: i_r, type: float }
-        k__voltage_l3_n_v:   { address: [3032,3033], group: i_r, type: float }
-        voltage_ln_avg_v:    { address: [3036,3037], group: i_r, type: float }
+        voltage_l1_l2_v: {address: [3020, 3021], group: i_r, type: float}
+        voltage_l2_l3_v: {address: [3022, 3023], group: i_r, type: float}
+        voltage_l3_l1_v: {address: [3024, 3025], group: i_r, type: float}
+        voltage_ll_avg_v: {address: [3026, 3027], group: i_r, type: float}
+        k__voltage_l1_n_v: {address: [3028, 3029], group: i_r, type: float}
+        k__voltage_l2_n_v: {address: [3030, 3031], group: i_r, type: float}
+        k__voltage_l3_n_v: {address: [3032, 3033], group: i_r, type: float}
+        voltage_ln_avg_v: {address: [3036, 3037], group: i_r, type: float}
 
         # Active power (kW) Float32
-        active_power_l1_kw:  { address: [3054,3055], group: i_r, type: float }
-        active_power_l2_kw:  { address: [3056,3057], group: i_r, type: float }
-        active_power_l3_kw:  { address: [3058,3059], group: i_r, type: float }
-        k__active_power_total_kw: { address: [3060,3061], group: i_r, type: float }
+        active_power_l1_kw: {address: [3054, 3055], group: i_r, type: float}
+        active_power_l2_kw: {address: [3056, 3057], group: i_r, type: float}
+        active_power_l3_kw: {address: [3058, 3059], group: i_r, type: float}
+        k__active_power_total_kw: {address: [3060, 3061], group: i_r, type: float}
 
         # Reactive power (kVAR) Float32
-        reactive_power_l1_kvar: { address: [3062,3063], group: i_r, type: float }
-        reactive_power_l2_kvar: { address: [3064,3065], group: i_r, type: float }
-        reactive_power_l3_kvar: { address: [3066,3067], group: i_r, type: float }
-        k__reactive_power_total_kvar: { address: [3068,3069], group: i_r, type: float }
+        reactive_power_l1_kvar: {address: [3062, 3063], group: i_r, type: float}
+        reactive_power_l2_kvar: {address: [3064, 3065], group: i_r, type: float}
+        reactive_power_l3_kvar: {address: [3066, 3067], group: i_r, type: float}
+        k__reactive_power_total_kvar: {address: [3068, 3069], group: i_r, type: float}
 
         # Apparent power (kVA) Float32
-        apparent_power_l1_kva: { address: [3070,3071], group: i_r, type: float }
-        apparent_power_l2_kva: { address: [3072,3073], group: i_r, type: float }
-        apparent_power_l3_kva: { address: [3074,3075], group: i_r, type: float }
-        k__apparent_power_total_kva: { address: [3076,3077], group: i_r, type: float }
+        apparent_power_l1_kva: {address: [3070, 3071], group: i_r, type: float}
+        apparent_power_l2_kva: {address: [3072, 3073], group: i_r, type: float}
+        apparent_power_l3_kva: {address: [3074, 3075], group: i_r, type: float}
+        k__apparent_power_total_kva: {address: [3076, 3077], group: i_r, type: float}
 
         # Power factor + frequency Float32
-        k__power_factor:     { address: [3084,3085], group: i_r, type: float }
-        k__frequency_hz:     { address: [3110,3111], group: i_r, type: float }
+        k__power_factor: {address: [3084, 3085], group: i_r, type: float}
+        k__frequency_hz: {address: [3110, 3111], group: i_r, type: float}
 
         # Meter temperature (C) Float32
-        temperature_c:       { address: [3132,3133], group: i_r, type: float }
+        temperature_c: {address: [3132, 3133], group: i_r, type: float}
 
         # Energy totals (Wh) Float32
-        energy_import_total_wh: { address: [45166,45167], group: h_r, type: float }
-        energy_export_total_wh: { address: [45168,45169], group: h_r, type: float }
+        energy_import_total_wh: {address: [45166, 45167], group: h_r, type: float}
+        energy_export_total_wh: {address: [45168, 45169], group: h_r, type: float}
 
 scenarios:
   peak_demand:
+    display_name: Peak Demand
     description: High load with balanced phases and near-unity power factor.
     duration: 30.0
     overrides:
@@ -236,6 +305,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   pv_export:
+    display_name: PV Export
     description: Simulated PV export using negative phase currents.
     duration: 30.0
     overrides:
@@ -246,6 +316,7 @@ scenarios:
       $in(power_factor_leading): 1
 
   low_power_factor_lagging:
+    display_name: Low Power Factor Lagging
     description: Inductive load with low power factor.
     duration: 45.0
     overrides:

--- a/library/domains/energy/meter/schneider/schneider_pm5330__modbus.yaml
+++ b/library/domains/energy/meter/schneider/schneider_pm5330__modbus.yaml
@@ -16,42 +16,99 @@ meta_parameters:
 
 attributes:
   # Phase currents (A)
-  k__current_l1_a: 12.0
-  k__current_l2_a: 10.5
-  k__current_l3_a: 11.2
-  current_avg_a: 0.0
-
-  # Phase-to-neutral voltages (V)
-  k__voltage_l1_n_v: 230.0
-  k__voltage_l2_n_v: 229.5
-  k__voltage_l3_n_v: 231.0
-  voltage_ln_avg_v: 0.0
-
-  # Line-to-line voltages (V) (derived from L-N; balanced phasor assumption)
-  voltage_l1_l2_v: 0.0
-  voltage_l2_l3_v: 0.0
-  voltage_l3_l1_v: 0.0
-  voltage_ll_avg_v: 0.0
-
-  # Power (kW/kVAR/kVA)
-  k__power_factor: 0.95
-  power_factor_leading: 0
-  active_power_l1_kw: 0.0
-  active_power_l2_kw: 0.0
-  active_power_l3_kw: 0.0
-  k__active_power_total_kw: 0.0
-  k__reactive_power_total_kvar: 0.0
-  k__apparent_power_total_kva: 0.0
-
-  # Frequency (Hz)
-  k__frequency_hz: 50.0
-
-  # Cumulative energy (kWh)
-  k__energy_import_total_kwh: 0.0
-  k__energy_export_total_kwh: 0.0
-
-  _cycle_time_s: 1.0
-
+  k__current_l1_a:
+    type: float
+    default: 12.0
+    unit: A
+  k__current_l2_a:
+    type: float
+    default: 10.5
+    unit: A
+  k__current_l3_a:
+    type: float
+    default: 11.2
+    unit: A
+  current_avg_a:
+    type: float
+    default: 0.0
+    unit: A
+  k__voltage_l1_n_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__voltage_l2_n_v:
+    type: float
+    default: 229.5
+    unit: V
+  k__voltage_l3_n_v:
+    type: float
+    default: 231.0
+    unit: V
+  voltage_ln_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l1_l2_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l2_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l3_l1_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_ll_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  k__power_factor:
+    type: float
+    default: 0.95
+  power_factor_leading:
+    type: int
+    default: 0
+  active_power_l1_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  active_power_l2_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  active_power_l3_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  k__active_power_total_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  k__reactive_power_total_kvar:
+    type: float
+    default: 0.0
+  k__apparent_power_total_kva:
+    type: float
+    default: 0.0
+    unit: kVA
+  k__frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  k__energy_import_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  k__energy_export_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  _cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 actions:
   - function: $in(current_avg_a)
     name: compute_current_avg
@@ -86,12 +143,7 @@ actions:
   - function: $in(k__apparent_power_total_kva)
     name: compute_apparent_power
     description: Total apparent power (sum of per-phase V*I).
-    call: 1e-3
-         * (
-             $in(k__voltage_l1_n_v) * $in(k__current_l1_a)
-             + $in(k__voltage_l2_n_v) * $in(k__current_l2_a)
-             + $in(k__voltage_l3_n_v) * $in(k__current_l3_a)
-           )
+    call: 1e-3 * ( $in(k__voltage_l1_n_v) * $in(k__current_l1_a) + $in(k__voltage_l2_n_v) * $in(k__current_l2_a) + $in(k__voltage_l3_n_v) * $in(k__current_l3_a) )
 
   - function: $in(active_power_l1_kw)
     name: compute_active_power_l1
@@ -116,9 +168,7 @@ actions:
   - function: $in(k__reactive_power_total_kvar)
     name: compute_reactive_power_total
     description: Approximate total reactive power magnitude from active/apparent power.
-    call: (
-          max(0.0, ($in(k__apparent_power_total_kva) ** 2) - ($in(k__active_power_total_kw) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(k__apparent_power_total_kva) ** 2) - ($in(k__active_power_total_kw) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(k__energy_import_total_kwh)
     name: integrate_energy_import
@@ -138,41 +188,42 @@ communication:
       zero_fill: true
       mapping:
         # Currents (A) Float32
-        k__current_l1_a:     { address: [3000,3001], group: i_r, type: float }
-        k__current_l2_a:     { address: [3002,3003], group: i_r, type: float }
-        k__current_l3_a:     { address: [3004,3005], group: i_r, type: float }
-        current_avg_a:       { address: [3010,3011], group: i_r, type: float }
+        k__current_l1_a: {address: [3000, 3001], group: i_r, type: float}
+        k__current_l2_a: {address: [3002, 3003], group: i_r, type: float}
+        k__current_l3_a: {address: [3004, 3005], group: i_r, type: float}
+        current_avg_a: {address: [3010, 3011], group: i_r, type: float}
 
         # Voltages (V) Float32
-        voltage_l1_l2_v:     { address: [3020,3021], group: i_r, type: float }
-        voltage_l2_l3_v:     { address: [3022,3023], group: i_r, type: float }
-        voltage_l3_l1_v:     { address: [3024,3025], group: i_r, type: float }
-        voltage_ll_avg_v:    { address: [3026,3027], group: i_r, type: float }
-        k__voltage_l1_n_v:   { address: [3028,3029], group: i_r, type: float }
-        k__voltage_l2_n_v:   { address: [3030,3031], group: i_r, type: float }
-        k__voltage_l3_n_v:   { address: [3032,3033], group: i_r, type: float }
-        voltage_ln_avg_v:    { address: [3036,3037], group: i_r, type: float }
+        voltage_l1_l2_v: {address: [3020, 3021], group: i_r, type: float}
+        voltage_l2_l3_v: {address: [3022, 3023], group: i_r, type: float}
+        voltage_l3_l1_v: {address: [3024, 3025], group: i_r, type: float}
+        voltage_ll_avg_v: {address: [3026, 3027], group: i_r, type: float}
+        k__voltage_l1_n_v: {address: [3028, 3029], group: i_r, type: float}
+        k__voltage_l2_n_v: {address: [3030, 3031], group: i_r, type: float}
+        k__voltage_l3_n_v: {address: [3032, 3033], group: i_r, type: float}
+        voltage_ln_avg_v: {address: [3036, 3037], group: i_r, type: float}
 
         # Active power (kW) Float32
-        active_power_l1_kw:  { address: [3054,3055], group: i_r, type: float }
-        active_power_l2_kw:  { address: [3056,3057], group: i_r, type: float }
-        active_power_l3_kw:  { address: [3058,3059], group: i_r, type: float }
-        k__active_power_total_kw: { address: [3060,3061], group: i_r, type: float }
+        active_power_l1_kw: {address: [3054, 3055], group: i_r, type: float}
+        active_power_l2_kw: {address: [3056, 3057], group: i_r, type: float}
+        active_power_l3_kw: {address: [3058, 3059], group: i_r, type: float}
+        k__active_power_total_kw: {address: [3060, 3061], group: i_r, type: float}
 
         # Optional power quality (kVAR/kVA) Float32
-        k__reactive_power_total_kvar: { address: [3068,3069], group: i_r, type: float }
-        k__apparent_power_total_kva:  { address: [3076,3077], group: i_r, type: float }
+        k__reactive_power_total_kvar: {address: [3068, 3069], group: i_r, type: float}
+        k__apparent_power_total_kva: {address: [3076, 3077], group: i_r, type: float}
 
         # Power factor + frequency Float32
-        k__power_factor:     { address: [3192,3193], group: i_r, type: float }
-        k__frequency_hz:     { address: [3110,3111], group: i_r, type: float }
+        k__power_factor: {address: [3192, 3193], group: i_r, type: float}
+        k__frequency_hz: {address: [3110, 3111], group: i_r, type: float}
 
         # Energy totals (kWh) Float32
-        k__energy_import_total_kwh: { address: [2700,2701], group: i_r, type: float }
-        k__energy_export_total_kwh: { address: [2702,2703], group: i_r, type: float }
+        k__energy_import_total_kwh: {address: [2700, 2701], group: i_r, type: float}
+        k__energy_export_total_kwh: {address: [2702, 2703], group: i_r, type: float}
 
 scenarios:
   peak_demand:
+    display_name: Peak Demand
     description: High load with balanced phases and near-unity power factor.
     duration: 30.0
     overrides:
@@ -183,6 +234,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   pv_export:
+    display_name: PV Export
     description: Simulated PV export using negative phase currents.
     duration: 30.0
     overrides:
@@ -193,6 +245,7 @@ scenarios:
       $in(power_factor_leading): 1
 
   low_power_factor_lagging:
+    display_name: Low Power Factor Lagging
     description: Inductive load with low power factor.
     duration: 45.0
     overrides:
@@ -200,6 +253,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   voltage_sag:
+    display_name: Voltage Sag
     description: Phase-to-neutral voltage sag across all phases.
     duration: 30.0
     overrides:
@@ -208,6 +262,7 @@ scenarios:
       $in(k__voltage_l3_n_v): 210.0
 
   frequency_drift:
+    display_name: Frequency Drift
     description: Off-nominal grid frequency condition.
     duration: 20.0
     overrides:

--- a/library/domains/energy/meter/schneider/schneider_powerlogic_pm8000__modbus.yaml
+++ b/library/domains/energy/meter/schneider/schneider_powerlogic_pm8000__modbus.yaml
@@ -17,24 +17,52 @@ meta_parameters:
 
 attributes:
   # Averaged electrical measurements
-  k__current_avg_a: 12.0
-  k__voltage_ll_avg_v: 400.0
-  k__voltage_ln_avg_v: 230.0
-  k__power_factor: 0.97
-  power_factor_leading: 0
-  k__frequency_hz: 50.0
-
-  # Derived totals (W/VAR/VA)
-  active_power_total_w: 0.0
-  reactive_power_total_var: 0.0
-  apparent_power_total_va: 0.0
-
-  # Cumulative energy (kWh)
-  energy_import_total_kwh: 0.0
-  energy_export_total_kwh: 0.0
-
-  _cycle_time_s: 1.0
-
+  k__current_avg_a:
+    type: float
+    default: 12.0
+    unit: A
+  k__voltage_ll_avg_v:
+    type: float
+    default: 400.0
+    unit: V
+  k__voltage_ln_avg_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__power_factor:
+    type: float
+    default: 0.97
+  power_factor_leading:
+    type: int
+    default: 0
+  k__frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  active_power_total_w:
+    type: float
+    default: 0.0
+    unit: W
+  reactive_power_total_var:
+    type: float
+    default: 0.0
+    unit: var
+  apparent_power_total_va:
+    type: float
+    default: 0.0
+    unit: VA
+  energy_import_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  energy_export_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  _cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 actions:
   - function: $in(apparent_power_total_va)
     name: compute_apparent_power
@@ -82,25 +110,26 @@ communication:
       zero_fill: true
       mapping:
         # Averages (Float32 input registers)
-        k__current_avg_a:     { address: [3010, 3011], group: i_r, type: float }
-        k__voltage_ll_avg_v:  { address: [3026, 3027], group: i_r, type: float }
-        k__voltage_ln_avg_v:  { address: [3036, 3037], group: i_r, type: float }
+        k__current_avg_a: {address: [3010, 3011], group: i_r, type: float}
+        k__voltage_ll_avg_v: {address: [3026, 3027], group: i_r, type: float}
+        k__voltage_ln_avg_v: {address: [3036, 3037], group: i_r, type: float}
 
         # Power totals (Float32 input registers)
-        active_power_total_w:    { address: [3060, 3061], group: i_r, type: float }
-        reactive_power_total_var: { address: [3068, 3069], group: i_r, type: float }
-        apparent_power_total_va: { address: [3076, 3077], group: i_r, type: float }
+        active_power_total_w: {address: [3060, 3061], group: i_r, type: float}
+        reactive_power_total_var: {address: [3068, 3069], group: i_r, type: float}
+        apparent_power_total_va: {address: [3076, 3077], group: i_r, type: float}
 
         # Power factor + frequency (Float32 input registers)
-        k__power_factor:      { address: [3150, 3151], group: i_r, type: float }
-        k__frequency_hz:      { address: [3110, 3111], group: i_r, type: float }
+        k__power_factor: {address: [3150, 3151], group: i_r, type: float}
+        k__frequency_hz: {address: [3110, 3111], group: i_r, type: float}
 
         # Energy totals (Float32 input registers)
-        energy_import_total_kwh: { address: [2700, 2701], group: i_r, type: float }
-        energy_export_total_kwh: { address: [2702, 2703], group: i_r, type: float }
+        energy_import_total_kwh: {address: [2700, 2701], group: i_r, type: float}
+        energy_export_total_kwh: {address: [2702, 2703], group: i_r, type: float}
 
 scenarios:
   peak_demand:
+    display_name: Peak Demand
     description: High load, lagging power factor.
     duration: 30.0
     overrides:
@@ -109,6 +138,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   pv_export:
+    display_name: PV Export
     description: Simulated PV export with leading power factor.
     duration: 30.0
     overrides:

--- a/library/domains/energy/meter/siemens/siemens_pac3200__modbus.yaml
+++ b/library/domains/energy/meter/siemens/siemens_pac3200__modbus.yaml
@@ -17,51 +17,133 @@ meta_parameters:
 
 attributes:
   # Phase currents (A)
-  k__current_l1_a: 12.0
-  k__current_l2_a: 10.5
-  k__current_l3_a: 11.2
-  current_avg_a: 0.0
-
-  # Phase-to-neutral voltages (V)
-  k__voltage_l1_n_v: 230.0
-  k__voltage_l2_n_v: 229.5
-  k__voltage_l3_n_v: 231.0
-  voltage_ln_avg_v: 0.0
-
-  # Line-to-line voltages (V)
-  voltage_l1_l2_v: 0.0
-  voltage_l2_l3_v: 0.0
-  voltage_l3_l1_v: 0.0
-  voltage_ll_avg_v: 0.0
-
-  # Power
-  k__power_factor: 0.95
-  power_factor_leading: 0
-  power_factor_l1: 0.0
-  power_factor_l2: 0.0
-  power_factor_l3: 0.0
-  apparent_power_l1_va: 0.0
-  apparent_power_l2_va: 0.0
-  apparent_power_l3_va: 0.0
-  active_power_l1_w: 0.0
-  active_power_l2_w: 0.0
-  active_power_l3_w: 0.0
-  reactive_power_l1_var: 0.0
-  reactive_power_l2_var: 0.0
-  reactive_power_l3_var: 0.0
-  active_power_total_w: 0.0
-  reactive_power_total_var: 0.0
-  apparent_power_total_va: 0.0
-
-  # Frequency (Hz)
-  k__frequency_hz: 50.0
-
-  # Cumulative energy (Wh)
-  energy_import_total_wh: 0.0
-  energy_export_total_wh: 0.0
-
-  _cycle_time_s: 1.0
-
+  k__current_l1_a:
+    type: float
+    default: 12.0
+    unit: A
+  k__current_l2_a:
+    type: float
+    default: 10.5
+    unit: A
+  k__current_l3_a:
+    type: float
+    default: 11.2
+    unit: A
+  current_avg_a:
+    type: float
+    default: 0.0
+    unit: A
+  k__voltage_l1_n_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__voltage_l2_n_v:
+    type: float
+    default: 229.5
+    unit: V
+  k__voltage_l3_n_v:
+    type: float
+    default: 231.0
+    unit: V
+  voltage_ln_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l1_l2_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l2_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l3_l1_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_ll_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  k__power_factor:
+    type: float
+    default: 0.95
+  power_factor_leading:
+    type: int
+    default: 0
+  power_factor_l1:
+    type: float
+    default: 0.0
+  power_factor_l2:
+    type: float
+    default: 0.0
+  power_factor_l3:
+    type: float
+    default: 0.0
+  apparent_power_l1_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_l2_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_l3_va:
+    type: float
+    default: 0.0
+    unit: VA
+  active_power_l1_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_l2_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_l3_w:
+    type: float
+    default: 0.0
+    unit: W
+  reactive_power_l1_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_l2_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_l3_var:
+    type: float
+    default: 0.0
+    unit: var
+  active_power_total_w:
+    type: float
+    default: 0.0
+    unit: W
+  reactive_power_total_var:
+    type: float
+    default: 0.0
+    unit: var
+  apparent_power_total_va:
+    type: float
+    default: 0.0
+    unit: VA
+  k__frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  energy_import_total_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  energy_export_total_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  _cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 actions:
   - function: $in(current_avg_a)
     name: compute_current_avg
@@ -141,23 +223,17 @@ actions:
   - function: $in(reactive_power_l1_var)
     name: compute_reactive_power_l1
     description: Phase L1 reactive power.
-    call: (
-          max(0.0, ($in(apparent_power_l1_va) ** 2) - ($in(active_power_l1_w) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(apparent_power_l1_va) ** 2) - ($in(active_power_l1_w) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(reactive_power_l2_var)
     name: compute_reactive_power_l2
     description: Phase L2 reactive power.
-    call: (
-          max(0.0, ($in(apparent_power_l2_va) ** 2) - ($in(active_power_l2_w) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(apparent_power_l2_va) ** 2) - ($in(active_power_l2_w) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(reactive_power_l3_var)
     name: compute_reactive_power_l3
     description: Phase L3 reactive power.
-    call: (
-          max(0.0, ($in(apparent_power_l3_va) ** 2) - ($in(active_power_l3_w) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(apparent_power_l3_va) ** 2) - ($in(active_power_l3_w) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(apparent_power_total_va)
     name: compute_apparent_power_total
@@ -192,44 +268,45 @@ communication:
       zero_fill: true
       mapping:
         # Voltages (V) Float32
-        k__voltage_l1_n_v:   { address: [1,2], group: h_r, type: float }
-        k__voltage_l2_n_v:   { address: [3,4], group: h_r, type: float }
-        k__voltage_l3_n_v:   { address: [5,6], group: h_r, type: float }
-        voltage_l1_l2_v:     { address: [7,8], group: h_r, type: float }
-        voltage_l2_l3_v:     { address: [9,10], group: h_r, type: float }
-        voltage_l3_l1_v:     { address: [11,12], group: h_r, type: float }
-        voltage_ln_avg_v:    { address: [57,58], group: h_r, type: float }
-        voltage_ll_avg_v:    { address: [59,60], group: h_r, type: float }
+        k__voltage_l1_n_v: {address: [1, 2], group: h_r, type: float}
+        k__voltage_l2_n_v: {address: [3, 4], group: h_r, type: float}
+        k__voltage_l3_n_v: {address: [5, 6], group: h_r, type: float}
+        voltage_l1_l2_v: {address: [7, 8], group: h_r, type: float}
+        voltage_l2_l3_v: {address: [9, 10], group: h_r, type: float}
+        voltage_l3_l1_v: {address: [11, 12], group: h_r, type: float}
+        voltage_ln_avg_v: {address: [57, 58], group: h_r, type: float}
+        voltage_ll_avg_v: {address: [59, 60], group: h_r, type: float}
 
         # Currents (A) Float32
-        k__current_l1_a:     { address: [13,14], group: h_r, type: float }
-        k__current_l2_a:     { address: [15,16], group: h_r, type: float }
-        k__current_l3_a:     { address: [17,18], group: h_r, type: float }
-        current_avg_a:       { address: [61,62], group: h_r, type: float }
+        k__current_l1_a: {address: [13, 14], group: h_r, type: float}
+        k__current_l2_a: {address: [15, 16], group: h_r, type: float}
+        k__current_l3_a: {address: [17, 18], group: h_r, type: float}
+        current_avg_a: {address: [61, 62], group: h_r, type: float}
 
         # Frequency (Hz) Float32
-        k__frequency_hz:     { address: [55,56], group: h_r, type: float }
+        k__frequency_hz: {address: [55, 56], group: h_r, type: float}
 
         # Power (W/var/VA) Float32
-        apparent_power_l1_va:    { address: [19,20], group: h_r, type: float }
-        apparent_power_l2_va:    { address: [21,22], group: h_r, type: float }
-        apparent_power_l3_va:    { address: [23,24], group: h_r, type: float }
-        active_power_l1_w:       { address: [25,26], group: h_r, type: float }
-        active_power_l2_w:       { address: [27,28], group: h_r, type: float }
-        active_power_l3_w:       { address: [29,30], group: h_r, type: float }
-        reactive_power_l1_var:   { address: [31,32], group: h_r, type: float }
-        reactive_power_l2_var:   { address: [33,34], group: h_r, type: float }
-        reactive_power_l3_var:   { address: [35,36], group: h_r, type: float }
-        power_factor_l1:         { address: [37,38], group: h_r, type: float }
-        power_factor_l2:         { address: [39,40], group: h_r, type: float }
-        power_factor_l3:         { address: [41,42], group: h_r, type: float }
-        apparent_power_total_va: { address: [63,64], group: h_r, type: float }
-        active_power_total_w:    { address: [65,66], group: h_r, type: float }
-        reactive_power_total_var: { address: [67,68], group: h_r, type: float }
-        k__power_factor:         { address: [69,70], group: h_r, type: float }
+        apparent_power_l1_va: {address: [19, 20], group: h_r, type: float}
+        apparent_power_l2_va: {address: [21, 22], group: h_r, type: float}
+        apparent_power_l3_va: {address: [23, 24], group: h_r, type: float}
+        active_power_l1_w: {address: [25, 26], group: h_r, type: float}
+        active_power_l2_w: {address: [27, 28], group: h_r, type: float}
+        active_power_l3_w: {address: [29, 30], group: h_r, type: float}
+        reactive_power_l1_var: {address: [31, 32], group: h_r, type: float}
+        reactive_power_l2_var: {address: [33, 34], group: h_r, type: float}
+        reactive_power_l3_var: {address: [35, 36], group: h_r, type: float}
+        power_factor_l1: {address: [37, 38], group: h_r, type: float}
+        power_factor_l2: {address: [39, 40], group: h_r, type: float}
+        power_factor_l3: {address: [41, 42], group: h_r, type: float}
+        apparent_power_total_va: {address: [63, 64], group: h_r, type: float}
+        active_power_total_w: {address: [65, 66], group: h_r, type: float}
+        reactive_power_total_var: {address: [67, 68], group: h_r, type: float}
+        k__power_factor: {address: [69, 70], group: h_r, type: float}
 
 scenarios:
   peak_demand:
+    display_name: Peak Demand
     description: High load with balanced phases and near-unity power factor.
     duration: 30.0
     overrides:
@@ -240,6 +317,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   pv_export:
+    display_name: PV Export
     description: Simulated PV export using negative phase currents.
     duration: 30.0
     overrides:
@@ -250,6 +328,7 @@ scenarios:
       $in(power_factor_leading): 1
 
   low_power_factor_lagging:
+    display_name: Low Power Factor Lagging
     description: Inductive load with low power factor.
     duration: 45.0
     overrides:
@@ -257,6 +336,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   voltage_sag:
+    display_name: Voltage Sag
     description: Phase-to-neutral voltage sag across all phases.
     duration: 30.0
     overrides:
@@ -265,6 +345,7 @@ scenarios:
       $in(k__voltage_l3_n_v): 210.0
 
   frequency_drift:
+    display_name: Frequency Drift
     description: Off-nominal grid frequency condition.
     duration: 20.0
     overrides:

--- a/library/domains/energy/meter/socomec/diris_a40__modbus.yaml
+++ b/library/domains/energy/meter/socomec/diris_a40__modbus.yaml
@@ -17,47 +17,115 @@ meta_parameters:
 
 attributes:
   # Phase currents (A)
-  k__current_l1_a: 12.0
-  k__current_l2_a: 10.5
-  k__current_l3_a: 11.2
-  current_avg_a: 0.0
-
-  # Phase-to-neutral voltages (V)
-  k__voltage_l1_n_v: 230.0
-  k__voltage_l2_n_v: 229.5
-  k__voltage_l3_n_v: 231.0
-  voltage_ln_avg_v: 0.0
-
-  # Line-to-line voltages (V) (derived from L-N; suitable for demo dashboards)
-  voltage_l1_l2_v: 0.0
-  voltage_l2_l3_v: 0.0
-  voltage_l3_l1_v: 0.0
-
-  # Power (kW/kVAR/kVA)
-  k__power_factor: 0.95
-  power_factor_leading: 0
-  active_power_l1_kw: 0.0
-  active_power_l2_kw: 0.0
-  active_power_l3_kw: 0.0
-  k__active_power_total_kw: 0.0
-  k__reactive_power_total_kvar: 0.0
-  k__apparent_power_total_kva: 0.0
-
-  # Frequency (Hz)
-  k__frequency_hz: 50.0
-
-  # Cumulative energy (kWh)
-  k__energy_import_total_kwh: 0.0
-  k__energy_export_total_kwh: 0.0
-
-  _modbus_active_power_l1_w: 0.0
-  _modbus_active_power_l2_w: 0.0
-  _modbus_active_power_l3_w: 0.0
-  _modbus_energy_import_total_kwh: 0
-  _modbus_energy_export_total_kwh: 0
-
-  _cycle_time_s: 1.0
-
+  k__current_l1_a:
+    type: float
+    default: 12.0
+    unit: A
+  k__current_l2_a:
+    type: float
+    default: 10.5
+    unit: A
+  k__current_l3_a:
+    type: float
+    default: 11.2
+    unit: A
+  current_avg_a:
+    type: float
+    default: 0.0
+    unit: A
+  k__voltage_l1_n_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__voltage_l2_n_v:
+    type: float
+    default: 229.5
+    unit: V
+  k__voltage_l3_n_v:
+    type: float
+    default: 231.0
+    unit: V
+  voltage_ln_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l1_l2_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l2_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l3_l1_v:
+    type: float
+    default: 0.0
+    unit: V
+  k__power_factor:
+    type: float
+    default: 0.95
+  power_factor_leading:
+    type: int
+    default: 0
+  active_power_l1_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  active_power_l2_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  active_power_l3_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  k__active_power_total_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  k__reactive_power_total_kvar:
+    type: float
+    default: 0.0
+  k__apparent_power_total_kva:
+    type: float
+    default: 0.0
+    unit: kVA
+  k__frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  k__energy_import_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  k__energy_export_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+  _modbus_active_power_l1_w:
+    type: float
+    default: 0.0
+    unit: W
+  _modbus_active_power_l2_w:
+    type: float
+    default: 0.0
+    unit: W
+  _modbus_active_power_l3_w:
+    type: float
+    default: 0.0
+    unit: W
+  _modbus_energy_import_total_kwh:
+    type: int
+    default: 0
+    unit: kWh
+  _modbus_energy_export_total_kwh:
+    type: int
+    default: 0
+    unit: kWh
+  _cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 actions:
   - function: $in(current_avg_a)
     name: compute_current_avg
@@ -87,12 +155,7 @@ actions:
   - function: $in(k__apparent_power_total_kva)
     name: compute_apparent_power
     description: Total apparent power (sum of per-phase V*I).
-    call: 1e-3
-         * (
-             $in(k__voltage_l1_n_v) * $in(k__current_l1_a)
-             + $in(k__voltage_l2_n_v) * $in(k__current_l2_a)
-             + $in(k__voltage_l3_n_v) * $in(k__current_l3_a)
-           )
+    call: 1e-3 * ( $in(k__voltage_l1_n_v) * $in(k__current_l1_a) + $in(k__voltage_l2_n_v) * $in(k__current_l2_a) + $in(k__voltage_l3_n_v) * $in(k__current_l3_a) )
 
   - function: $in(active_power_l1_kw)
     name: compute_active_power_l1
@@ -117,9 +180,7 @@ actions:
   - function: $in(k__reactive_power_total_kvar)
     name: compute_reactive_power_total
     description: Approximate total reactive power magnitude from active/apparent power.
-    call: (
-          max(0.0, ($in(k__apparent_power_total_kva) ** 2) - ($in(k__active_power_total_kw) ** 2)) ** 0.5
-        ) * (-1.0 if $in(power_factor_leading) else 1.0)
+    call: ( max(0.0, ($in(k__apparent_power_total_kva) ** 2) - ($in(k__active_power_total_kw) ** 2)) ** 0.5 ) * (-1.0 if $in(power_factor_leading) else 1.0)
 
   - function: $in(k__energy_import_total_kwh)
     name: integrate_energy_import
@@ -164,34 +225,35 @@ communication:
       zero_fill: true
       mapping:
         # Frequency (Hz) Float32
-        k__frequency_hz:    { address: [264,265], group: i_r, type: float }
+        k__frequency_hz: {address: [264, 265], group: i_r, type: float}
 
         # Line-to-line voltages (V) Float32
-        voltage_l1_l2_v:    { address: [266,267], group: i_r, type: float }
-        voltage_l2_l3_v:    { address: [268,269], group: i_r, type: float }
-        voltage_l3_l1_v:    { address: [270,271], group: i_r, type: float }
+        voltage_l1_l2_v: {address: [266, 267], group: i_r, type: float}
+        voltage_l2_l3_v: {address: [268, 269], group: i_r, type: float}
+        voltage_l3_l1_v: {address: [270, 271], group: i_r, type: float}
 
         # Phase-to-neutral voltages (V) Float32
-        k__voltage_l1_n_v:  { address: [284,285], group: i_r, type: float }
-        k__voltage_l2_n_v:  { address: [286,287], group: i_r, type: float }
-        k__voltage_l3_n_v:  { address: [288,289], group: i_r, type: float }
+        k__voltage_l1_n_v: {address: [284, 285], group: i_r, type: float}
+        k__voltage_l2_n_v: {address: [286, 287], group: i_r, type: float}
+        k__voltage_l3_n_v: {address: [288, 289], group: i_r, type: float}
 
         # Currents (A) Float32
-        k__current_l1_a:    { address: [308,309], group: i_r, type: float }
-        k__current_l2_a:    { address: [310,311], group: i_r, type: float }
-        k__current_l3_a:    { address: [312,313], group: i_r, type: float }
+        k__current_l1_a: {address: [308, 309], group: i_r, type: float}
+        k__current_l2_a: {address: [310, 311], group: i_r, type: float}
+        k__current_l3_a: {address: [312, 313], group: i_r, type: float}
 
         # Active power (W) Float32
-        _modbus_active_power_l1_w: { address: [344,345], group: i_r, type: float }
-        _modbus_active_power_l2_w: { address: [346,347], group: i_r, type: float }
-        _modbus_active_power_l3_w: { address: [348,349], group: i_r, type: float }
+        _modbus_active_power_l1_w: {address: [344, 345], group: i_r, type: float}
+        _modbus_active_power_l2_w: {address: [346, 347], group: i_r, type: float}
+        _modbus_active_power_l3_w: {address: [348, 349], group: i_r, type: float}
 
         # Energy totals (kWh) UInt32
-        _modbus_energy_import_total_kwh: { address: [19843,19844], group: i_r, type: uint_32 }
-        _modbus_energy_export_total_kwh: { address: [19846,19847], group: i_r, type: uint_32 }
+        _modbus_energy_import_total_kwh: {address: [19843, 19844], group: i_r, type: uint_32}
+        _modbus_energy_export_total_kwh: {address: [19846, 19847], group: i_r, type: uint_32}
 
 scenarios:
   peak_demand:
+    display_name: Peak Demand
     description: High load with balanced phases and near-unity power factor.
     duration: 30.0
     overrides:
@@ -202,6 +264,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   pv_export:
+    display_name: PV Export
     description: Simulated PV export using negative phase currents.
     duration: 30.0
     overrides:
@@ -212,6 +275,7 @@ scenarios:
       $in(power_factor_leading): 1
 
   low_power_factor_lagging:
+    display_name: Low Power Factor Lagging
     description: Inductive load with low power factor.
     duration: 45.0
     overrides:
@@ -219,6 +283,7 @@ scenarios:
       $in(power_factor_leading): 0
 
   voltage_sag:
+    display_name: Voltage Sag
     description: Phase-to-neutral voltage sag across all phases.
     duration: 30.0
     overrides:
@@ -227,6 +292,7 @@ scenarios:
       $in(k__voltage_l3_n_v): 210.0
 
   frequency_drift:
+    display_name: Frequency Drift
     description: Off-nominal grid frequency condition.
     duration: 20.0
     overrides:

--- a/library/domains/energy/power_quality_analyzer/janitza/janitza_umg604_pro__modbus.yaml
+++ b/library/domains/energy/power_quality_analyzer/janitza/janitza_umg604_pro__modbus.yaml
@@ -16,56 +16,138 @@ meta_parameters:
 
 attributes:
   # Phase-to-neutral voltages (V)
-  k__voltage_l1_n_v: 230.0
-  k__voltage_l2_n_v: 229.5
-  k__voltage_l3_n_v: 231.0
-
-  # Line-to-line voltages (V)
-  voltage_l1_l2_v: 0.0
-  voltage_l2_l3_v: 0.0
-  voltage_l3_l1_v: 0.0
-
-  # Phase currents (A)
-  k__current_l1_a: 12.0
-  k__current_l2_a: 11.0
-  k__current_l3_a: 11.5
-  current_neutral_a: 0.0
-
-  # Power factor
-  k__power_factor_l1: 0.97
-  k__power_factor_l2: 0.96
-  k__power_factor_l3: 0.98
-  power_factor_avg: 0.0
-
-  # Frequency (Hz)
-  k__frequency_hz: 50.0
-
-  # Power (W/VA/var)
-  active_power_l1_w: 0.0
-  active_power_l2_w: 0.0
-  active_power_l3_w: 0.0
-  k__active_power_total_w: 0.0
-
-  apparent_power_l1_va: 0.0
-  apparent_power_l2_va: 0.0
-  apparent_power_l3_va: 0.0
-  k__apparent_power_total_va: 0.0
-
-  reactive_power_l1_var: 0.0
-  reactive_power_l2_var: 0.0
-  reactive_power_l3_var: 0.0
-  k__reactive_power_total_var: 0.0
-
-  # Energy (Wh)
-  energy_l1_wh: 0.0
-  energy_l2_wh: 0.0
-  energy_l3_wh: 0.0
-  k__energy_total_wh: 0.0
-  k__energy_import_total_wh: 0.0
-  k__energy_export_total_wh: 0.0
-
-  _cycle_time_s: 1.0
-
+  k__voltage_l1_n_v:
+    type: float
+    default: 230.0
+    unit: V
+  k__voltage_l2_n_v:
+    type: float
+    default: 229.5
+    unit: V
+  k__voltage_l3_n_v:
+    type: float
+    default: 231.0
+    unit: V
+  voltage_l1_l2_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l2_l3_v:
+    type: float
+    default: 0.0
+    unit: V
+  voltage_l3_l1_v:
+    type: float
+    default: 0.0
+    unit: V
+  k__current_l1_a:
+    type: float
+    default: 12.0
+    unit: A
+  k__current_l2_a:
+    type: float
+    default: 11.0
+    unit: A
+  k__current_l3_a:
+    type: float
+    default: 11.5
+    unit: A
+  current_neutral_a:
+    type: float
+    default: 0.0
+    unit: A
+  k__power_factor_l1:
+    type: float
+    default: 0.97
+  k__power_factor_l2:
+    type: float
+    default: 0.96
+  k__power_factor_l3:
+    type: float
+    default: 0.98
+  power_factor_avg:
+    type: float
+    default: 0.0
+  k__frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  active_power_l1_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_l2_w:
+    type: float
+    default: 0.0
+    unit: W
+  active_power_l3_w:
+    type: float
+    default: 0.0
+    unit: W
+  k__active_power_total_w:
+    type: float
+    default: 0.0
+    unit: W
+  apparent_power_l1_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_l2_va:
+    type: float
+    default: 0.0
+    unit: VA
+  apparent_power_l3_va:
+    type: float
+    default: 0.0
+    unit: VA
+  k__apparent_power_total_va:
+    type: float
+    default: 0.0
+    unit: VA
+  reactive_power_l1_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_l2_var:
+    type: float
+    default: 0.0
+    unit: var
+  reactive_power_l3_var:
+    type: float
+    default: 0.0
+    unit: var
+  k__reactive_power_total_var:
+    type: float
+    default: 0.0
+    unit: var
+  energy_l1_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  energy_l2_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  energy_l3_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  k__energy_total_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  k__energy_import_total_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  k__energy_export_total_wh:
+    type: float
+    default: 0.0
+    unit: Wh
+  _cycle_time_s:
+    type: float
+    default: 1.0
+    unit: s
 actions:
   - function: $in(current_neutral_a)
     name: approximate_neutral_current_a
@@ -190,50 +272,50 @@ communication:
       zero_fill: true
       mapping:
         # Voltages (V) Float32
-        k__voltage_l1_n_v:   { address: [19000, 19001], group: i_r, type: float }
-        k__voltage_l2_n_v:   { address: [19002, 19003], group: i_r, type: float }
-        k__voltage_l3_n_v:   { address: [19004, 19005], group: i_r, type: float }
-        voltage_l1_l2_v:     { address: [19006, 19007], group: i_r, type: float }
-        voltage_l2_l3_v:     { address: [19008, 19009], group: i_r, type: float }
-        voltage_l3_l1_v:     { address: [19010, 19011], group: i_r, type: float }
+        k__voltage_l1_n_v: {address: [19000, 19001], group: i_r, type: float}
+        k__voltage_l2_n_v: {address: [19002, 19003], group: i_r, type: float}
+        k__voltage_l3_n_v: {address: [19004, 19005], group: i_r, type: float}
+        voltage_l1_l2_v: {address: [19006, 19007], group: i_r, type: float}
+        voltage_l2_l3_v: {address: [19008, 19009], group: i_r, type: float}
+        voltage_l3_l1_v: {address: [19010, 19011], group: i_r, type: float}
 
         # Currents (A) Float32
-        k__current_l1_a:     { address: [19012, 19013], group: i_r, type: float }
-        k__current_l2_a:     { address: [19014, 19015], group: i_r, type: float }
-        k__current_l3_a:     { address: [19016, 19017], group: i_r, type: float }
-        current_neutral_a:   { address: [19018, 19019], group: i_r, type: float }
+        k__current_l1_a: {address: [19012, 19013], group: i_r, type: float}
+        k__current_l2_a: {address: [19014, 19015], group: i_r, type: float}
+        k__current_l3_a: {address: [19016, 19017], group: i_r, type: float}
+        current_neutral_a: {address: [19018, 19019], group: i_r, type: float}
 
         # Power factor + frequency Float32
-        k__power_factor_l1:  { address: [19044, 19045], group: i_r, type: float }
-        k__power_factor_l2:  { address: [19046, 19047], group: i_r, type: float }
-        k__power_factor_l3:  { address: [19048, 19049], group: i_r, type: float }
-        k__frequency_hz:     { address: [19050, 19051], group: i_r, type: float }
+        k__power_factor_l1: {address: [19044, 19045], group: i_r, type: float}
+        k__power_factor_l2: {address: [19046, 19047], group: i_r, type: float}
+        k__power_factor_l3: {address: [19048, 19049], group: i_r, type: float}
+        k__frequency_hz: {address: [19050, 19051], group: i_r, type: float}
 
         # Active power (W) Float32
-        active_power_l1_w:   { address: [19020, 19021], group: i_r, type: float }
-        active_power_l2_w:   { address: [19022, 19023], group: i_r, type: float }
-        active_power_l3_w:   { address: [19024, 19025], group: i_r, type: float }
-        k__active_power_total_w: { address: [19026, 19027], group: i_r, type: float }
+        active_power_l1_w: {address: [19020, 19021], group: i_r, type: float}
+        active_power_l2_w: {address: [19022, 19023], group: i_r, type: float}
+        active_power_l3_w: {address: [19024, 19025], group: i_r, type: float}
+        k__active_power_total_w: {address: [19026, 19027], group: i_r, type: float}
 
         # Apparent power (VA) Float32
-        apparent_power_l1_va: { address: [19028, 19029], group: i_r, type: float }
-        apparent_power_l2_va: { address: [19030, 19031], group: i_r, type: float }
-        apparent_power_l3_va: { address: [19032, 19033], group: i_r, type: float }
-        k__apparent_power_total_va: { address: [19034, 19035], group: i_r, type: float }
+        apparent_power_l1_va: {address: [19028, 19029], group: i_r, type: float}
+        apparent_power_l2_va: {address: [19030, 19031], group: i_r, type: float}
+        apparent_power_l3_va: {address: [19032, 19033], group: i_r, type: float}
+        k__apparent_power_total_va: {address: [19034, 19035], group: i_r, type: float}
 
         # Reactive power (var) Float32
-        reactive_power_l1_var: { address: [19036, 19037], group: i_r, type: float }
-        reactive_power_l2_var: { address: [19038, 19039], group: i_r, type: float }
-        reactive_power_l3_var: { address: [19040, 19041], group: i_r, type: float }
-        k__reactive_power_total_var: { address: [19042, 19043], group: i_r, type: float }
+        reactive_power_l1_var: {address: [19036, 19037], group: i_r, type: float}
+        reactive_power_l2_var: {address: [19038, 19039], group: i_r, type: float}
+        reactive_power_l3_var: {address: [19040, 19041], group: i_r, type: float}
+        k__reactive_power_total_var: {address: [19042, 19043], group: i_r, type: float}
 
         # Energy (Wh) Float32
-        energy_l1_wh:         { address: [19054, 19055], group: i_r, type: float }
-        energy_l2_wh:         { address: [19056, 19057], group: i_r, type: float }
-        energy_l3_wh:         { address: [19058, 19059], group: i_r, type: float }
-        k__energy_total_wh:   { address: [19060, 19061], group: i_r, type: float }
-        k__energy_import_total_wh: { address: [19068, 19069], group: i_r, type: float }
-        k__energy_export_total_wh: { address: [19076, 19077], group: i_r, type: float }
+        energy_l1_wh: {address: [19054, 19055], group: i_r, type: float}
+        energy_l2_wh: {address: [19056, 19057], group: i_r, type: float}
+        energy_l3_wh: {address: [19058, 19059], group: i_r, type: float}
+        k__energy_total_wh: {address: [19060, 19061], group: i_r, type: float}
+        k__energy_import_total_wh: {address: [19068, 19069], group: i_r, type: float}
+        k__energy_export_total_wh: {address: [19076, 19077], group: i_r, type: float}
 
 scenarios:
   balanced_nominal_load:

--- a/library/domains/energy/ups/apc/apc_easy_ups_3m__modbus.yaml
+++ b/library/domains/energy/ups/apc/apc_easy_ups_3m__modbus.yaml
@@ -16,83 +16,229 @@ meta_parameters:
 
 attributes:
   # Input currents (A)
-  input_current_phase_a_a: 12.0
-  input_current_phase_b_a: 11.6
-  input_current_phase_c_a: 12.2
-  input_current_avg_a: 0.0
-
-  # Output currents (A)
-  output_current_phase_a_a: 10.8
-  output_current_phase_b_a: 10.4
-  output_current_phase_c_a: 11.1
-  output_current_avg_a: 0.0
-
-  # Frequencies (Hz)
-  input_frequency_hz: 50.0
-  output_frequency_hz: 50.0
-  bypass_frequency_hz: 50.0
-
-  # Power factor (ratio)
-  input_power_factor_phase_a: 0.98
-  input_power_factor_phase_b: 0.97
-  input_power_factor_phase_c: 0.99
-
-  # Output power
-  output_active_power_phase_a_kw: 8.2
-  output_active_power_phase_b_kw: 7.9
-  output_active_power_phase_c_kw: 8.4
-  output_active_power_total_kw: 0.0
-
-  output_apparent_power_phase_a_kva: 8.7
-  output_apparent_power_phase_b_kva: 8.3
-  output_apparent_power_phase_c_kva: 8.9
-  output_apparent_power_total_kva: 0.0
-
-  # Output load
-  output_load_pct_phase_a: 32.0
-  output_load_pct_phase_b: 30.0
-  output_load_pct_phase_c: 33.0
-
-  # Line voltages (V)
-  input_line_voltage_ab_v: 400.0
-  input_line_voltage_bc_v: 398.5
-  input_line_voltage_ca_v: 401.0
-  input_line_voltage_avg_v: 0.0
-
-  output_line_voltage_ab_v: 400.0
-  output_line_voltage_bc_v: 399.0
-  output_line_voltage_ca_v: 401.5
-  output_line_voltage_avg_v: 0.0
-
-  # Internal registers (scaled integer values for Modbus mapping)
-  _reg_input_current_phase_a: 0
-  _reg_input_current_phase_b: 0
-  _reg_input_current_phase_c: 0
-  _reg_output_current_phase_a: 0
-  _reg_output_current_phase_b: 0
-  _reg_output_current_phase_c: 0
-  _reg_input_frequency: 0
-  _reg_output_frequency: 0
-  _reg_bypass_frequency: 0
-  _reg_input_power_factor_phase_a: 0
-  _reg_input_power_factor_phase_b: 0
-  _reg_input_power_factor_phase_c: 0
-  _reg_output_active_power_phase_a: 0
-  _reg_output_active_power_phase_b: 0
-  _reg_output_active_power_phase_c: 0
-  _reg_output_apparent_power_phase_a: 0
-  _reg_output_apparent_power_phase_b: 0
-  _reg_output_apparent_power_phase_c: 0
-  _reg_output_load_pct_phase_a: 0
-  _reg_output_load_pct_phase_b: 0
-  _reg_output_load_pct_phase_c: 0
-  _reg_input_line_voltage_ab: 0
-  _reg_input_line_voltage_bc: 0
-  _reg_input_line_voltage_ca: 0
-  _reg_output_line_voltage_ab: 0
-  _reg_output_line_voltage_bc: 0
-  _reg_output_line_voltage_ca: 0
-
+  input_current_phase_a_a:
+    type: float
+    default: 12.0
+    unit: A
+  input_current_phase_b_a:
+    type: float
+    default: 11.6
+    unit: A
+  input_current_phase_c_a:
+    type: float
+    default: 12.2
+    unit: A
+  input_current_avg_a:
+    type: float
+    default: 0.0
+    unit: A
+  output_current_phase_a_a:
+    type: float
+    default: 10.8
+    unit: A
+  output_current_phase_b_a:
+    type: float
+    default: 10.4
+    unit: A
+  output_current_phase_c_a:
+    type: float
+    default: 11.1
+    unit: A
+  output_current_avg_a:
+    type: float
+    default: 0.0
+    unit: A
+  input_frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  output_frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  bypass_frequency_hz:
+    type: float
+    default: 50.0
+    unit: Hz
+  input_power_factor_phase_a:
+    type: float
+    default: 0.98
+    unit: A
+  input_power_factor_phase_b:
+    type: float
+    default: 0.97
+  input_power_factor_phase_c:
+    type: float
+    default: 0.99
+    unit: degC
+  output_active_power_phase_a_kw:
+    type: float
+    default: 8.2
+    unit: kW
+  output_active_power_phase_b_kw:
+    type: float
+    default: 7.9
+    unit: kW
+  output_active_power_phase_c_kw:
+    type: float
+    default: 8.4
+    unit: kW
+  output_active_power_total_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  output_apparent_power_phase_a_kva:
+    type: float
+    default: 8.7
+    unit: kVA
+  output_apparent_power_phase_b_kva:
+    type: float
+    default: 8.3
+    unit: kVA
+  output_apparent_power_phase_c_kva:
+    type: float
+    default: 8.9
+    unit: kVA
+  output_apparent_power_total_kva:
+    type: float
+    default: 0.0
+    unit: kVA
+  output_load_pct_phase_a:
+    type: float
+    default: 32.0
+    unit: A
+  output_load_pct_phase_b:
+    type: float
+    default: 30.0
+  output_load_pct_phase_c:
+    type: float
+    default: 33.0
+    unit: degC
+  input_line_voltage_ab_v:
+    type: float
+    default: 400.0
+    unit: V
+  input_line_voltage_bc_v:
+    type: float
+    default: 398.5
+    unit: V
+  input_line_voltage_ca_v:
+    type: float
+    default: 401.0
+    unit: V
+  input_line_voltage_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  output_line_voltage_ab_v:
+    type: float
+    default: 400.0
+    unit: V
+  output_line_voltage_bc_v:
+    type: float
+    default: 399.0
+    unit: V
+  output_line_voltage_ca_v:
+    type: float
+    default: 401.5
+    unit: V
+  output_line_voltage_avg_v:
+    type: float
+    default: 0.0
+    unit: V
+  _reg_input_current_phase_a:
+    type: int
+    default: 0
+    unit: A
+  _reg_input_current_phase_b:
+    type: int
+    default: 0
+  _reg_input_current_phase_c:
+    type: int
+    default: 0
+    unit: degC
+  _reg_output_current_phase_a:
+    type: int
+    default: 0
+    unit: A
+  _reg_output_current_phase_b:
+    type: int
+    default: 0
+  _reg_output_current_phase_c:
+    type: int
+    default: 0
+    unit: degC
+  _reg_input_frequency:
+    type: int
+    default: 0
+  _reg_output_frequency:
+    type: int
+    default: 0
+  _reg_bypass_frequency:
+    type: int
+    default: 0
+  _reg_input_power_factor_phase_a:
+    type: int
+    default: 0
+    unit: A
+  _reg_input_power_factor_phase_b:
+    type: int
+    default: 0
+  _reg_input_power_factor_phase_c:
+    type: int
+    default: 0
+    unit: degC
+  _reg_output_active_power_phase_a:
+    type: int
+    default: 0
+    unit: A
+  _reg_output_active_power_phase_b:
+    type: int
+    default: 0
+  _reg_output_active_power_phase_c:
+    type: int
+    default: 0
+    unit: degC
+  _reg_output_apparent_power_phase_a:
+    type: int
+    default: 0
+    unit: A
+  _reg_output_apparent_power_phase_b:
+    type: int
+    default: 0
+  _reg_output_apparent_power_phase_c:
+    type: int
+    default: 0
+    unit: degC
+  _reg_output_load_pct_phase_a:
+    type: int
+    default: 0
+    unit: A
+  _reg_output_load_pct_phase_b:
+    type: int
+    default: 0
+  _reg_output_load_pct_phase_c:
+    type: int
+    default: 0
+    unit: degC
+  _reg_input_line_voltage_ab:
+    type: int
+    default: 0
+  _reg_input_line_voltage_bc:
+    type: int
+    default: 0
+  _reg_input_line_voltage_ca:
+    type: int
+    default: 0
+  _reg_output_line_voltage_ab:
+    type: int
+    default: 0
+  _reg_output_line_voltage_bc:
+    type: int
+    default: 0
+  _reg_output_line_voltage_ca:
+    type: int
+    default: 0
 actions:
   - function: $in(input_current_avg_a)
     name: compute_input_current_avg
@@ -267,52 +413,53 @@ communication:
       zero_fill: true
       mapping:
         # Input current (A) 0.1 A
-        _reg_input_current_phase_a: { address: [30005,30005], group: i_r, type: uint_16 }
-        _reg_input_current_phase_b: { address: [30006,30006], group: i_r, type: uint_16 }
-        _reg_input_current_phase_c: { address: [30007,30007], group: i_r, type: uint_16 }
+        _reg_input_current_phase_a: {address: [30005, 30005], group: i_r, type: uint_16}
+        _reg_input_current_phase_b: {address: [30006, 30006], group: i_r, type: uint_16}
+        _reg_input_current_phase_c: {address: [30007, 30007], group: i_r, type: uint_16}
 
         # Output current (A) 0.1 A
-        _reg_output_current_phase_a: { address: [30015,30015], group: i_r, type: uint_16 }
-        _reg_output_current_phase_b: { address: [30016,30016], group: i_r, type: uint_16 }
-        _reg_output_current_phase_c: { address: [30017,30017], group: i_r, type: uint_16 }
+        _reg_output_current_phase_a: {address: [30015, 30015], group: i_r, type: uint_16}
+        _reg_output_current_phase_b: {address: [30016, 30016], group: i_r, type: uint_16}
+        _reg_output_current_phase_c: {address: [30017, 30017], group: i_r, type: uint_16}
 
         # Frequencies (Hz) 0.1 Hz
-        _reg_input_frequency: { address: [30004,30004], group: i_r, type: uint_16 }
-        _reg_output_frequency: { address: [30014,30014], group: i_r, type: uint_16 }
-        _reg_bypass_frequency: { address: [30030,30030], group: i_r, type: uint_16 }
+        _reg_input_frequency: {address: [30004, 30004], group: i_r, type: uint_16}
+        _reg_output_frequency: {address: [30014, 30014], group: i_r, type: uint_16}
+        _reg_bypass_frequency: {address: [30030, 30030], group: i_r, type: uint_16}
 
         # Input power factor 0.001
-        _reg_input_power_factor_phase_a: { address: [30008,30008], group: i_r, type: uint_16 }
-        _reg_input_power_factor_phase_b: { address: [30009,30009], group: i_r, type: uint_16 }
-        _reg_input_power_factor_phase_c: { address: [30010,30010], group: i_r, type: uint_16 }
+        _reg_input_power_factor_phase_a: {address: [30008, 30008], group: i_r, type: uint_16}
+        _reg_input_power_factor_phase_b: {address: [30009, 30009], group: i_r, type: uint_16}
+        _reg_input_power_factor_phase_c: {address: [30010, 30010], group: i_r, type: uint_16}
 
         # Output active power (kW) 0.1 kW
-        _reg_output_active_power_phase_a: { address: [30018,30018], group: i_r, type: uint_16 }
-        _reg_output_active_power_phase_b: { address: [30019,30019], group: i_r, type: uint_16 }
-        _reg_output_active_power_phase_c: { address: [30020,30020], group: i_r, type: uint_16 }
+        _reg_output_active_power_phase_a: {address: [30018, 30018], group: i_r, type: uint_16}
+        _reg_output_active_power_phase_b: {address: [30019, 30019], group: i_r, type: uint_16}
+        _reg_output_active_power_phase_c: {address: [30020, 30020], group: i_r, type: uint_16}
 
         # Output load (%) 1%
-        _reg_output_load_pct_phase_a: { address: [30021,30021], group: i_r, type: uint_16 }
-        _reg_output_load_pct_phase_b: { address: [30022,30022], group: i_r, type: uint_16 }
-        _reg_output_load_pct_phase_c: { address: [30023,30023], group: i_r, type: uint_16 }
+        _reg_output_load_pct_phase_a: {address: [30021, 30021], group: i_r, type: uint_16}
+        _reg_output_load_pct_phase_b: {address: [30022, 30022], group: i_r, type: uint_16}
+        _reg_output_load_pct_phase_c: {address: [30023, 30023], group: i_r, type: uint_16}
 
         # Output apparent power (kVA) 0.1 kVA
-        _reg_output_apparent_power_phase_a: { address: [30047,30047], group: i_r, type: uint_16 }
-        _reg_output_apparent_power_phase_b: { address: [30048,30048], group: i_r, type: uint_16 }
-        _reg_output_apparent_power_phase_c: { address: [30049,30049], group: i_r, type: uint_16 }
+        _reg_output_apparent_power_phase_a: {address: [30047, 30047], group: i_r, type: uint_16}
+        _reg_output_apparent_power_phase_b: {address: [30048, 30048], group: i_r, type: uint_16}
+        _reg_output_apparent_power_phase_c: {address: [30049, 30049], group: i_r, type: uint_16}
 
         # Input line voltage (V) 0.1 V
-        _reg_input_line_voltage_ab: { address: [30050,30050], group: i_r, type: uint_16 }
-        _reg_input_line_voltage_bc: { address: [30051,30051], group: i_r, type: uint_16 }
-        _reg_input_line_voltage_ca: { address: [30052,30052], group: i_r, type: uint_16 }
+        _reg_input_line_voltage_ab: {address: [30050, 30050], group: i_r, type: uint_16}
+        _reg_input_line_voltage_bc: {address: [30051, 30051], group: i_r, type: uint_16}
+        _reg_input_line_voltage_ca: {address: [30052, 30052], group: i_r, type: uint_16}
 
         # Output line voltage (V) 0.1 V
-        _reg_output_line_voltage_ab: { address: [30056,30056], group: i_r, type: uint_16 }
-        _reg_output_line_voltage_bc: { address: [30057,30057], group: i_r, type: uint_16 }
-        _reg_output_line_voltage_ca: { address: [30058,30058], group: i_r, type: uint_16 }
+        _reg_output_line_voltage_ab: {address: [30056, 30056], group: i_r, type: uint_16}
+        _reg_output_line_voltage_bc: {address: [30057, 30057], group: i_r, type: uint_16}
+        _reg_output_line_voltage_ca: {address: [30058, 30058], group: i_r, type: uint_16}
 
 scenarios:
   normal_operation:
+    display_name: Normal Operation
     description: Balanced load with nominal frequencies and voltages.
     duration: 30.0
     overrides:
@@ -333,6 +480,7 @@ scenarios:
       $in(output_load_pct_phase_c): 33.0
 
   high_load:
+    display_name: High Load
     description: Elevated output load and current draw.
     duration: 30.0
     overrides:

--- a/library/domains/environment/feed/generic/weather_forecast__http.yaml
+++ b/library/domains/environment/feed/generic/weather_forecast__http.yaml
@@ -17,75 +17,117 @@ meta_parameters:
     default: 8091
 
 attributes:
-  k__latitude: 52.2297
-  k__longitude: 21.0122
-  elevation_m: 100.0
-  k__timezone: Europe/Warsaw
-  generation_time_ms: 18.5
-  forecast_horizon_hours: 48
-
-  k__active_profile: clear
-
+  k__latitude:
+    type: float
+    default: 52.2297
+    unit: deg
+  k__longitude:
+    type: float
+    default: 21.0122
+    unit: deg
+  elevation_m:
+    type: float
+    default: 100.0
+    unit: m
+  k__timezone:
+    type: str
+    default: Europe/Warsaw
+  generation_time_ms:
+    type: float
+    default: 18.5
+    unit: ms
+  forecast_horizon_hours:
+    type: int
+    default: 48
+    unit: h
+  k__active_profile:
+    type: str
+    default: clear
   hourly_time:
-    - "2025-01-01T00:00"
-    - "2025-01-01T03:00"
-    - "2025-01-01T06:00"
-    - "2025-01-01T09:00"
-    - "2025-01-01T12:00"
-    - "2025-01-01T15:00"
-    - "2025-01-01T18:00"
-    - "2025-01-01T21:00"
-
+    type: list
+    default:
+      - "2025-01-01T00:00"
+      - "2025-01-01T03:00"
+      - "2025-01-01T06:00"
+      - "2025-01-01T09:00"
+      - "2025-01-01T12:00"
+      - "2025-01-01T15:00"
+      - "2025-01-01T18:00"
+      - "2025-01-01T21:00"
   hourly_temperature_2m:
-    - -3.1
-    - -1.5
-    - 0.2
-    - 2.8
-    - 5.6
-    - 4.9
-    - 1.7
-    - -0.8
-
+    type: list
+    default:
+      - -3.1
+      - -1.5
+      - 0.2
+      - 2.8
+      - 5.6
+      - 4.9
+      - 1.7
+      - -0.8
+    unit: degC
   hourly_precipitation_probability:
-    - 10
-    - 15
-    - 20
-    - 25
-    - 30
-    - 20
-    - 15
-    - 10
-
+    type: list
+    default:
+      - 10
+      - 15
+      - 20
+      - 25
+      - 30
+      - 20
+      - 15
+      - 10
+    unit: "%"
   hourly_wind_speed_10m:
-    - 8.0
-    - 10.4
-    - 12.8
-    - 14.2
-    - 16.7
-    - 12.1
-    - 9.5
-    - 7.3
-
+    type: list
+    default:
+      - 8.0
+      - 10.4
+      - 12.8
+      - 14.2
+      - 16.7
+      - 12.1
+      - 9.5
+      - 7.3
+    unit: km/h
   daily_time:
-    - "2025-01-01"
-    - "2025-01-02"
-
+    type: list
+    default:
+      - "2025-01-01"
+      - "2025-01-02"
   daily_temp_max:
-    - 5.8
-    - 3.2
-
+    type: list
+    default:
+      - 5.8
+      - 3.2
+    unit: degC
   daily_temp_min:
-    - -3.4
-    - -6.1
-
+    type: list
+    default:
+      - -3.4
+      - -6.1
+    unit: degC
   daily_precip_sum:
-    - 2.6
-    - 0.8
-
-  k__current_temperature: 4.2
-  k__current_wind_speed: 14.3
-  k__current_wind_direction: 245
-  k__current_weather_code: 2
+    type: list
+    default:
+      - 2.6
+      - 0.8
+    unit: mm
+  k__current_temperature:
+    type: float
+    default: 4.2
+    unit: degC
+  k__current_wind_speed:
+    type: float
+    default: 14.3
+    unit: km/h
+  k__current_wind_direction:
+    type: int
+    default: 245
+    unit: deg
+  k__current_weather_code:
+    type: int
+    default: 2
 
 communication:
   - http_endpoint:
@@ -107,7 +149,7 @@ communication:
             forecast_horizon_hours: "#attr(forecast_horizon_hours)"
             hourly_units:
               time: "iso8601"
-              temperature_2m: "°C"
+              temperature_2m: "\u00b0C"
               precipitation_probability: "%"
               wind_speed_10m: "km/h"
             hourly:
@@ -117,8 +159,8 @@ communication:
               wind_speed_10m: "#attr(hourly_wind_speed_10m)"
             daily_units:
               time: "iso8601"
-              temperature_2m_max: "°C"
-              temperature_2m_min: "°C"
+              temperature_2m_max: "\u00b0C"
+              temperature_2m_min: "\u00b0C"
               precipitation_sum: "mm"
             daily:
               time: "#attr(daily_time)"

--- a/library/domains/environment/gateway/wago_vaisala/weather_gateway_wago_pfc200__vaisala_wxt530__mqtt.yaml
+++ b/library/domains/environment/gateway/wago_vaisala/weather_gateway_wago_pfc200__vaisala_wxt530__mqtt.yaml
@@ -24,229 +24,263 @@ meta_parameters:
     default: 1.0
 
 attributes:
-  k__outdoor_temperature_c: 5.0
-  k__wind_speed_ms: 3.0
-  k__wind_gust_ms: 6.0
-  k__brightness_lux: 20000.0
-  k__rain:
-  k__outdoor_temperature_c: 5.0
-  k__wind_speed_ms: 3.0
-  k__wind_gust_ms: 6.0
-  k__brightness_lux: 20000.0
+  k__outdoor_temperature_c:
+    type: float
+    default: 5.0
+    unit: degC
+  k__wind_speed_ms:
+    type: float
+    default: 3.0
+    unit: m/s
+  k__wind_gust_ms:
+    type: float
+    default: 6.0
+    unit: m/s
+  k__brightness_lux:
+    type: float
+    default: 20000.0
+    unit: lux
   k__rain:
     type: int
     default: 0
   k__wind_direction_deg:
-  k__wind_direction_deg:
     type: int
     default: 180
-
-  k__humidity_percent: 62.0
-  k__pressure_hpa: 1012.0
-  k__rain_rate_mm_h: 0.0
-  dew_point_c: -2.6
-  wind_chill_c: 1.8
-
-  availability: "online"
-  _test_logs: []
-
-  _ha_discovery_outdoor_temperature_config: |-
-    {
-      "name": "Outdoor Temperature",
-      "unique_id": "spx_weather_outdoor_temperature",
-      "state_topic": "spx/weather/outdoor_temperature_c",
-      "availability_topic": "spx/weather/availability",
-      "payload_available": "online",
-      "payload_not_available": "offline",
-      "unit_of_measurement": "°C",
-      "device_class": "temperature",
-      "state_class": "measurement",
-      "device": {
-        "identifiers": ["vaisala_wxt530_1"],
-        "manufacturer": "Vaisala",
-        "model": "WXT530 (Sim)",
-        "name": "Vaisala WXT530 Weather Transmitter",
-        "via_device": "wago_pfc200_gateway_1"
+    unit: deg
+  k__humidity_percent:
+    type: float
+    default: 62.0
+    unit: "%"
+  k__pressure_hpa:
+    type: float
+    default: 1012.0
+    unit: hPa
+  k__rain_rate_mm_h:
+    type: float
+    default: 0.0
+    unit: mm/h
+  dew_point_c:
+    type: float
+    default: -2.6
+    unit: degC
+  wind_chill_c:
+    type: float
+    default: 1.8
+    unit: degC
+  availability:
+    type: str
+    default: online
+  _test_logs:
+    type: list
+    default: []
+  _ha_discovery_outdoor_temperature_config:
+    type: str
+    default: |-
+      {
+        "name": "Outdoor Temperature",
+        "unique_id": "spx_weather_outdoor_temperature",
+        "state_topic": "spx/weather/outdoor_temperature_c",
+        "availability_topic": "spx/weather/availability",
+        "payload_available": "online",
+        "payload_not_available": "offline",
+        "unit_of_measurement": "\u00b0C",
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "device": {
+          "identifiers": ["vaisala_wxt530_1"],
+          "manufacturer": "Vaisala",
+          "model": "WXT530 (Sim)",
+          "name": "Vaisala WXT530 Weather Transmitter",
+          "via_device": "wago_pfc200_gateway_1"
+        }
       }
-    }
-
-  _ha_discovery_gateway_availability_config: |-
-    {
-      "name": "Weather Gateway Availability",
-      "unique_id": "spx_weather_gateway_availability",
-      "state_topic": "spx/weather/availability",
-      "availability_topic": "spx/weather/availability",
-      "payload_available": "online",
-      "payload_not_available": "offline",
-      "entity_category": "diagnostic",
-      "enabled_by_default": false,
-      "device": {
-        "identifiers": ["wago_pfc200_gateway_1"],
-        "manufacturer": "WAGO",
-        "model": "PFC200 (Sim)",
-        "name": "Weather Gateway",
-        "sw_version": "SPX"
+  _ha_discovery_gateway_availability_config:
+    type: str
+    default: |-
+      {
+        "name": "Weather Gateway Availability",
+        "unique_id": "spx_weather_gateway_availability",
+        "state_topic": "spx/weather/availability",
+        "availability_topic": "spx/weather/availability",
+        "payload_available": "online",
+        "payload_not_available": "offline",
+        "entity_category": "diagnostic",
+        "enabled_by_default": false,
+        "device": {
+          "identifiers": ["wago_pfc200_gateway_1"],
+          "manufacturer": "WAGO",
+          "model": "PFC200 (Sim)",
+          "name": "Weather Gateway",
+          "sw_version": "SPX"
+        }
       }
-    }
-
-  _ha_discovery_wind_speed_config: |-
-    {
-      "name": "Wind Speed",
-      "unique_id": "spx_weather_wind_speed",
-      "state_topic": "spx/weather/wind_speed_ms",
-      "availability_topic": "spx/weather/availability",
-      "payload_available": "online",
-      "payload_not_available": "offline",
-      "unit_of_measurement": "m/s",
-      "device_class": "wind_speed",
-      "state_class": "measurement",
-      "device": {
-        "identifiers": ["vaisala_wxt530_1"],
-        "manufacturer": "Vaisala",
-        "model": "WXT530 (Sim)",
-        "name": "Vaisala WXT530 Weather Transmitter",
-        "via_device": "wago_pfc200_gateway_1"
+  _ha_discovery_wind_speed_config:
+    type: str
+    default: |-
+      {
+        "name": "Wind Speed",
+        "unique_id": "spx_weather_wind_speed",
+        "state_topic": "spx/weather/wind_speed_ms",
+        "availability_topic": "spx/weather/availability",
+        "payload_available": "online",
+        "payload_not_available": "offline",
+        "unit_of_measurement": "m/s",
+        "device_class": "wind_speed",
+        "state_class": "measurement",
+        "device": {
+          "identifiers": ["vaisala_wxt530_1"],
+          "manufacturer": "Vaisala",
+          "model": "WXT530 (Sim)",
+          "name": "Vaisala WXT530 Weather Transmitter",
+          "via_device": "wago_pfc200_gateway_1"
+        }
       }
-    }
-
-  _ha_discovery_wind_gust_config: |-
-    {
-      "name": "Wind Gust",
-      "unique_id": "spx_weather_wind_gust",
-      "state_topic": "spx/weather/wind_gust_ms",
-      "availability_topic": "spx/weather/availability",
-      "payload_available": "online",
-      "payload_not_available": "offline",
-      "unit_of_measurement": "m/s",
-      "device_class": "wind_speed",
-      "state_class": "measurement",
-      "device": {
-        "identifiers": ["vaisala_wxt530_1"],
-        "manufacturer": "Vaisala",
-        "model": "WXT530 (Sim)",
-        "name": "Vaisala WXT530 Weather Transmitter",
-        "via_device": "wago_pfc200_gateway_1"
+  _ha_discovery_wind_gust_config:
+    type: str
+    default: |-
+      {
+        "name": "Wind Gust",
+        "unique_id": "spx_weather_wind_gust",
+        "state_topic": "spx/weather/wind_gust_ms",
+        "availability_topic": "spx/weather/availability",
+        "payload_available": "online",
+        "payload_not_available": "offline",
+        "unit_of_measurement": "m/s",
+        "device_class": "wind_speed",
+        "state_class": "measurement",
+        "device": {
+          "identifiers": ["vaisala_wxt530_1"],
+          "manufacturer": "Vaisala",
+          "model": "WXT530 (Sim)",
+          "name": "Vaisala WXT530 Weather Transmitter",
+          "via_device": "wago_pfc200_gateway_1"
+        }
       }
-    }
-
-  _ha_discovery_brightness_config: |-
-    {
-      "name": "Brightness",
-      "unique_id": "spx_weather_brightness",
-      "state_topic": "spx/weather/brightness_lux",
-      "availability_topic": "spx/weather/availability",
-      "payload_available": "online",
-      "payload_not_available": "offline",
-      "unit_of_measurement": "lx",
-      "device_class": "illuminance",
-      "state_class": "measurement",
-      "device": {
-        "identifiers": ["vaisala_wxt530_1"],
-        "manufacturer": "Vaisala",
-        "model": "WXT530 (Sim)",
-        "name": "Vaisala WXT530 Weather Transmitter",
-        "via_device": "wago_pfc200_gateway_1"
+  _ha_discovery_brightness_config:
+    type: str
+    default: |-
+      {
+        "name": "Brightness",
+        "unique_id": "spx_weather_brightness",
+        "state_topic": "spx/weather/brightness_lux",
+        "availability_topic": "spx/weather/availability",
+        "payload_available": "online",
+        "payload_not_available": "offline",
+        "unit_of_measurement": "lx",
+        "device_class": "illuminance",
+        "state_class": "measurement",
+        "device": {
+          "identifiers": ["vaisala_wxt530_1"],
+          "manufacturer": "Vaisala",
+          "model": "WXT530 (Sim)",
+          "name": "Vaisala WXT530 Weather Transmitter",
+          "via_device": "wago_pfc200_gateway_1"
+        }
       }
-    }
-
-  _ha_discovery_rain_config: |-
-    {
-      "name": "Rain",
-      "unique_id": "spx_weather_rain",
-      "state_topic": "spx/weather/rain",
-      "availability_topic": "spx/weather/availability",
-      "payload_available": "online",
-      "payload_not_available": "offline",
-      "payload_on": "1",
-      "payload_off": "0",
-      "device_class": "moisture",
-      "device": {
-        "identifiers": ["vaisala_wxt530_1"],
-        "manufacturer": "Vaisala",
-        "model": "WXT530 (Sim)",
-        "name": "Vaisala WXT530 Weather Transmitter",
-        "via_device": "wago_pfc200_gateway_1"
+  _ha_discovery_rain_config:
+    type: str
+    default: |-
+      {
+        "name": "Rain",
+        "unique_id": "spx_weather_rain",
+        "state_topic": "spx/weather/rain",
+        "availability_topic": "spx/weather/availability",
+        "payload_available": "online",
+        "payload_not_available": "offline",
+        "payload_on": "1",
+        "payload_off": "0",
+        "device_class": "moisture",
+        "device": {
+          "identifiers": ["vaisala_wxt530_1"],
+          "manufacturer": "Vaisala",
+          "model": "WXT530 (Sim)",
+          "name": "Vaisala WXT530 Weather Transmitter",
+          "via_device": "wago_pfc200_gateway_1"
+        }
       }
-    }
-
-  _ha_discovery_wind_direction_config: |-
-    {
-      "name": "Wind Direction",
-      "unique_id": "spx_weather_wind_direction",
-      "state_topic": "spx/weather/wind_direction_deg",
-      "availability_topic": "spx/weather/availability",
-      "payload_available": "online",
-      "payload_not_available": "offline",
-      "unit_of_measurement": "°",
-      "state_class": "measurement",
-      "device": {
-        "identifiers": ["vaisala_wxt530_1"],
-        "manufacturer": "Vaisala",
-        "model": "WXT530 (Sim)",
-        "name": "Vaisala WXT530 Weather Transmitter",
-        "via_device": "wago_pfc200_gateway_1"
+  _ha_discovery_wind_direction_config:
+    type: str
+    default: |-
+      {
+        "name": "Wind Direction",
+        "unique_id": "spx_weather_wind_direction",
+        "state_topic": "spx/weather/wind_direction_deg",
+        "availability_topic": "spx/weather/availability",
+        "payload_available": "online",
+        "payload_not_available": "offline",
+        "unit_of_measurement": "\u00b0",
+        "state_class": "measurement",
+        "device": {
+          "identifiers": ["vaisala_wxt530_1"],
+          "manufacturer": "Vaisala",
+          "model": "WXT530 (Sim)",
+          "name": "Vaisala WXT530 Weather Transmitter",
+          "via_device": "wago_pfc200_gateway_1"
+        }
       }
-    }
-
-  _ha_discovery_humidity_config: |-
-    {
-      "name": "Humidity",
-      "unique_id": "spx_weather_humidity",
-      "state_topic": "spx/weather/humidity_percent",
-      "availability_topic": "spx/weather/availability",
-      "payload_available": "online",
-      "payload_not_available": "offline",
-      "unit_of_measurement": "%",
-      "device_class": "humidity",
-      "state_class": "measurement",
-      "device": {
-        "identifiers": ["vaisala_wxt530_1"],
-        "manufacturer": "Vaisala",
-        "model": "WXT530 (Sim)",
-        "name": "Vaisala WXT530 Weather Transmitter",
-        "via_device": "wago_pfc200_gateway_1"
+  _ha_discovery_humidity_config:
+    type: str
+    default: |-
+      {
+        "name": "Humidity",
+        "unique_id": "spx_weather_humidity",
+        "state_topic": "spx/weather/humidity_percent",
+        "availability_topic": "spx/weather/availability",
+        "payload_available": "online",
+        "payload_not_available": "offline",
+        "unit_of_measurement": "%",
+        "device_class": "humidity",
+        "state_class": "measurement",
+        "device": {
+          "identifiers": ["vaisala_wxt530_1"],
+          "manufacturer": "Vaisala",
+          "model": "WXT530 (Sim)",
+          "name": "Vaisala WXT530 Weather Transmitter",
+          "via_device": "wago_pfc200_gateway_1"
+        }
       }
-    }
-
-  _ha_discovery_pressure_config: |-
-    {
-      "name": "Pressure",
-      "unique_id": "spx_weather_pressure",
-      "state_topic": "spx/weather/pressure_hpa",
-      "availability_topic": "spx/weather/availability",
-      "payload_available": "online",
-      "payload_not_available": "offline",
-      "unit_of_measurement": "hPa",
-      "device_class": "pressure",
-      "state_class": "measurement",
-      "device": {
-        "identifiers": ["vaisala_wxt530_1"],
-        "manufacturer": "Vaisala",
-        "model": "WXT530 (Sim)",
-        "name": "Vaisala WXT530 Weather Transmitter",
-        "via_device": "wago_pfc200_gateway_1"
+  _ha_discovery_pressure_config:
+    type: str
+    default: |-
+      {
+        "name": "Pressure",
+        "unique_id": "spx_weather_pressure",
+        "state_topic": "spx/weather/pressure_hpa",
+        "availability_topic": "spx/weather/availability",
+        "payload_available": "online",
+        "payload_not_available": "offline",
+        "unit_of_measurement": "hPa",
+        "device_class": "pressure",
+        "state_class": "measurement",
+        "device": {
+          "identifiers": ["vaisala_wxt530_1"],
+          "manufacturer": "Vaisala",
+          "model": "WXT530 (Sim)",
+          "name": "Vaisala WXT530 Weather Transmitter",
+          "via_device": "wago_pfc200_gateway_1"
+        }
       }
-    }
-
-  _ha_discovery_rain_rate_config: |-
-    {
-      "name": "Rain Rate",
-      "unique_id": "spx_weather_rain_rate",
-      "state_topic": "spx/weather/rain_rate_mm_h",
-      "availability_topic": "spx/weather/availability",
-      "payload_available": "online",
-      "payload_not_available": "offline",
-      "unit_of_measurement": "mm/h",
-      "device_class": "precipitation_intensity",
-      "state_class": "measurement",
-      "device": {
-        "identifiers": ["vaisala_wxt530_1"],
-        "manufacturer": "Vaisala",
-        "model": "WXT530 (Sim)",
-        "name": "Vaisala WXT530 Weather Transmitter",
-        "via_device": "wago_pfc200_gateway_1"
+  _ha_discovery_rain_rate_config:
+    type: str
+    default: |-
+      {
+        "name": "Rain Rate",
+        "unique_id": "spx_weather_rain_rate",
+        "state_topic": "spx/weather/rain_rate_mm_h",
+        "availability_topic": "spx/weather/availability",
+        "payload_available": "online",
+        "payload_not_available": "offline",
+        "unit_of_measurement": "mm/h",
+        "device_class": "precipitation_intensity",
+        "state_class": "measurement",
+        "device": {
+          "identifiers": ["vaisala_wxt530_1"],
+          "manufacturer": "Vaisala",
+          "model": "WXT530 (Sim)",
+          "name": "Vaisala WXT530 Weather Transmitter",
+          "via_device": "wago_pfc200_gateway_1"
+        }
       }
-    }
 
 timer:
   time_step: 1.0
@@ -422,29 +456,11 @@ scenarios:
       $in(k__rain): 0
       $in(k__rain_rate_mm_h): 0.0
       $in(k__wind_direction_deg): 190
-      $in(k__outdoor_temperature_c): 22.0
-      $in(k__humidity_percent): 45.0
-      $in(k__pressure_hpa): 1018.0
-      $in(k__wind_speed_ms): 2.5
-      $in(k__wind_gust_ms): 5.0
-      $in(k__brightness_lux): 48000.0
-      $in(k__rain): 0
-      $in(k__rain_rate_mm_h): 0.0
-      $in(k__wind_direction_deg): 190
 
   Overcast cool day:
     display_name: "Overcast cool day"
     duration: 20.0
     overrides:
-      $in(k__outdoor_temperature_c): 9.0
-      $in(k__humidity_percent): 72.0
-      $in(k__pressure_hpa): 1010.0
-      $in(k__wind_speed_ms): 4.0
-      $in(k__wind_gust_ms): 7.0
-      $in(k__brightness_lux): 12000.0
-      $in(k__rain): 0
-      $in(k__rain_rate_mm_h): 0.0
-      $in(k__wind_direction_deg): 230
       $in(k__outdoor_temperature_c): 9.0
       $in(k__humidity_percent): 72.0
       $in(k__pressure_hpa): 1010.0
@@ -468,29 +484,11 @@ scenarios:
       $in(k__rain): 1
       $in(k__rain_rate_mm_h): 2.5
       $in(k__wind_direction_deg): 210
-      $in(k__outdoor_temperature_c): 11.5
-      $in(k__humidity_percent): 88.0
-      $in(k__pressure_hpa): 1006.0
-      $in(k__wind_speed_ms): 5.0
-      $in(k__wind_gust_ms): 9.0
-      $in(k__brightness_lux): 8000.0
-      $in(k__rain): 1
-      $in(k__rain_rate_mm_h): 2.5
-      $in(k__wind_direction_deg): 210
 
   Summer storm:
     display_name: "Summer storm"
     duration: 20.0
     overrides:
-      $in(k__outdoor_temperature_c): 18.0
-      $in(k__humidity_percent): 92.0
-      $in(k__pressure_hpa): 1002.0
-      $in(k__wind_speed_ms): 12.0
-      $in(k__wind_gust_ms): 22.0
-      $in(k__brightness_lux): 4500.0
-      $in(k__rain): 1
-      $in(k__rain_rate_mm_h): 15.0
-      $in(k__wind_direction_deg): 265
       $in(k__outdoor_temperature_c): 18.0
       $in(k__humidity_percent): 92.0
       $in(k__pressure_hpa): 1002.0
@@ -514,29 +512,11 @@ scenarios:
       $in(k__rain): 0
       $in(k__rain_rate_mm_h): 0.0
       $in(k__wind_direction_deg): 140
-      $in(k__outdoor_temperature_c): -3.0
-      $in(k__humidity_percent): 78.0
-      $in(k__pressure_hpa): 1024.0
-      $in(k__wind_speed_ms): 1.5
-      $in(k__wind_gust_ms): 3.5
-      $in(k__brightness_lux): 0.0
-      $in(k__rain): 0
-      $in(k__rain_rate_mm_h): 0.0
-      $in(k__wind_direction_deg): 140
 
   Warm summer night:
     display_name: "Warm summer night"
     duration: 20.0
     overrides:
-      $in(k__outdoor_temperature_c): 23.0
-      $in(k__humidity_percent): 68.0
-      $in(k__pressure_hpa): 1016.0
-      $in(k__wind_speed_ms): 1.2
-      $in(k__wind_gust_ms): 2.5
-      $in(k__brightness_lux): 0.0
-      $in(k__rain): 0
-      $in(k__rain_rate_mm_h): 0.0
-      $in(k__wind_direction_deg): 160
       $in(k__outdoor_temperature_c): 23.0
       $in(k__humidity_percent): 68.0
       $in(k__pressure_hpa): 1016.0
@@ -560,29 +540,11 @@ scenarios:
       $in(k__rain): 0
       $in(k__rain_rate_mm_h): 0.0
       $in(k__wind_direction_deg): 80
-      $in(k__outdoor_temperature_c): 7.0
-      $in(k__humidity_percent): 98.0
-      $in(k__pressure_hpa): 1022.0
-      $in(k__wind_speed_ms): 0.8
-      $in(k__wind_gust_ms): 1.8
-      $in(k__brightness_lux): 600.0
-      $in(k__rain): 0
-      $in(k__rain_rate_mm_h): 0.0
-      $in(k__wind_direction_deg): 80
 
   Humid hot day:
     display_name: "Humid hot day"
     duration: 20.0
     overrides:
-      $in(k__outdoor_temperature_c): 30.0
-      $in(k__humidity_percent): 78.0
-      $in(k__pressure_hpa): 1009.0
-      $in(k__wind_speed_ms): 3.5
-      $in(k__wind_gust_ms): 6.0
-      $in(k__brightness_lux): 65000.0
-      $in(k__rain): 0
-      $in(k__rain_rate_mm_h): 0.0
-      $in(k__wind_direction_deg): 170
       $in(k__outdoor_temperature_c): 30.0
       $in(k__humidity_percent): 78.0
       $in(k__pressure_hpa): 1009.0
@@ -606,15 +568,6 @@ scenarios:
       $in(k__rain): 0
       $in(k__rain_rate_mm_h): 0.0
       $in(k__wind_direction_deg): 40
-      $in(k__outdoor_temperature_c): -8.0
-      $in(k__humidity_percent): 65.0
-      $in(k__pressure_hpa): 1032.0
-      $in(k__wind_speed_ms): 1.0
-      $in(k__wind_gust_ms): 2.5
-      $in(k__brightness_lux): 12000.0
-      $in(k__rain): 0
-      $in(k__rain_rate_mm_h): 0.0
-      $in(k__wind_direction_deg): 40
 
   Tropical downpour:
     display_name: "Tropical downpour"
@@ -629,29 +582,11 @@ scenarios:
       $in(k__rain): 1
       $in(k__rain_rate_mm_h): 35.0
       $in(k__wind_direction_deg): 200
-      $in(k__outdoor_temperature_c): 26.0
-      $in(k__humidity_percent): 98.0
-      $in(k__pressure_hpa): 1003.0
-      $in(k__wind_speed_ms): 8.0
-      $in(k__wind_gust_ms): 15.0
-      $in(k__brightness_lux): 1200.0
-      $in(k__rain): 1
-      $in(k__rain_rate_mm_h): 35.0
-      $in(k__wind_direction_deg): 200
 
   Blizzard whiteout:
     display_name: "Blizzard whiteout"
     duration: 20.0
     overrides:
-      $in(k__outdoor_temperature_c): -9.0
-      $in(k__humidity_percent): 92.0
-      $in(k__pressure_hpa): 998.0
-      $in(k__wind_speed_ms): 14.0
-      $in(k__wind_gust_ms): 26.0
-      $in(k__brightness_lux): 400.0
-      $in(k__rain): 1
-      $in(k__rain_rate_mm_h): 6.0
-      $in(k__wind_direction_deg): 230
       $in(k__outdoor_temperature_c): -9.0
       $in(k__humidity_percent): 92.0
       $in(k__pressure_hpa): 998.0
@@ -743,9 +678,7 @@ scenarios:
               ramp_duration: 20.0
             call: |
               (lambda t:
-                int(
-                  dir_start + (dir_end - dir_start) * min(1.0, max(0.0, (t - ramp_start)) / ramp_duration)
-                )
+                int(dir_start + (dir_end - dir_start) * min(1.0, max(0.0, (t - ramp_start)) / ramp_duration))
               )($attr(timer.time))
       - if: $attr(timer.time) >= 40.0
         actions:

--- a/tests/packs/smart_building_pack/unit/test_model_metadata_refresh.py
+++ b/tests/packs/smart_building_pack/unit/test_model_metadata_refresh.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+
+import yaml
+
+from tests.common.repo import repo_root
+
+
+ROOT = repo_root()
+
+
+def _load_yaml(relative_path: str) -> dict[str, Any]:
+    path = ROOT / Path(relative_path)
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _iter_pack_models() -> Iterator[tuple[str, dict[str, Any]]]:
+    pack_index = _load_yaml("library/industries/smart_building_pack/MODELS.yaml")
+    catalog = _load_yaml("library/catalog/models.yaml")
+    catalog_index = {entry["id"]: entry for entry in catalog["models"]}
+
+    for entry in pack_index["models"]:
+        yield entry["id"], _load_yaml(catalog_index[entry["id"]]["path"])
+
+
+def _iter_bindings(node: Any) -> Iterator[dict[str, Any]]:
+    if isinstance(node, dict):
+        bindings = node.get("bindings")
+        if isinstance(bindings, list):
+            for binding in bindings:
+                if isinstance(binding, dict):
+                    yield binding
+        elif isinstance(bindings, dict):
+            for binding in bindings.values():
+                if isinstance(binding, dict):
+                    yield binding
+        for value in node.values():
+            yield from _iter_bindings(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_bindings(item)
+
+
+def test_smart_building_pack_models_use_typed_attributes_and_labeled_scenarios() -> None:
+    scalar_attrs: list[str] = []
+    missing_display_names: list[str] = []
+    unnamed_bindings: list[str] = []
+    missing_name: list[str] = []
+    missing_description: list[str] = []
+
+    for model_id, model in _iter_pack_models():
+        if not model.get("name"):
+            missing_name.append(model_id)
+        if not model.get("description"):
+            missing_description.append(model_id)
+
+        attributes = model.get("attributes") or {}
+        for attr_name, attr_spec in attributes.items():
+            if not isinstance(attr_spec, dict) or "type" not in attr_spec or "default" not in attr_spec:
+                scalar_attrs.append(f"{model_id}:{attr_name}")
+
+        for scenario_name, scenario in (model.get("scenarios") or {}).items():
+            if isinstance(scenario, dict) and "display_name" not in scenario:
+                missing_display_names.append(f"{model_id}:{scenario_name}")
+
+        for binding in _iter_bindings(model.get("communication") or []):
+            if "name" not in binding:
+                unnamed_bindings.append(model_id)
+
+    assert scalar_attrs == []
+    assert missing_display_names == []
+    assert unnamed_bindings == []
+    assert missing_name == []
+    assert missing_description == []
+
+
+def test_smart_building_pack_representative_models_expose_modern_metadata() -> None:
+    hvac = _load_yaml("library/domains/building/controller/generic/hvac_flexit_nordic__bacnet.yaml")
+    assert hvac["attributes"]["room_thermal_mass_kwh_per_k"]["unit"] == "kWh/K"
+    assert hvac["attributes"]["heater_load_pct"]["unit"] == "%"
+    assert hvac["scenarios"]["heater_failure"]["display_name"] == "Heater failure"
+
+    theronda = _load_yaml("library/domains/building/sensor/theben/theronda_p360__knx.yaml")
+    assert theronda["attributes"]["k__brightness_ceiling_lux"]["unit"] == "lux"
+    assert theronda["attributes"]["lighting_time_delay_s"]["unit"] == "s"
+    assert theronda["scenarios"]["parallel_switching_pulse"]["display_name"] == "Parallel Switching Pulse"
+
+    weather_feed = _load_yaml("library/domains/environment/feed/generic/weather_forecast__http.yaml")
+    assert weather_feed["attributes"]["hourly_temperature_2m"]["type"] == "list"
+    assert weather_feed["attributes"]["k__current_wind_speed"]["unit"] == "km/h"
+
+    weather_gateway = _load_yaml(
+        "library/domains/environment/gateway/wago_vaisala/weather_gateway_wago_pfc200__vaisala_wxt530__mqtt.yaml"
+    )
+    assert weather_gateway["attributes"]["k__wind_speed_ms"]["unit"] == "m/s"
+    assert weather_gateway["attributes"]["_ha_discovery_outdoor_temperature_config"]["type"] == "str"
+    assert weather_gateway["scenarios"]["Frontal passage sequence"]["display_name"] == (
+        "Frontal passage sequence"
+    )

--- a/tests/packs/smart_building_pack/unit/test_robot_vacuum_mqtt_model.py
+++ b/tests/packs/smart_building_pack/unit/test_robot_vacuum_mqtt_model.py
@@ -32,9 +32,11 @@ def test_robot_vacuum_mqtt_model_loads() -> None:
 
     attributes = doc["attributes"]
     assert isinstance(attributes, dict)
-    assert attributes.get("docked") == 1
-    assert attributes.get("battery_percent") == 100.0
-    assert attributes.get("suction_level_percent") == 70.0
+    assert attributes["docked"]["type"] == "int"
+    assert attributes["docked"]["default"] == 1
+    assert attributes["battery_percent"]["type"] == "float"
+    assert attributes["battery_percent"]["default"] == 100.0
+    assert attributes["suction_level_percent"]["default"] == 70.0
 
     comm = doc["communication"]
     assert isinstance(comm, list) and comm


### PR DESCRIPTION
## Summary
- standardize smart_building_pack models to typed attributes with aligned units and labeled scenarios
- clean up the remaining legacy shared models used by the pack, including weather feed/gateway and shared energy meters
- add pack-level metadata regression coverage and update the robot vacuum unit test for typed attrs

## Validation
- poetry run python tools/validate_models.py
- poetry run pytest tests/packs/smart_building_pack/unit
- poetry run pytest tests/packs/smart_building_pack
