### PR TITLE
fix(lab): name oscilloscope scpi mappings

### DIFF
--- a/library/domains/lab/oscilloscope/keysight/keysight_infiniivision_1000x__scpi.yaml
+++ b/library/domains/lab/oscilloscope/keysight/keysight_infiniivision_1000x__scpi.yaml
@@ -51,27 +51,54 @@ communication:
       response_delay: 0.01
       response_jitter: 0.0
       mappings:
-        "*IDN?": "KEYSIGHT TECHNOLOGIES,DSOX1000X,MY00000000,01.20.0000"
-        ":SYSTem:ERRor?": "#out(last_error)"
-        ":MEASure:VPP?": "#out(vpp_v)"
-        ":MEASure:VRMS?": "#out(vrms_v)"
-        ":MEASure:VAVerage?": "#out(vavg_v)"
-        ":MEASure:FREQuency?": "#out(frequency_hz)"
-        ":MEASure:SOURce?": "#out(k__measurement_source)"
+        "*IDN?":
+          name: query_idn
+          response: "KEYSIGHT TECHNOLOGIES,DSOX1000X,MY00000000,01.20.0000"
+        ":SYSTem:ERRor?":
+          name: query_system_error
+          response: "#out(last_error)"
+        ":MEASure:VPP?":
+          name: query_channel_1_vpp
+          response: "#out(vpp_v)"
+        ":MEASure:VRMS?":
+          name: query_channel_1_vrms
+          response: "#out(vrms_v)"
+        ":MEASure:VAVerage?":
+          name: query_channel_1_vavg
+          response: "#out(vavg_v)"
+        ":MEASure:FREQuency?":
+          name: query_channel_1_frequency
+          response: "#out(frequency_hz)"
+        ":MEASure:SOURce?":
+          name: query_measurement_source
+          response: "#out(k__measurement_source)"
         ":MEASure:SOURce {source}":
+          name: set_measurement_source
           "#attr(k__measurement_source)": "source"
           response: "OK"
-        ":CHANnel1:SCALe?": "#out(k__channel_1_scale_v)"
+        ":CHANnel1:SCALe?":
+          name: query_channel_1_scale
+          response: "#out(k__channel_1_scale_v)"
         ":CHANnel1:SCALe {scale}":
+          name: set_channel_1_scale
           "#attr(k__channel_1_scale_v)": "scale"
-        ":CHANnel1:OFFSet?": "#out(k__channel_1_offset_v)"
+        ":CHANnel1:OFFSet?":
+          name: query_channel_1_offset
+          response: "#out(k__channel_1_offset_v)"
         ":CHANnel1:OFFSet {offset}":
+          name: set_channel_1_offset
           "#attr(k__channel_1_offset_v)": "offset"
-        ":TIMebase:SCALe?": "#out(k__timebase_scale_s)"
+        ":TIMebase:SCALe?":
+          name: query_timebase_scale
+          response: "#out(k__timebase_scale_s)"
         ":TIMebase:SCALe {scale}":
+          name: set_timebase_scale
           "#attr(k__timebase_scale_s)": "scale"
-        ":TRIGger:LEVel?": "#out(k__trigger_level_v)"
+        ":TRIGger:LEVel?":
+          name: query_trigger_level
+          response: "#out(k__trigger_level_v)"
         ":TRIGger:LEVel {level}":
+          name: set_trigger_level
           "#attr(k__trigger_level_v)": "level"
 
 scenarios:

--- a/library/domains/lab/oscilloscope/rigol/rigol_ds1000z__scpi.yaml
+++ b/library/domains/lab/oscilloscope/rigol/rigol_ds1000z__scpi.yaml
@@ -48,12 +48,24 @@ communication:
       response_delay: 0.01
       response_jitter: 0.0
       mappings:
-        "*IDN?": "#out(idn)"
-        ":MEASure:ITEM? VPP,CHANnel1": "#out(channel1_vpp_v)"
-        ":MEASure:ITEM? VRMS,CHANnel1": "#out(channel1_vrms_v)"
-        ":MEASure:ITEM? VAVG,CHANnel1": "#out(channel1_vavg_v)"
-        ":MEASure:ITEM? FREQuency,CHANnel1": "#out(channel1_freq_hz)"
-        ":MEASure:ITEM? PERiod,CHANnel1": "#out(channel1_period_s)"
+        "*IDN?":
+          name: query_idn
+          response: "#out(idn)"
+        ":MEASure:ITEM? VPP,CHANnel1":
+          name: query_channel_1_vpp
+          response: "#out(channel1_vpp_v)"
+        ":MEASure:ITEM? VRMS,CHANnel1":
+          name: query_channel_1_vrms
+          response: "#out(channel1_vrms_v)"
+        ":MEASure:ITEM? VAVG,CHANnel1":
+          name: query_channel_1_vavg
+          response: "#out(channel1_vavg_v)"
+        ":MEASure:ITEM? FREQuency,CHANnel1":
+          name: query_channel_1_frequency
+          response: "#out(channel1_freq_hz)"
+        ":MEASure:ITEM? PERiod,CHANnel1":
+          name: query_channel_1_period
+          response: "#out(channel1_period_s)"
 
 scenarios:
   amplitude_sweep:

--- a/library/domains/lab/oscilloscope/rigol/rigol_mso5000__scpi.yaml
+++ b/library/domains/lab/oscilloscope/rigol/rigol_mso5000__scpi.yaml
@@ -48,12 +48,24 @@ communication:
       response_delay: 0.01
       response_jitter: 0.0
       mappings:
-        "*IDN?": "#out(idn)"
-        ":MEASure:ITEM? VPP,CHANnel1": "#out(channel1_vpp_v)"
-        ":MEASure:ITEM? VRMS,CHANnel1": "#out(channel1_vrms_v)"
-        ":MEASure:ITEM? VAVG,CHANnel1": "#out(channel1_vavg_v)"
-        ":MEASure:ITEM? FREQuency,CHANnel1": "#out(channel1_freq_hz)"
-        ":MEASure:ITEM? PERiod,CHANnel1": "#out(channel1_period_s)"
+        "*IDN?":
+          name: query_idn
+          response: "#out(idn)"
+        ":MEASure:ITEM? VPP,CHANnel1":
+          name: query_channel_1_vpp
+          response: "#out(channel1_vpp_v)"
+        ":MEASure:ITEM? VRMS,CHANnel1":
+          name: query_channel_1_vrms
+          response: "#out(channel1_vrms_v)"
+        ":MEASure:ITEM? VAVG,CHANnel1":
+          name: query_channel_1_vavg
+          response: "#out(channel1_vavg_v)"
+        ":MEASure:ITEM? FREQuency,CHANnel1":
+          name: query_channel_1_frequency
+          response: "#out(channel1_freq_hz)"
+        ":MEASure:ITEM? PERiod,CHANnel1":
+          name: query_channel_1_period
+          response: "#out(channel1_period_s)"
 
 scenarios:
   amplitude_sweep:

--- a/library/domains/lab/oscilloscope/rohde_schwarz/rohde_schwarz_hmo1002__scpi.yaml
+++ b/library/domains/lab/oscilloscope/rohde_schwarz/rohde_schwarz_hmo1002__scpi.yaml
@@ -90,40 +90,71 @@ communication:
       response_delay: 0.01
       response_jitter: 0.0
       mappings:
-        "*IDN?": "#out(idn)"
+        "*IDN?":
+          name: query_idn
+          response: "#out(idn)"
 
-        "CHANnel1:SCALe?": "#out(k__channel_1_scale_v)"
+        "CHANnel1:SCALe?":
+          name: query_channel_1_scale
+          response: "#out(k__channel_1_scale_v)"
         "CHANnel1:SCALe {scale}":
+          name: set_channel_1_scale
           "#attr(k__channel_1_scale_v)": "scale"
           response: "OK"
-        "CHANnel1:OFFSet?": "#out(k__channel_1_offset_v)"
+        "CHANnel1:OFFSet?":
+          name: query_channel_1_offset
+          response: "#out(k__channel_1_offset_v)"
         "CHANnel1:OFFSet {offset}":
+          name: set_channel_1_offset
           "#attr(k__channel_1_offset_v)": "offset"
           response: "OK"
 
-        "TIMebase:SCALe?": "#out(k__timebase_scale_s)"
+        "TIMebase:SCALe?":
+          name: query_timebase_scale
+          response: "#out(k__timebase_scale_s)"
         "TIMebase:SCALe {scale}":
+          name: set_timebase_scale
           "#attr(k__timebase_scale_s)": "scale"
           response: "OK"
 
-        "TRIGger:A:LEVel1?": "#out(k__trigger_level_v)"
+        "TRIGger:A:LEVel1?":
+          name: query_trigger_level
+          response: "#out(k__trigger_level_v)"
         "TRIGger:A:LEVel1 {level}":
+          name: set_trigger_level
           "#attr(k__trigger_level_v)": "level"
           response: "OK"
 
-        "MEASurement1:MAIN?": "#out(k__measurement_type)"
+        "MEASurement1:MAIN?":
+          name: query_measurement_type
+          response: "#out(k__measurement_type)"
         "MEASurement1:MAIN {mtype}":
+          name: set_measurement_type
           "#attr(k__measurement_type)": "mtype"
           response: "OK"
-        "MEASurement1:RESult?": "#out(measurement_value)"
+        "MEASurement1:RESult?":
+          name: query_measurement_value
+          response: "#out(measurement_value)"
 
-        "SYSTem:ERRor:ALL?": "#out(error_status)"
+        "SYSTem:ERRor:ALL?":
+          name: query_system_error
+          response: "#out(error_status)"
 
-        ":MEASure:ITEM? VPP,CHANnel1": "#out(channel1_vpp_v)"
-        ":MEASure:ITEM? VRMS,CHANnel1": "#out(channel1_vrms_v)"
-        ":MEASure:ITEM? VAVG,CHANnel1": "#out(channel1_vavg_v)"
-        ":MEASure:ITEM? FREQuency,CHANnel1": "#out(channel1_freq_hz)"
-        ":MEASure:ITEM? PERiod,CHANnel1": "#out(channel1_period_s)"
+        ":MEASure:ITEM? VPP,CHANnel1":
+          name: query_channel_1_vpp
+          response: "#out(channel1_vpp_v)"
+        ":MEASure:ITEM? VRMS,CHANnel1":
+          name: query_channel_1_vrms
+          response: "#out(channel1_vrms_v)"
+        ":MEASure:ITEM? VAVG,CHANnel1":
+          name: query_channel_1_vavg
+          response: "#out(channel1_vavg_v)"
+        ":MEASure:ITEM? FREQuency,CHANnel1":
+          name: query_channel_1_frequency
+          response: "#out(channel1_freq_hz)"
+        ":MEASure:ITEM? PERiod,CHANnel1":
+          name: query_channel_1_period
+          response: "#out(channel1_period_s)"
 
 scenarios:
   calibration_tone:

--- a/library/domains/lab/oscilloscope/siglent/siglent_sds1000x_e__scpi.yaml
+++ b/library/domains/lab/oscilloscope/siglent/siglent_sds1000x_e__scpi.yaml
@@ -64,28 +64,52 @@ communication:
       response_delay: 0.01
       response_jitter: 0.0
       mappings:
-        "*IDN?": "#out(idn)"
-        "C1:VDIV?": "#out(k__channel_1_scale_v)"
+        "*IDN?":
+          name: query_idn
+          response: "#out(idn)"
+        "C1:VDIV?":
+          name: query_channel_1_scale
+          response: "#out(k__channel_1_scale_v)"
         "C1:VDIV {scale}":
+          name: set_channel_1_scale
           "#attr(k__channel_1_scale_v)": "scale"
           response: "OK"
-        "C1:OFST?": "#out(k__channel_1_offset_v)"
+        "C1:OFST?":
+          name: query_channel_1_offset
+          response: "#out(k__channel_1_offset_v)"
         "C1:OFST {offset}":
+          name: set_channel_1_offset
           "#attr(k__channel_1_offset_v)": "offset"
           response: "OK"
-        "TDIV?": "#out(k__timebase_scale_s)"
+        "TDIV?":
+          name: query_timebase_scale
+          response: "#out(k__timebase_scale_s)"
         "TDIV {scale}":
+          name: set_timebase_scale
           "#attr(k__timebase_scale_s)": "scale"
           response: "OK"
-        "TRLV?": "#out(k__trigger_level_v)"
+        "TRLV?":
+          name: query_trigger_level
+          response: "#out(k__trigger_level_v)"
         "TRLV {level}":
+          name: set_trigger_level
           "#attr(k__trigger_level_v)": "level"
           response: "OK"
-        "C1:PAVA? PKPK": "#out(channel1_vpp_v)"
-        "C1:PAVA? RMS": "#out(channel1_vrms_v)"
-        "C1:PAVA? MEAN": "#out(channel1_vavg_v)"
-        "C1:PAVA? FREQ": "#out(channel1_freq_hz)"
-        "C1:PAVA? PER": "#out(channel1_period_s)"
+        "C1:PAVA? PKPK":
+          name: query_channel_1_vpp
+          response: "#out(channel1_vpp_v)"
+        "C1:PAVA? RMS":
+          name: query_channel_1_vrms
+          response: "#out(channel1_vrms_v)"
+        "C1:PAVA? MEAN":
+          name: query_channel_1_vavg
+          response: "#out(channel1_vavg_v)"
+        "C1:PAVA? FREQ":
+          name: query_channel_1_frequency
+          response: "#out(channel1_freq_hz)"
+        "C1:PAVA? PER":
+          name: query_channel_1_period
+          response: "#out(channel1_period_s)"
 
 scenarios:
   amplitude_sweep:

--- a/library/domains/lab/oscilloscope/siglent/siglent_sds2000x_hd__scpi.yaml
+++ b/library/domains/lab/oscilloscope/siglent/siglent_sds2000x_hd__scpi.yaml
@@ -64,28 +64,52 @@ communication:
       response_delay: 0.01
       response_jitter: 0.0
       mappings:
-        "*IDN?": "#out(idn)"
-        "C1:VDIV?": "#out(k__channel_1_scale_v)"
+        "*IDN?":
+          name: query_idn
+          response: "#out(idn)"
+        "C1:VDIV?":
+          name: query_channel_1_scale
+          response: "#out(k__channel_1_scale_v)"
         "C1:VDIV {scale}":
+          name: set_channel_1_scale
           "#attr(k__channel_1_scale_v)": "scale"
           response: "OK"
-        "C1:OFST?": "#out(k__channel_1_offset_v)"
+        "C1:OFST?":
+          name: query_channel_1_offset
+          response: "#out(k__channel_1_offset_v)"
         "C1:OFST {offset}":
+          name: set_channel_1_offset
           "#attr(k__channel_1_offset_v)": "offset"
           response: "OK"
-        "TDIV?": "#out(k__timebase_scale_s)"
+        "TDIV?":
+          name: query_timebase_scale
+          response: "#out(k__timebase_scale_s)"
         "TDIV {scale}":
+          name: set_timebase_scale
           "#attr(k__timebase_scale_s)": "scale"
           response: "OK"
-        "TRLV?": "#out(k__trigger_level_v)"
+        "TRLV?":
+          name: query_trigger_level
+          response: "#out(k__trigger_level_v)"
         "TRLV {level}":
+          name: set_trigger_level
           "#attr(k__trigger_level_v)": "level"
           response: "OK"
-        "C1:PAVA? PKPK": "#out(channel1_vpp_v)"
-        "C1:PAVA? RMS": "#out(channel1_vrms_v)"
-        "C1:PAVA? MEAN": "#out(channel1_vavg_v)"
-        "C1:PAVA? FREQ": "#out(channel1_freq_hz)"
-        "C1:PAVA? PER": "#out(channel1_period_s)"
+        "C1:PAVA? PKPK":
+          name: query_channel_1_vpp
+          response: "#out(channel1_vpp_v)"
+        "C1:PAVA? RMS":
+          name: query_channel_1_vrms
+          response: "#out(channel1_vrms_v)"
+        "C1:PAVA? MEAN":
+          name: query_channel_1_vavg
+          response: "#out(channel1_vavg_v)"
+        "C1:PAVA? FREQ":
+          name: query_channel_1_frequency
+          response: "#out(channel1_freq_hz)"
+        "C1:PAVA? PER":
+          name: query_channel_1_period
+          response: "#out(channel1_period_s)"
 
 scenarios:
   amplitude_sweep:

--- a/library/domains/lab/oscilloscope/tektronix/tektronix_mdo3000__scpi.yaml
+++ b/library/domains/lab/oscilloscope/tektronix/tektronix_mdo3000__scpi.yaml
@@ -90,33 +90,57 @@ communication:
       response_delay: 0.01
       response_jitter: 0.0
       mappings:
-        "*IDN?": "#out(idn)"
-        ":SYSTem:ERRor?": "#out(last_error)"
-        ":CHANnel1:SCAle?": "#out(k__channel_1_scale_v)"
+        "*IDN?":
+          name: query_idn
+          response: "#out(idn)"
+        ":SYSTem:ERRor?":
+          name: query_system_error
+          response: "#out(last_error)"
+        ":CHANnel1:SCAle?":
+          name: query_channel_1_scale
+          response: "#out(k__channel_1_scale_v)"
         ":CHANnel1:SCAle {scale}":
+          name: set_channel_1_scale
           "#attr(k__channel_1_scale_v)": "scale"
           response: "OK"
-        ":CHANnel1:OFFSet?": "#out(k__channel_1_offset_v)"
+        ":CHANnel1:OFFSet?":
+          name: query_channel_1_offset
+          response: "#out(k__channel_1_offset_v)"
         ":CHANnel1:OFFSet {offset}":
+          name: set_channel_1_offset
           "#attr(k__channel_1_offset_v)": "offset"
           response: "OK"
-        ":HORizontal:MAIn:SCAle?": "#out(k__timebase_scale_s)"
+        ":HORizontal:MAIn:SCAle?":
+          name: query_timebase_scale
+          response: "#out(k__timebase_scale_s)"
         ":HORizontal:MAIn:SCAle {scale}":
+          name: set_timebase_scale
           "#attr(k__timebase_scale_s)": "scale"
           response: "OK"
-        ":TRIGger:A:LEVel?": "#out(k__trigger_level_v)"
+        ":TRIGger:A:LEVel?":
+          name: query_trigger_level
+          response: "#out(k__trigger_level_v)"
         ":TRIGger:A:LEVel {level}":
+          name: set_trigger_level
           "#attr(k__trigger_level_v)": "level"
           response: "OK"
-        ":MEASUrement:IMMed:TYPe?": "#out(k__measurement_type)"
+        ":MEASUrement:IMMed:TYPe?":
+          name: query_measurement_type
+          response: "#out(k__measurement_type)"
         ":MEASUrement:IMMed:TYPe {mtype}":
+          name: set_measurement_type
           "#attr(k__measurement_type)": "mtype"
           response: "OK"
-        ":MEASUrement:IMMed:SOUrce?": "#out(k__measurement_source)"
+        ":MEASUrement:IMMed:SOUrce?":
+          name: query_measurement_source
+          response: "#out(k__measurement_source)"
         ":MEASUrement:IMMed:SOUrce {source}":
+          name: set_measurement_source
           "#attr(k__measurement_source)": "source"
           response: "OK"
-        ":MEASUrement:IMMed:VALue?": "#out(measurement_value)"
+        ":MEASUrement:IMMed:VALue?":
+          name: query_measurement_value
+          response: "#out(measurement_value)"
 
 scenarios:
   calibration_tone:

--- a/tests/packs/embedded_lab_pack/unit/test_model_metadata_refresh_batch9.py
+++ b/tests/packs/embedded_lab_pack/unit/test_model_metadata_refresh_batch9.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from tests.common.repo import repo_root
+
+
+ROOT = repo_root()
+
+
+def _load_yaml(relative_path: str) -> dict:
+    path = ROOT / Path(relative_path)
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_embedded_lab_oscilloscope_scpi_mappings_are_named() -> None:
+    pack_index = _load_yaml("library/industries/embedded_lab_pack/MODELS.yaml")
+    catalog = _load_yaml("library/catalog/models.yaml")
+    model_index = {entry["id"]: entry for entry in catalog["models"]}
+
+    oscilloscope_ids = [
+        entry["id"]
+        for entry in pack_index["models"]
+        if entry["id"].startswith("Lab.Oscilloscope.") and entry["id"].endswith(".Scpi")
+    ]
+
+    assert oscilloscope_ids
+
+    for model_id in oscilloscope_ids:
+        model = _load_yaml(model_index[model_id]["path"])
+        communication = model["communication"]
+        ascii_protocol = communication[0]["ascii"]
+        mappings = ascii_protocol["mappings"]
+
+        names = []
+        for command, spec in mappings.items():
+            assert isinstance(spec, dict), f"{model_id}:{command} must use dict-form mapping"
+            assert "name" in spec, f"{model_id}:{command} is missing explicit mapping name"
+            names.append(spec["name"])
+
+        assert len(names) == len(set(names)), f"{model_id} has duplicate mapping names"
+
+
+def test_keysight_1000x_scpi_uses_descriptive_mapping_names() -> None:
+    model = _load_yaml(
+        "library/domains/lab/oscilloscope/keysight/keysight_infiniivision_1000x__scpi.yaml"
+    )
+    mappings = model["communication"][0]["ascii"]["mappings"]
+
+    assert mappings["*IDN?"]["name"] == "query_idn"
+    assert mappings[":MEASure:VPP?"]["name"] == "query_channel_1_vpp"
+    assert mappings[":MEASure:VAVerage?"]["name"] == "query_channel_1_vavg"
+    assert mappings[":TIMebase:SCALe {scale}"]["name"] == "set_timebase_scale"


### PR DESCRIPTION
## Summary
- add explicit names to legacy ASCII/SCPI oscilloscope mappings in embedded_lab_pack
- standardize mapping names across the Lab oscilloscope family so runtime bindings no longer fall back to binding_0 style names
- add a regression test that requires explicit, unique mapping names for Lab oscilloscope SCPI models

## Validation
- poetry run python tools/validate_models.py
- poetry run pytest tests/packs/embedded_lab_pack/unit
