### PR TITLE
feat(installer): group macOS tools and add uninstall flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ This repository includes a local MCP tool for code-oriented LLM workflows agains
 Claude Code and is aware of the repository catalog, profiles, packs, model
 validation rules, runtime logs, `communication`, and protocol bindings.
 
-If you install the macOS `.pkg`, the companion `SPX MCP Setup.app` can create an
-installer-managed Codex workspace with `.codex/config.toml` preconfigured for
-the local `spx-mcp` server. That managed workspace defaults to read-only MCP
-mode; for Git-backed write workflows, continue to use a normal repository clone.
+If you install the macOS `.pkg`, the companion `SPX MCP Setup.app` in
+`/Applications/SPX Tools/` can create an installer-managed Codex workspace with
+`.codex/config.toml` preconfigured for the local `spx-mcp` server. That managed
+workspace defaults to read-only MCP mode; for Git-backed write workflows,
+continue to use a normal repository clone.
 
 For attribute-heavy runtime workflows, prefer the batch MCP tools
 `server_get_attrs` and `server_set_attrs` to reduce round trips. For time-based
@@ -217,13 +218,14 @@ Hand the `.tgz` to teammates; they can extract it anywhere and run the platform 
 ### 6. Build a trusted macOS installer (Developer ID + notarization)
 
 For a macOS-native distribution, build a signed `.pkg` that installs
-`SPX Setup.app`, `SPX MCP Setup.app`, `SPX Start.app`, `SPX Stop.app`, and
-`SPX Cleanup.app` into `/Applications`. `SPX Setup.app` embeds the full
-installer payload inside the bundle, opens Terminal, and runs the existing
-terminal-based wizard without asking the user to trust a loose downloaded
-`.command` file. The other launchers operate on the generated environment in
-`~/Library/Application Support/SPX/generated` or bootstrap the installer-managed
-Codex MCP workspace.
+`SPX Setup.app`, `SPX MCP Setup.app`, `SPX Start.app`, `SPX Stop.app`,
+`SPX Cleanup.app`, and `SPX Uninstall.app` into `/Applications/SPX Tools`.
+`SPX Setup.app` embeds the full installer payload inside the bundle, opens
+Terminal, and runs the existing terminal-based wizard without asking the user
+to trust a loose downloaded `.command` file. The other launchers operate on the
+generated environment in `~/Library/Application Support/SPX/generated`,
+bootstrap the installer-managed Codex MCP workspace, or remove the installed
+SPX tools.
 
 1. Confirm both Developer ID certificates are present in your keychain:
 
@@ -249,11 +251,11 @@ scripts/build_macos_pkg.sh \
 ```
 
 The output package is written to `dist/spx-installer-macos-<version>.pkg`. After
-installation, users launch `SPX Setup.app` from `/Applications`; the installer
-defaults to a user-writable output directory when it is running from a packaged
-location such as `/Applications`. Once they have generated a local environment,
-they can later manage it via the companion launchers in the same Applications
-folder:
+installation, users launch `SPX Setup.app` from `/Applications/SPX Tools/`; the
+installer defaults to a user-writable output directory when it is running from
+a packaged location such as `/Applications/SPX Tools/`. Once they have
+generated a local environment, they can later manage it via the companion
+launchers in the same folder:
 
 - `SPX MCP Setup.app` creates `~/Documents/SPX Codex Workspace`, prepares a
   local `.venv`, writes `.codex/config.toml`, and opens that folder for Codex.
@@ -263,6 +265,9 @@ folder:
 - `SPX Cleanup.app` stops the generated stack, asks Docker to remove the
   generated environment's containers, images, and volumes, then deletes the
   local generated/runtime directories without uninstalling the macOS apps.
+- `SPX Uninstall.app` runs the cleanup flow, removes the installed macOS apps,
+  forgets the package receipt, and can optionally remove
+  `~/Documents/SPX Codex Workspace`.
 
 ### Windows trusted installer foundation (WiX MSI/EXE)
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -48,11 +48,11 @@ Linux or macOS:
 sh tools/setup_codex_mcp.sh
 ```
 
-If you installed the macOS `.pkg`, you can also launch `SPX MCP Setup.app`.
-That companion app creates an installer-managed workspace at
-`~/Documents/SPX Codex Workspace`, prepares a local `.venv`, and writes
-`.codex/config.toml` for that folder in read-only mode. Open Codex in the
-generated workspace and start a fresh thread to pick up the config.
+If you installed the macOS `.pkg`, you can also launch `SPX MCP Setup.app` from
+`/Applications/SPX Tools/`. That companion app creates an installer-managed
+workspace at `~/Documents/SPX Codex Workspace`, prepares a local `.venv`, and
+writes `.codex/config.toml` for that folder in read-only mode. Open Codex in
+the generated workspace and start a fresh thread to pick up the config.
 
 Optional flags:
 

--- a/installer/macos/spx_uninstall_launcher.applescript
+++ b/installer/macos/spx_uninstall_launcher.applescript
@@ -1,0 +1,99 @@
+property appTitle : "SPX Uninstall"
+property packageId : "com.hammerheadsengineers.spx.installer"
+property supportDirRelativePath : "Library/Application Support/SPX"
+property generatedDirRelativePath : "Library/Application Support/SPX/generated"
+property workspaceRelativePath : "Documents/SPX Codex Workspace"
+
+on run
+  set homePath to POSIX path of (path to home folder)
+  set appBundlePath to POSIX path of (path to me)
+  set appsDirPath to do shell script "/usr/bin/dirname " & quoted form of appBundlePath
+  set supportDir to homePath & supportDirRelativePath
+  set generatedDir to homePath & generatedDirRelativePath
+  set workspaceDir to homePath & workspaceRelativePath
+  set removeWorkspace to false
+  set uninstallMessage to "SPX Uninstall will stop the local stack, remove generated SPX files, delete the installed SPX apps, and forget the macOS package receipt."
+
+  activate
+  if my fileOrDirExists(workspaceDir) then
+    set workspaceChoice to button returned of (display dialog uninstallMessage & return & return & "Choose whether to keep the installer-managed workspace:" & return & workspaceDir buttons {"Cancel", "Keep Workspace", "Remove Workspace"} default button "Keep Workspace" cancel button "Cancel" with icon caution)
+    set removeWorkspace to workspaceChoice is "Remove Workspace"
+  else
+    display dialog uninstallMessage buttons {"Cancel", "Uninstall"} default button "Uninstall" cancel button "Cancel" with icon caution
+  end if
+
+  try
+    do shell script "/bin/bash -lc " & quoted form of my cleanupShell(supportDir, generatedDir, workspaceDir, removeWorkspace)
+    do shell script "/bin/bash -lc " & quoted form of my uninstallShell(appsDirPath, packageId) with administrator privileges
+    activate
+    if removeWorkspace then
+      display dialog appTitle & " removed the installed SPX tools and the installer-managed workspace." buttons {"OK"} default button "OK" with icon note
+    else
+      display dialog appTitle & " removed the installed SPX tools." & return & return & "The installer-managed workspace was left in place." buttons {"OK"} default button "OK" with icon note
+    end if
+  on error errMsg number errNum
+    if errNum is -128 then
+      return
+    end if
+
+    activate
+    display dialog "Unable to uninstall SPX." & return & return & errMsg & " (" & errNum & ")" buttons {"OK"} default button "OK" with icon stop
+  end try
+end run
+
+on cleanupShell(supportDir, generatedDir, workspaceDir, removeWorkspace)
+  set commandLines to {}
+  set end of commandLines to "set -euo pipefail"
+  set end of commandLines to "SUPPORT_DIR=" & quoted form of supportDir
+  set end of commandLines to "GENERATED_DIR=" & quoted form of generatedDir
+  set end of commandLines to "WORKSPACE_DIR=" & quoted form of workspaceDir
+  set end of commandLines to "REMOVE_WORKSPACE=" & (my boolToFlag(removeWorkspace))
+  set end of commandLines to "pkill -f spx-ble-adapter >/dev/null 2>&1 || true"
+  set end of commandLines to "if [ -f \"$GENERATED_DIR/docker-compose.generated.yml\" ] && command -v docker >/dev/null 2>&1; then"
+  set end of commandLines to "  docker compose -f \"$GENERATED_DIR/docker-compose.generated.yml\" --env-file \"$GENERATED_DIR/.env\" down --remove-orphans --volumes --rmi all || true"
+  set end of commandLines to "fi"
+  set end of commandLines to "rm -rf \"$SUPPORT_DIR\""
+  set end of commandLines to "if [ \"$REMOVE_WORKSPACE\" = 1 ]; then"
+  set end of commandLines to "  rm -rf \"$WORKSPACE_DIR\""
+  set end of commandLines to "fi"
+  return my joinLines(commandLines, linefeed)
+end cleanupShell
+
+on uninstallShell(appsDirPath, packageId)
+  set commandLines to {}
+  set end of commandLines to "set -euo pipefail"
+  set end of commandLines to "APPS_DIR=" & quoted form of appsDirPath
+  set end of commandLines to "PACKAGE_ID=" & quoted form of packageId
+  set end of commandLines to "for app_name in 'SPX Setup.app' 'SPX MCP Setup.app' 'SPX Start.app' 'SPX Stop.app' 'SPX Cleanup.app' 'SPX Uninstall.app'; do"
+  set end of commandLines to "  rm -rf \"$APPS_DIR/$app_name\""
+  set end of commandLines to "done"
+  set end of commandLines to "if [ \"$(/usr/bin/basename \"$APPS_DIR\")\" = 'SPX Tools' ]; then"
+  set end of commandLines to "  rmdir \"$APPS_DIR\" 2>/dev/null || true"
+  set end of commandLines to "fi"
+  set end of commandLines to "pkgutil --forget \"$PACKAGE_ID\" >/dev/null 2>&1 || true"
+  return my joinLines(commandLines, linefeed)
+end uninstallShell
+
+on fileOrDirExists(targetPath)
+  try
+    do shell script "test -e " & quoted form of targetPath
+    return true
+  on error
+    return false
+  end try
+end fileOrDirExists
+
+on boolToFlag(flagValue)
+  if flagValue then
+    return "1"
+  end if
+  return "0"
+end boolToFlag
+
+on joinLines(itemsList, delimiter)
+  set previousDelimiters to AppleScript's text item delimiters
+  set AppleScript's text item delimiters to delimiter
+  set joinedText to itemsList as text
+  set AppleScript's text item delimiters to previousDelimiters
+  return joinedText
+end joinLines

--- a/scripts/build_macos_pkg.sh
+++ b/scripts/build_macos_pkg.sh
@@ -7,10 +7,11 @@ usage() {
 Usage: scripts/build_macos_pkg.sh [options]
 
  Builds a macOS flat installer package (.pkg) that installs SPX Setup.app,
- SPX MCP Setup.app, SPX Start.app, SPX Stop.app, and SPX Cleanup.app into
- /Applications. SPX Setup.app contains the full installer payload; the other
- launchers operate on the generated environment in the user's Application
- Support directory or bootstrap a managed Codex MCP workspace.
+ SPX MCP Setup.app, SPX Start.app, SPX Stop.app, SPX Cleanup.app, and
+ SPX Uninstall.app into /Applications/SPX Tools. SPX Setup.app contains the
+ full installer payload; the other launchers operate on the generated
+ environment in the user's Application Support directory, bootstrap a managed
+ Codex MCP workspace, or remove the installed SPX tools.
 
 Options:
   --output-dir DIR              Directory for the final .pkg (default: dist)
@@ -18,7 +19,7 @@ Options:
   --pkg-name NAME               Output package stem without version/ext (default: spx-installer-macos)
   --identifier ID               macOS package identifier (default: com.hammerheadsengineers.spx.installer)
   --version VERSION             Package version (default: pyproject.toml version or dev)
-  --install-location PATH       Install destination on macOS (default: /Applications)
+  --install-location PATH       Parent install destination on macOS (default: /Applications)
   --app-name NAME               Installed launcher app name without extension (default: SPX Setup)
   --app-bundle-id ID            CFBundleIdentifier for the launcher app (default: com.hammerheadsengineers.spx.setup)
   --app-sign IDENTITY           Sign the launcher app with this Developer ID Application identity
@@ -46,6 +47,51 @@ resolve_version() {
   printf 'dev\n'
 }
 
+apply_folder_icon() {
+  local folder_path="$1"
+  local icon_source="$2"
+  local icon_path="${folder_path}/Icon"$'\r'
+
+  cp "${icon_source}" "${icon_path}"
+  chflags hidden "${icon_path}"
+  xattr -wx com.apple.FinderInfo \
+    0000000000000000040000000000000000000000000000000000000000000000 \
+    "${folder_path}"
+  xattr -wx com.apple.FinderInfo \
+    0000000000000000400000000000000000000000000000000000000000000000 \
+    "${icon_path}"
+}
+
+write_pkg_scripts() {
+  local scripts_dir="$1"
+  local install_root="$2"
+  local tools_dir_name="$3"
+
+  mkdir -p "${scripts_dir}"
+
+  cat > "${scripts_dir}/postinstall" <<EOF
+#!/bin/bash
+set -euo pipefail
+
+tools_dir="${install_root}/${tools_dir_name}"
+setup_icon="\${tools_dir}/SPX Setup.app/Contents/Resources/spx.icns"
+folder_icon="\${tools_dir}/Icon"$'\r'
+
+if [[ -d "\${tools_dir}" && -f "\${setup_icon}" ]]; then
+  cp "\${setup_icon}" "\${folder_icon}"
+  chflags hidden "\${folder_icon}" || true
+  xattr -wx com.apple.FinderInfo \
+    0000000000000000040000000000000000000000000000000000000000000000 \
+    "\${tools_dir}" || true
+  xattr -wx com.apple.FinderInfo \
+    0000000000000000400000000000000000000000000000000000000000000000 \
+    "\${folder_icon}" || true
+fi
+EOF
+
+  chmod +x "${scripts_dir}/postinstall"
+}
+
 OUTPUT_DIR="dist"
 STAGING_DIR="build/macos-pkg"
 PKG_NAME="spx-installer-macos"
@@ -62,6 +108,9 @@ STOP_APP_NAME="SPX Stop"
 STOP_APP_BUNDLE_ID="com.hammerheadsengineers.spx.stop"
 CLEANUP_APP_NAME="SPX Cleanup"
 CLEANUP_APP_BUNDLE_ID="com.hammerheadsengineers.spx.cleanup"
+UNINSTALL_APP_NAME="SPX Uninstall"
+UNINSTALL_APP_BUNDLE_ID="com.hammerheadsengineers.spx.uninstall"
+TOOLS_DIR_NAME="SPX Tools"
 APP_SIGN_IDENTITY=""
 SIGN_IDENTITY=""
 KEYCHAIN_PATH=""
@@ -138,6 +187,9 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST_DIR="${REPO_ROOT}/${OUTPUT_DIR}"
 STAGING_ROOT="${REPO_ROOT}/${STAGING_DIR}"
 APP_ROOT="${STAGING_ROOT}/root"
+APP_OUTPUT_DIR="${STAGING_DIR}/root/${TOOLS_DIR_NAME}"
+APP_INSTALL_ROOT="${APP_ROOT}/${TOOLS_DIR_NAME}"
+PKG_SCRIPTS_DIR="${STAGING_ROOT}/pkg-scripts"
 
 if [[ -z "${VERSION}" ]]; then
   VERSION="$(resolve_version)"
@@ -161,13 +213,16 @@ require_command pkgbuild
 require_command pkgutil
 require_command sed
 require_command /usr/libexec/PlistBuddy
+require_command chflags
+require_command xattr
 
 mkdir -p "${DEST_DIR}"
 rm -rf "${APP_ROOT}"
-mkdir -p "${APP_ROOT}"
+rm -rf "${PKG_SCRIPTS_DIR}"
+mkdir -p "${APP_INSTALL_ROOT}"
 
 build_app_args=(
-  --output-dir "${STAGING_DIR}/root"
+  --output-dir "${APP_OUTPUT_DIR}"
   --staging-dir "${STAGING_DIR}/payload"
   --app-name "${APP_NAME}"
   --bundle-id "${APP_BUNDLE_ID}"
@@ -181,7 +236,7 @@ fi
 "${REPO_ROOT}/scripts/build_macos_setup_app.sh" "${build_app_args[@]}"
 
 build_mcp_setup_app_args=(
-  --output-dir "${STAGING_DIR}/root"
+  --output-dir "${APP_OUTPUT_DIR}"
   --app-name "${MCP_SETUP_APP_NAME}"
   --bundle-id "${MCP_SETUP_APP_BUNDLE_ID}"
   --version "${VERSION}"
@@ -194,7 +249,7 @@ fi
 "${REPO_ROOT}/scripts/build_macos_mcp_setup_app.sh" "${build_mcp_setup_app_args[@]}"
 
 build_start_app_args=(
-  --output-dir "${STAGING_DIR}/root"
+  --output-dir "${APP_OUTPUT_DIR}"
   --app-name "${START_APP_NAME}"
   --bundle-id "${START_APP_BUNDLE_ID}"
   --version "${VERSION}"
@@ -207,7 +262,7 @@ fi
 "${REPO_ROOT}/scripts/build_macos_start_app.sh" "${build_start_app_args[@]}"
 
 build_stop_app_args=(
-  --output-dir "${STAGING_DIR}/root"
+  --output-dir "${APP_OUTPUT_DIR}"
   --app-name "${STOP_APP_NAME}"
   --bundle-id "${STOP_APP_BUNDLE_ID}"
   --version "${VERSION}"
@@ -220,7 +275,7 @@ fi
 "${REPO_ROOT}/scripts/build_macos_stop_app.sh" "${build_stop_app_args[@]}"
 
 build_cleanup_app_args=(
-  --output-dir "${STAGING_DIR}/root"
+  --output-dir "${APP_OUTPUT_DIR}"
   --app-name "${CLEANUP_APP_NAME}"
   --bundle-id "${CLEANUP_APP_BUNDLE_ID}"
   --version "${VERSION}"
@@ -232,16 +287,40 @@ fi
 
 "${REPO_ROOT}/scripts/build_macos_cleanup_app.sh" "${build_cleanup_app_args[@]}"
 
+build_uninstall_app_args=(
+  --output-dir "${APP_OUTPUT_DIR}"
+  --app-name "${UNINSTALL_APP_NAME}"
+  --bundle-id "${UNINSTALL_APP_BUNDLE_ID}"
+  --version "${VERSION}"
+)
+
+if [[ -n "${APP_SIGN_IDENTITY}" ]]; then
+  build_uninstall_app_args+=(--sign "${APP_SIGN_IDENTITY}")
+fi
+
+"${REPO_ROOT}/scripts/build_macos_uninstall_app.sh" "${build_uninstall_app_args[@]}"
+
+apply_folder_icon \
+  "${APP_INSTALL_ROOT}" \
+  "${APP_INSTALL_ROOT}/${APP_NAME}.app/Contents/Resources/spx.icns"
+write_pkg_scripts "${PKG_SCRIPTS_DIR}" "${INSTALL_LOCATION}" "${TOOLS_DIR_NAME}"
+
 PKG_PATH="${DEST_DIR}/${PKG_NAME}-${VERSION}.pkg"
 COMPONENT_PLIST="${STAGING_ROOT}/component.plist"
 rm -f "${PKG_PATH}"
 rm -f "${COMPONENT_PLIST}"
 
 pkgbuild --analyze --root "${APP_ROOT}" "${COMPONENT_PLIST}"
-/usr/libexec/PlistBuddy -c "Set :0:BundleIsRelocatable false" "${COMPONENT_PLIST}"
+
+component_index=0
+while /usr/libexec/PlistBuddy -c "Print :${component_index}" "${COMPONENT_PLIST}" >/dev/null 2>&1; do
+  /usr/libexec/PlistBuddy -c "Set :${component_index}:BundleIsRelocatable false" "${COMPONENT_PLIST}" >/dev/null 2>&1 || true
+  component_index=$((component_index + 1))
+done
 
 pkgbuild_args=(
   --root "${APP_ROOT}"
+  --scripts "${PKG_SCRIPTS_DIR}"
   --component-plist "${COMPONENT_PLIST}"
   --identifier "${IDENTIFIER}"
   --version "${VERSION}"

--- a/scripts/build_macos_setup_app.sh
+++ b/scripts/build_macos_setup_app.sh
@@ -17,6 +17,7 @@ Options:
   --app-name NAME     App bundle name without extension (default: SPX Setup)
   --bundle-id ID      CFBundleIdentifier for the app (default: com.hammerheadsengineers.spx.setup)
   --script-source P   AppleScript source used to build the app (default: installer/macos/spx_setup_launcher.applescript)
+  --icon-source P     PNG or ICNS used as the app icon (default: packaging/windows/assets/spx.png)
   --skip-payload      Build the launcher without embedding the installer payload
   --version VERSION   App version (default: pyproject.toml version or dev)
   --sign IDENTITY     Sign with this Developer ID Application identity
@@ -41,11 +42,65 @@ resolve_version() {
   printf 'dev\n'
 }
 
+install_app_icon() {
+  local source_path="$1"
+  local app_path="$2"
+  local staging_root="$3"
+  local resources_dir="${app_path}/Contents/Resources"
+  local icon_target="${resources_dir}/spx.icns"
+  local legacy_applet_icon="${resources_dir}/applet.icns"
+  local icon_ext
+
+  icon_ext="$(printf '%s' "${source_path##*.}" | tr '[:upper:]' '[:lower:]')"
+
+  case "${icon_ext}" in
+    icns)
+      cp "${source_path}" "${icon_target}"
+      ;;
+    png)
+      local app_stem
+      local iconset_dir
+
+      app_stem="$(basename "${app_path}" ".app" | tr ' /' '__')"
+      iconset_dir="${staging_root}/${app_stem}.iconset"
+      rm -rf "${iconset_dir}"
+      mkdir -p "${iconset_dir}"
+
+      while IFS=':' read -r icon_name icon_size; do
+        sips -z "${icon_size}" "${icon_size}" "${source_path}" \
+          --out "${iconset_dir}/${icon_name}" >/dev/null
+      done <<'EOF'
+icon_16x16.png:16
+icon_16x16@2x.png:32
+icon_32x32.png:32
+icon_32x32@2x.png:64
+icon_128x128.png:128
+icon_128x128@2x.png:256
+icon_256x256.png:256
+icon_256x256@2x.png:512
+icon_512x512.png:512
+icon_512x512@2x.png:1024
+EOF
+
+      iconutil -c icns "${iconset_dir}" -o "${icon_target}"
+      ;;
+    *)
+      echo "Unsupported icon format: ${source_path}" >&2
+      exit 1
+      ;;
+  esac
+
+  # AppleScript applets ship with a default applet.icns; replace it as well so
+  # Finder and LaunchServices cannot fall back to the generic Script Editor icon.
+  cp "${icon_target}" "${legacy_applet_icon}"
+}
+
 OUTPUT_DIR="dist"
 STAGING_DIR="build/macos-app"
 APP_NAME="SPX Setup"
 BUNDLE_ID="com.hammerheadsengineers.spx.setup"
 SCRIPT_SOURCE_REL="installer/macos/spx_setup_launcher.applescript"
+ICON_SOURCE_INPUT="packaging/windows/assets/spx.png"
 SKIP_PAYLOAD=0
 VERSION=""
 SIGN_IDENTITY=""
@@ -71,6 +126,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --script-source)
       SCRIPT_SOURCE_REL="$2"
+      shift 2
+      ;;
+    --icon-source)
+      ICON_SOURCE_INPUT="$2"
       shift 2
       ;;
     --skip-payload)
@@ -108,16 +167,33 @@ STAGING_ROOT="${REPO_ROOT}/${STAGING_DIR}"
 PAYLOAD_DIR="${STAGING_ROOT}/${PAYLOAD_NAME}"
 SCRIPT_SOURCE="${REPO_ROOT}/${SCRIPT_SOURCE_REL}"
 APP_PATH="${DEST_DIR}/${APP_NAME}.app"
+if [[ "${ICON_SOURCE_INPUT}" = /* ]]; then
+  ICON_SOURCE="${ICON_SOURCE_INPUT}"
+else
+  ICON_SOURCE="${REPO_ROOT}/${ICON_SOURCE_INPUT}"
+fi
 
 if [[ -z "${VERSION}" ]]; then
   VERSION="$(resolve_version)"
 fi
 
 require_command xcrun
+require_command iconutil
 require_command rsync
 require_command sed
+require_command sips
 require_command /usr/libexec/PlistBuddy
 require_command codesign
+
+if [[ ! -f "${SCRIPT_SOURCE}" ]]; then
+  echo "AppleScript source not found: ${SCRIPT_SOURCE}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${ICON_SOURCE}" ]]; then
+  echo "Icon source not found: ${ICON_SOURCE}" >&2
+  exit 1
+fi
 
 mkdir -p "${DEST_DIR}"
 mkdir -p "${STAGING_ROOT}"
@@ -130,6 +206,7 @@ if [[ "${SKIP_PAYLOAD}" -eq 0 ]]; then
 fi
 
 xcrun osacompile -o "${APP_PATH}" "${SCRIPT_SOURCE}"
+install_app_icon "${ICON_SOURCE}" "${APP_PATH}" "${STAGING_ROOT}"
 
 if [[ "${SKIP_PAYLOAD}" -eq 0 ]]; then
   RESOURCE_PAYLOAD_DIR="${APP_PATH}/Contents/Resources/${PAYLOAD_NAME}"
@@ -143,6 +220,9 @@ plist="${APP_PATH}/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleName '${APP_NAME}'" "${plist}"
 /usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string '${APP_NAME}'" "${plist}" 2>/dev/null || \
   /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName '${APP_NAME}'" "${plist}"
+/usr/libexec/PlistBuddy -c "Add :CFBundleIconFile string 'spx.icns'" "${plist}" 2>/dev/null || \
+  /usr/libexec/PlistBuddy -c "Set :CFBundleIconFile 'spx.icns'" "${plist}"
+/usr/libexec/PlistBuddy -c "Delete :CFBundleIconName" "${plist}" >/dev/null 2>&1 || true
 /usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string '${VERSION}'" "${plist}" 2>/dev/null || \
   /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString '${VERSION}'" "${plist}"
 /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string '${VERSION}'" "${plist}" 2>/dev/null || \

--- a/scripts/build_macos_uninstall_app.sh
+++ b/scripts/build_macos_uninstall_app.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build_macos_uninstall_app.sh [options]
+
+Builds SPX Uninstall.app, a macOS launcher that removes the installed SPX apps,
+forgets the package receipt, and optionally removes the installer-managed
+workspace.
+
+Options:
+  --output-dir DIR    Directory where the app bundle will be created (default: dist)
+  --app-name NAME     App bundle name without extension (default: SPX Uninstall)
+  --bundle-id ID      CFBundleIdentifier for the app (default: com.hammerheadsengineers.spx.uninstall)
+  --version VERSION   App version (default: pyproject.toml version or dev)
+  --sign IDENTITY     Sign with this Developer ID Application identity
+  -h, --help          Show this help
+EOF
+}
+
+OUTPUT_DIR="dist"
+APP_NAME="SPX Uninstall"
+BUNDLE_ID="com.hammerheadsengineers.spx.uninstall"
+VERSION=""
+SIGN_IDENTITY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --app-name)
+      APP_NAME="$2"
+      shift 2
+      ;;
+    --bundle-id)
+      BUNDLE_ID="$2"
+      shift 2
+      ;;
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --sign)
+      SIGN_IDENTITY="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+build_args=(
+  --output-dir "${OUTPUT_DIR}"
+  --app-name "${APP_NAME}"
+  --bundle-id "${BUNDLE_ID}"
+  --script-source "installer/macos/spx_uninstall_launcher.applescript"
+  --skip-payload
+)
+
+if [[ -n "${VERSION}" ]]; then
+  build_args+=(--version "${VERSION}")
+fi
+
+if [[ -n "${SIGN_IDENTITY}" ]]; then
+  build_args+=(--sign "${SIGN_IDENTITY}")
+fi
+
+"${REPO_ROOT}/scripts/build_macos_setup_app.sh" "${build_args[@]}"


### PR DESCRIPTION
## Summary
- install macOS launcher apps under `/Applications/SPX Tools`
- add `SPX Uninstall.app` alongside the existing setup/start/stop/cleanup tools
- apply custom SPX icons to the launcher apps and the `SPX Tools` folder
- update macOS installer docs for the new layout and uninstall flow

## Verification
- built the macOS installer package end-to-end
- verified launcher bundles use `CFBundleIconFile=spx.icns` without `CFBundleIconName=applet`
- verified the installer stages `SPX Tools` and reapplies the folder icon in `postinstall`
- produced a signed/notarized test artifact at `build/spx-tools-pkg-foldericon-signed/spx-installer-macos-1.1.0-rc.31.pkg`