### PR TITLE
fix(installer): use SPX runtime defaults for health and UI start

### DIFF
--- a/installer/generator.py
+++ b/installer/generator.py
@@ -18,11 +18,11 @@ from . import paths
 
 
 SPX_SERVER_SERVICE_NAME = "spx-server"
-SPX_SERVER_IMAGE = "simplephysx/spx-server:v1.0.0-rc.54"
-SPX_SERVER_IMAGE = "simplephysx/spx-server:v1.0.0-rc.54"
+SPX_SERVER_IMAGE = "simplephysx/spx-server:v1.0.0-rc.60"
 # SPX_SERVER_IMAGE = "spx-server:trial"
 SPX_UI_SERVICE_NAME = "spx-ui"
-SPX_UI_IMAGE = "simplephysx/spx-ui:v1.0.0-rc.55"
+SPX_UI_IMAGE = "simplephysx/spx-ui:v1.0.0-rc.61"
+# SPX_UI_IMAGE = "spx-ui:trial"
 
 
 class DeploymentGenerator:
@@ -436,12 +436,6 @@ exit /b %EXITCODE%
             "environment": {
                 "SPX_PRODUCT_KEY": "${SPX_PRODUCT_KEY}",
             },
-            "healthcheck": {
-                "test": ["CMD-SHELL", "curl -f http://localhost:8000 || exit 1"],
-                "interval": "10s",
-                "timeout": "5s",
-                "retries": 5,
-            },
             "volumes": volumes,
             "command": [
                 "--address",
@@ -467,10 +461,6 @@ exit /b %EXITCODE%
             "environment": {
                 "SPX_PRODUCT_KEY": "${SPX_PRODUCT_KEY}",
             },
-            "command": [
-                "--product-key",
-                "${SPX_PRODUCT_KEY}",
-            ],
         }
 
     def _build_docker_service(self, manifest: ServiceManifest, assets_root: Path) -> Dict:

--- a/tests/installer/test_generator.py
+++ b/tests/installer/test_generator.py
@@ -142,6 +142,7 @@ def test_generator_creates_compose(tmp_path: Path) -> None:
     assert "spx-ui" not in services
     assert "mqtt_broker" in services
     assert "8000:8000" in services["spx-server"]["ports"]
+    assert "healthcheck" not in services["spx-server"]
     assert "host.docker.internal:host-gateway" in services["spx-server"].get(
         "extra_hosts", []
     )
@@ -235,7 +236,7 @@ def test_generator_includes_ui_when_requested(tmp_path: Path) -> None:
     assert ui_service["image"] == SPX_UI_IMAGE
     assert ui_service["ports"] == ["3000:3000"]
     assert ui_service["environment"]["SPX_PRODUCT_KEY"] == "${SPX_PRODUCT_KEY}"
-    assert ui_service["command"] == ["--product-key", "${SPX_PRODUCT_KEY}"]
+    assert "command" not in ui_service
     assert ui_service["depends_on"]["spx-server"]["condition"] == "service_healthy"
 
 


### PR DESCRIPTION
## Summary
- bump the generated runtime images to `simplephysx/spx-server:v1.0.0-rc.60` and `simplephysx/spx-ui:v1.0.0-rc.61`
- stop overriding the `spx-server` healthcheck in generated Compose so the image healthcheck is used
- stop overriding the `spx-ui` command so the image entrypoint can keep its default standalone startup path

## Root Cause
- the generated Compose file still forced a `curl`-based healthcheck for `spx-server`, but the newer server image now ships its own Python-based healthcheck
- the generated Compose file also overrode the `spx-ui` command with `--product-key ...`, which replaced the image CMD and forced the entrypoint fallback to `npm run start`
- in the trimmed UI image this fallback fails with `next: not found`, while the default image CMD (`node server.js`) works correctly

## Verification
- regenerated `build/spx-generated`
- started the stack with `docker compose -f build/spx-generated/docker-compose.generated.yml --env-file build/spx-generated/.env up -d`
- verified `spx-server` becomes healthy with the image healthcheck
- verified `spx-ui-server` starts successfully and `http://localhost:3000` responds