### PR TITLE
fix(installer): skip unreadable MCP payload files

### DIFF
--- a/installer/mcp_workspace.py
+++ b/installer/mcp_workspace.py
@@ -182,6 +182,19 @@ def remove_path(path: Path) -> None:
         shutil.rmtree(path)
 
 
+def copy_file(src: str | Path, dest: str | Path) -> None:
+    src_path = Path(src)
+    dest_path = Path(dest)
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        shutil.copy2(src_path, dest_path)
+    except PermissionError:
+        print(
+            f"[spx-mcp-setup] Skipping unreadable payload file: {src_path}",
+            file=sys.stderr,
+        )
+
+
 def copy_path(src: Path, dest: Path) -> None:
     if src.is_dir():
         shutil.copytree(
@@ -189,10 +202,10 @@ def copy_path(src: Path, dest: Path) -> None:
             dest,
             symlinks=True,
             ignore=shutil.ignore_patterns(*sorted(SKIP_ENTRY_NAMES)),
+            copy_function=copy_file,
         )
         return
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(src, dest)
+    copy_file(src, dest)
 
 
 def sync_payload(source_root: Path, workspace_dir: Path) -> None:

--- a/tests/installer/test_mcp_workspace.py
+++ b/tests/installer/test_mcp_workspace.py
@@ -84,6 +84,37 @@ def test_sync_payload_replaces_managed_entries_and_keeps_local_state(tmp_path: P
     assert (workspace / "local.txt").read_text(encoding="utf-8") == "keep me\n"
 
 
+def test_sync_payload_skips_unreadable_files(tmp_path: Path, monkeypatch, capsys) -> None:
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    library_dir = source_root / "library" / "assets" / "matter" / "data"
+    library_dir.mkdir(parents=True)
+    readable_file = library_dir / "chip.json"
+    blocked_file = library_dir / "chip_config.ini"
+    readable_file.write_text('{"ok": true}\n', encoding="utf-8")
+    blocked_file.write_text("secret\n", encoding="utf-8")
+
+    original_copy2 = mcp_workspace.shutil.copy2
+
+    def flaky_copy2(src, dest, *args, **kwargs):
+        if Path(src).name == blocked_file.name:
+            raise PermissionError("permission denied")
+        return original_copy2(src, dest, *args, **kwargs)
+
+    monkeypatch.setattr(mcp_workspace.shutil, "copy2", flaky_copy2)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    mcp_workspace.sync_payload(source_root, workspace)
+
+    assert (workspace / "library" / "assets" / "matter" / "data" / "chip.json").exists()
+    assert not (workspace / "library" / "assets" / "matter" / "data" / "chip_config.ini").exists()
+    stderr = capsys.readouterr().err
+    assert "Skipping unreadable payload file" in stderr
+    assert str(blocked_file) in stderr
+
+
 def test_bootstrap_runtime_installs_workspace_editably(tmp_path: Path, monkeypatch) -> None:
     source_root = tmp_path / "source"
     runtime_helper = source_root / "installer" / "runtime_bootstrap.py"


### PR DESCRIPTION
## Summary
- make MCP workspace sync resilient to unreadable payload files inside the packaged installer bundle
- log skipped files to stderr instead of failing the entire `spx-mcp-setup` flow
- add a regression test for `PermissionError` during payload sync

## Root Cause
- the packaged `SPX Setup.app` payload under `/Applications` contains some root-owned `0600` files in `library/assets/homeassistant/config/.storage` and `library/assets/matter/data`
- `installer/mcp_workspace.py` copied the full workspace payload with `shutil.copytree`, so a single unreadable file aborted the whole MCP setup with `shutil.Error`

## Verification
- ran `pytest tests/installer/test_mcp_workspace.py`
- verified all 8 tests pass locally
- ran `python installer/mcp_workspace.py` against the real installed payload from `/Applications/SPX Tools/SPX Setup.app/Contents/Resources/spx-installer`
- confirmed the command now exits successfully and logs skipped unreadable files instead of crashing