### PR TITLE
fix(packaging): restore Windows MCP setup prompt

### DIFF
--- a/installer/mcp_workspace.py
+++ b/installer/mcp_workspace.py
@@ -601,6 +601,53 @@ def resolve_workspace_contract(
     return WORKSPACE_KIND_GIT, WORK_MODE_REPO_DEV
 
 
+def is_interactive_session() -> bool:
+    try:
+        return bool(sys.stdin.isatty())
+    except Exception:
+        return False
+
+
+def prompt_work_mode(default_mode: str) -> str:
+    default_selection = "1" if default_mode == WORK_MODE_RUNTIME_MCP else "2"
+
+    while True:
+        print("[spx-mcp-setup] Choose workspace work mode:")
+        print("  1. runtime_mcp  Fast MCP-first workspace for live spx-server work")
+        print("  2. repo_dev     Full git checkout for models, tests, docs, and PRs")
+        choice = input(f"Selection [1/2, default {default_selection}]: ").strip()
+        selected = choice or default_selection
+        if selected == "1":
+            return WORK_MODE_RUNTIME_MCP
+        if selected == "2":
+            return WORK_MODE_REPO_DEV
+        print("[spx-mcp-setup] Invalid selection. Choose 1 or 2.")
+
+
+def resolve_workspace_selection(
+    *,
+    workspace_dir: Path,
+    explicit_workspace_kind: Optional[str],
+    explicit_work_mode: Optional[str],
+) -> tuple[str, str]:
+    if explicit_workspace_kind is not None or explicit_work_mode is not None:
+        return resolve_workspace_contract(
+            workspace_dir=workspace_dir,
+            explicit_workspace_kind=explicit_workspace_kind,
+            explicit_work_mode=explicit_work_mode,
+        )
+
+    workspace_kind, work_mode = resolve_workspace_contract(
+        workspace_dir=workspace_dir,
+        explicit_workspace_kind=None,
+        explicit_work_mode=None,
+    )
+    if is_interactive_session():
+        selected_mode = prompt_work_mode(work_mode)
+        return workspace_kind_for_work_mode(selected_mode), selected_mode
+    return workspace_kind, work_mode
+
+
 def assert_workspace_ready_for_managed_bootstrap(workspace_dir: Path) -> None:
     assert_no_duplicate_workspace_entries(workspace_dir)
     assert_workspace_marker_consistency(workspace_dir)
@@ -805,13 +852,15 @@ def verify_workspace(
     ]
     if allow_write:
         doctor_argv.append("--allow-write")
-    doctor_result = run_command(doctor_argv, capture_output=True)
-    try:
-        doctor_report = json.loads(doctor_result.stdout)
-    except json.JSONDecodeError as exc:
+    doctor_report = run_json_command(
+        doctor_argv,
+        command_label="spx_mcp doctor --json",
+        allow_nonzero_json=True,
+    )
+    if not isinstance(doctor_report, dict):
         raise RuntimeError(
-            "Workspace bootstrap could not parse `spx_mcp doctor --json` output."
-        ) from exc
+            "Workspace bootstrap expected `spx_mcp doctor --json` to return an object."
+        )
     if not bool(doctor_report.get("ok")):
         problems = doctor_report.get("problems") or []
         details = "\n".join(f"- {problem}" for problem in problems) or "- unknown doctor failure"
@@ -829,13 +878,10 @@ def verify_workspace(
     ]
     if allow_write:
         list_tools_argv.append("--allow-write")
-    list_tools_result = run_command(list_tools_argv, capture_output=True)
-    try:
-        tool_specs = json.loads(list_tools_result.stdout)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(
-            "Workspace bootstrap could not parse `spx_mcp list-tools --json` output."
-        ) from exc
+    tool_specs = run_json_command(
+        list_tools_argv,
+        command_label="spx_mcp list-tools --json",
+    )
     if not isinstance(tool_specs, list):
         raise RuntimeError(
             "Workspace bootstrap expected `spx_mcp list-tools --json` to return a list."
@@ -869,6 +915,37 @@ def verify_workspace(
                 "are still exposed:\n- "
                 + "\n- ".join(unexpected_tools)
             )
+
+
+def run_json_command(
+    argv: Sequence[str],
+    *,
+    command_label: str,
+    allow_nonzero_json: bool = False,
+) -> object:
+    try:
+        result = run_command(argv, capture_output=True)
+        stdout = result.stdout
+    except subprocess.CalledProcessError as exc:
+        stdout = exc.stdout or ""
+        if allow_nonzero_json and stdout.strip():
+            try:
+                return json.loads(stdout)
+            except json.JSONDecodeError:
+                pass
+        details = (exc.stderr or "").strip() or stdout.strip() or (
+            f"{command_label} exited with status {exc.returncode}."
+        )
+        raise RuntimeError(
+            f"Workspace bootstrap could not complete `{command_label}`:\n{details}"
+        ) from exc
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Workspace bootstrap could not parse `{command_label}` output."
+        ) from exc
 
 
 def write_workspace_readme(
@@ -1012,7 +1089,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         else None
     )
 
-    workspace_kind, work_mode = resolve_workspace_contract(
+    workspace_kind, work_mode = resolve_workspace_selection(
         workspace_dir=workspace_dir,
         explicit_workspace_kind=args.workspace_kind,
         explicit_work_mode=args.work_mode,

--- a/packaging/windows/launcher/Program.cs
+++ b/packaging/windows/launcher/Program.cs
@@ -55,7 +55,7 @@ internal static class Program
         Console.WriteLine("Usage: SpxLauncher.exe [setup|mcp-setup|start|stop|cleanup] [--pause-on-error]");
         Console.WriteLine();
         Console.WriteLine("  setup      Generate or refresh the local SPX environment.");
-        Console.WriteLine("  mcp-setup  Create or refresh the Codex MCP workspace (defaults to runtime_mcp).");
+        Console.WriteLine("  mcp-setup  Create or refresh the Codex MCP workspace.");
         Console.WriteLine("  start      Run the generated SPX start script.");
         Console.WriteLine("  stop       Run the generated SPX stop script.");
         Console.WriteLine("  cleanup    Remove the generated SPX environment and Docker resources.");
@@ -119,17 +119,8 @@ internal static class Program
         var pythonExecutable = ResolvePythonExecutable();
         var scriptPath = Path.Combine(installRoot, "installer", "mcp_workspace.py");
         EnsureFileExists(scriptPath, "Missing installed script 'installer\\mcp_workspace.py'. Reinstall SPX.");
-        var hasWorkspaceKind = extraArgs.Any(
-            argument => string.Equals(argument, "--workspace-kind", StringComparison.OrdinalIgnoreCase)
-        );
-        var hasWorkMode = extraArgs.Any(
-            argument => string.Equals(argument, "--work-mode", StringComparison.OrdinalIgnoreCase)
-        );
-        var hasAllowWrite = extraArgs.Any(
-            argument => string.Equals(argument, "--allow-write", StringComparison.OrdinalIgnoreCase)
-        );
-        var hasReadOnly = extraArgs.Any(
-            argument => string.Equals(argument, "--read-only", StringComparison.OrdinalIgnoreCase)
+        var hasSeedEnv = extraArgs.Any(
+            argument => string.Equals(argument, "--seed-env", StringComparison.OrdinalIgnoreCase)
         );
 
         var arguments = new List<string>
@@ -144,19 +135,10 @@ internal static class Program
             "--server-name",
             "spx",
         };
-        if (!hasWorkspaceKind)
+        if (!hasSeedEnv)
         {
-            arguments.Add("--workspace-kind");
-            arguments.Add("managed");
-        }
-        if (!hasWorkMode)
-        {
-            arguments.Add("--work-mode");
-            arguments.Add("runtime_mcp");
-        }
-        if (!hasAllowWrite && !hasReadOnly)
-        {
-            arguments.Add("--allow-write");
+            arguments.Add("--seed-env");
+            arguments.Add(GetGeneratedEnvFile());
         }
         arguments.AddRange(extraArgs);
 
@@ -340,6 +322,11 @@ internal static class Program
     private static string GetGeneratedDirectory()
     {
         return Path.Combine(GetSpxRootDirectory(), GeneratedDirectoryName);
+    }
+
+    private static string GetGeneratedEnvFile()
+    {
+        return Path.Combine(GetGeneratedDirectory(), ".env");
     }
 
     private static string GetWorkspaceDirectory()

--- a/tests/installer/test_mcp_workspace.py
+++ b/tests/installer/test_mcp_workspace.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import subprocess
 from types import SimpleNamespace
 
 import pytest
@@ -205,6 +206,54 @@ def test_resolve_workspace_contract_defaults_to_repo_dev(tmp_path: Path) -> None
 
     assert workspace_kind == mcp_workspace.WORKSPACE_KIND_GIT
     assert work_mode == mcp_workspace.WORK_MODE_REPO_DEV
+
+
+def test_resolve_workspace_selection_prompts_and_can_override_suggested_mode(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    prompted_defaults: list[str] = []
+
+    monkeypatch.setattr(mcp_workspace, "is_interactive_session", lambda: True)
+    monkeypatch.setattr(
+        mcp_workspace,
+        "prompt_work_mode",
+        lambda default_mode: prompted_defaults.append(default_mode) or mcp_workspace.WORK_MODE_RUNTIME_MCP,
+    )
+
+    workspace_kind, work_mode = mcp_workspace.resolve_workspace_selection(
+        workspace_dir=workspace,
+        explicit_workspace_kind=None,
+        explicit_work_mode=None,
+    )
+
+    assert prompted_defaults == [mcp_workspace.WORK_MODE_REPO_DEV]
+    assert workspace_kind == mcp_workspace.WORKSPACE_KIND_MANAGED
+    assert work_mode == mcp_workspace.WORK_MODE_RUNTIME_MCP
+
+
+def test_resolve_workspace_selection_skips_prompt_for_explicit_mode(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+
+    monkeypatch.setattr(mcp_workspace, "is_interactive_session", lambda: True)
+    monkeypatch.setattr(
+        mcp_workspace,
+        "prompt_work_mode",
+        lambda default_mode: (_ for _ in ()).throw(AssertionError("prompt should not run")),
+    )
+
+    workspace_kind, work_mode = mcp_workspace.resolve_workspace_selection(
+        workspace_dir=workspace,
+        explicit_workspace_kind=None,
+        explicit_work_mode=mcp_workspace.WORK_MODE_RUNTIME_MCP,
+    )
+
+    assert workspace_kind == mcp_workspace.WORKSPACE_KIND_MANAGED
+    assert work_mode == mcp_workspace.WORK_MODE_RUNTIME_MCP
 
 
 def test_resolve_workspace_contract_prefers_local_mode_file_over_metadata(tmp_path: Path) -> None:
@@ -891,6 +940,46 @@ def test_verify_workspace_fails_when_required_runtime_write_tools_are_missing(
     monkeypatch.setattr(mcp_workspace, "run_command", fake_run)
 
     with pytest.raises(RuntimeError, match="server_register_model_and_ensure_instance"):
+        mcp_workspace.verify_workspace(
+            tmp_path / ".venv" / "bin" / "python",
+            workspace,
+            server_name="spx",
+            allow_write=True,
+        )
+
+
+def test_verify_workspace_reports_doctor_problems_from_nonzero_json(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    codex_dir = workspace / ".codex"
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "config.toml").write_text(
+        "[mcp_servers.spx]\n"
+        'command = "python3.11"\n'
+        'args = ["-m", "spx_mcp", "stdio", "--allow-write"]\n',
+        encoding="utf-8",
+    )
+
+    def fake_run(argv, *, cwd=None, capture_output=False):
+        if "doctor" in argv:
+            raise subprocess.CalledProcessError(
+                1,
+                argv,
+                output=json.dumps(
+                    {
+                        "ok": False,
+                        "problems": ["SPX_PRODUCT_KEY is missing or invalid for this MCP workspace."],
+                    }
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(mcp_workspace, "run_command", fake_run)
+
+    with pytest.raises(RuntimeError, match="SPX_PRODUCT_KEY is missing or invalid"):
         mcp_workspace.verify_workspace(
             tmp_path / ".venv" / "bin" / "python",
             workspace,


### PR DESCRIPTION
This pull request introduces improvements to the workspace setup flow, error handling, and test coverage for the MCP workspace installer. The main changes include adding interactive work mode selection, robust JSON command execution, and enhanced test cases. Additionally, the Windows launcher logic is simplified to better align with the new workspace setup flow.

**Workspace setup and selection improvements:**

* Added `resolve_workspace_selection`, `is_interactive_session`, and `prompt_work_mode` to enable interactive selection of workspace mode when not explicitly specified, improving user experience during setup (`mcp_workspace.py`). [[1]](diffhunk://#diff-adc5367b11b416a0ced008065a2a5382781e04d8a1b89df85331082dd4ed2489R604-R650) [[2]](diffhunk://#diff-adc5367b11b416a0ced008065a2a5382781e04d8a1b89df85331082dd4ed2489L1015-R1092)
* Updated Windows launcher (`Program.cs`) to remove hardcoded workspace kind and work mode arguments, and to handle `.env` file generation more cleanly. [[1]](diffhunk://#diff-80e2ef6da89f22efb68cc10c580b4dbbbca128b6bbc461dd674547ed3c3076afL58-R58) [[2]](diffhunk://#diff-80e2ef6da89f22efb68cc10c580b4dbbbca128b6bbc461dd674547ed3c3076afL122-R123) [[3]](diffhunk://#diff-80e2ef6da89f22efb68cc10c580b4dbbbca128b6bbc461dd674547ed3c3076afL147-R141) [[4]](diffhunk://#diff-80e2ef6da89f22efb68cc10c580b4dbbbca128b6bbc461dd674547ed3c3076afR327-R331)

**Error handling and robustness:**

* Introduced `run_json_command` to standardize subprocess execution and JSON parsing, handling nonzero exit codes when JSON output is still provided (e.g., for `spx_mcp doctor`). Updated `verify_workspace` to use this helper for both doctor and list-tools checks. [[1]](diffhunk://#diff-adc5367b11b416a0ced008065a2a5382781e04d8a1b89df85331082dd4ed2489L808-R863) [[2]](diffhunk://#diff-adc5367b11b416a0ced008065a2a5382781e04d8a1b89df85331082dd4ed2489L832-R884) [[3]](diffhunk://#diff-adc5367b11b416a0ced008065a2a5382781e04d8a1b89df85331082dd4ed2489R920-R950)

**Testing improvements:**

* Added tests for interactive workspace selection, explicit mode override, and for handling nonzero JSON output from `spx_mcp doctor`, ensuring the new logic is covered and robust. [[1]](diffhunk://#diff-d15cc20023130d965c641bd882cd3d450a0faa59de95ecdb07d7f205c6b4b1c9R211-R258) [[2]](diffhunk://#diff-d15cc20023130d965c641bd882cd3d450a0faa59de95ecdb07d7f205c6b4b1c9R949-R988)