### PR TITLE
feat(industrial): add modbus master plc demo

### DIFF
--- a/library/catalog/industries.yaml
+++ b/library/catalog/industries.yaml
@@ -139,6 +139,7 @@ industries:
     profiles:
       - profiles/industrial_iiot_pack/process_cell_quickstart.yaml
       - profiles/industrial_iiot_pack/iiot_monitoring.yaml
+      - profiles/industrial_iiot_pack/modbus_master_plc_demo.yaml
     default_instances:
       - model: Motion.StepperController.Modbus
         instance: spx_stepper_axis

--- a/library/catalog/models.yaml
+++ b/library/catalog/models.yaml
@@ -905,7 +905,8 @@ models:
   - id: modbus_tcp_gateway
   packages:
   - industrial_iiot_pack
-  profiles: []
+  profiles:
+  - modbus_master_plc_demo
 - id: IO.IOModule.Modbus
   name: IO Module (Modbus)
   path: library/domains/industrial/io_module/generic/io_module__modbus.yaml
@@ -950,6 +951,20 @@ models:
   - industrial_iiot_pack
   profiles:
   - process_cell_quickstart
+- id: Industrial.PlcController.ModbusMaster
+  name: Generic PLC Controller (Modbus Master)
+  path: library/domains/industrial/controller/generic/plc_controller__modbus_master.yaml
+  domain: industrial
+  domain_group: industrial
+  device_class: controller
+  vendor: generic
+  protocols:
+  - modbus
+  services: []
+  packages:
+  - industrial_iiot_pack
+  profiles:
+  - modbus_master_plc_demo
 - id: Energy.EnergyMeter3Ph.Modbus
   name: 3-Phase Energy Meter (Modbus)
   path: library/domains/energy/meter/generic/energy_meter_3ph__modbus.yaml
@@ -979,8 +994,10 @@ models:
   - id: modbus_tcp_gateway
   packages:
   - smart_building_pack
+  - industrial_iiot_pack
   profiles:
   - bms_quickstart
+  - modbus_master_plc_demo
 - id: Energy.EnergyMeterPm3200.Modbus
   name: Schneider Electric PowerLogic PM3200 Energy Meter (Modbus)
   path: library/domains/energy/meter/schneider/schneider_pm3200__modbus.yaml

--- a/library/domains/industrial/controller/generic/plc_controller__modbus_master.yaml
+++ b/library/domains/industrial/controller/generic/plc_controller__modbus_master.yaml
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Hammerheads Engineers Sp. z o.o.
+# See the accompanying LICENSE file for terms.
+
+name: plc_controller__modbus_master
+description: |
+  Generic PLC-style controller that uses Modbus TCP master bindings to supervise
+  a Schneider Altivar 320 VFD and a Schneider iEM3000 energy meter. The model
+  demonstrates a typical PLC pattern:
+    - persistent drive run/speed commands written to downstream Modbus slaves
+    - drive feedback and meter telemetry read back into controller state
+    - a simple local interlock that blocks the drive when measured power exceeds
+      the configured limit
+
+meta_parameters:
+  drive_host:
+    type: string
+    default: 127.0.0.1
+  drive_port:
+    type: int
+    default: 5030
+  drive_unit_id:
+    type: int
+    default: 1
+  meter_host:
+    type: string
+    default: 127.0.0.1
+  meter_port:
+    type: int
+    default: 5023
+  meter_unit_id:
+    type: int
+    default: 1
+
+attributes:
+  k__drive_run_enable:
+    type: int
+    default: 0
+  k__drive_speed_setpoint_hz:
+    type: float
+    default: 0.0
+    unit: Hz
+  k__power_limit_kw:
+    type: float
+    default: 20.0
+    unit: kW
+  k__power_limit_stop_enable:
+    type: int
+    default: 1
+
+  drive_status_word_raw:
+    type: int
+    default: 0
+  drive_speed_actual_raw:
+    type: int
+    default: 0
+  drive_speed_actual_hz:
+    type: float
+    default: 0.0
+    unit: Hz
+  drive_run_effective:
+    type: int
+    default: 0
+  drive_running:
+    type: int
+    default: 0
+  drive_fault_active:
+    type: int
+    default: 0
+
+  meter_active_power_total_kw:
+    type: float
+    default: 0.0
+    unit: kW
+  meter_frequency_hz:
+    type: float
+    default: 0.0
+    unit: Hz
+  meter_energy_import_total_kwh:
+    type: float
+    default: 0.0
+    unit: kWh
+
+  power_limit_active:
+    type: int
+    default: 0
+  drive_command_blocked:
+    type: int
+    default: 0
+
+  drive_speed_scale_hz_per_unit:
+    type: float
+    default: 1.0
+    unit: Hz/unit
+  drive_speed_max_hz:
+    type: float
+    default: 60.0
+    unit: Hz
+
+  _drive_control_word_raw:
+    type: int
+    default: 0
+  _drive_speed_setpoint_raw:
+    type: int
+    default: 0
+
+actions:
+  - function: $in(power_limit_active)
+    name: compute_power_limit_active
+    description: Raise the PLC interlock when measured active power exceeds the configured limit.
+    call: 1 if ($in(k__power_limit_stop_enable) == 1 and $in(meter_active_power_total_kw) > $in(k__power_limit_kw)) else 0
+
+  - function: $in(drive_command_blocked)
+    name: compute_drive_command_blocked
+    description: Expose whether a requested drive run is currently blocked by the PLC interlock.
+    call: 1 if ($in(k__drive_run_enable) == 1 and $in(power_limit_active) == 1) else 0
+
+  - function: $in(drive_run_effective)
+    name: compute_drive_run_effective
+    description: Forward the run request only when the power-limit interlock is clear.
+    call: 1 if ($in(k__drive_run_enable) == 1 and $in(power_limit_active) == 0) else 0
+
+  - function: $in(_drive_control_word_raw)
+    name: encode_drive_control_word_raw
+    description: Encode the effective run request into the Altivar command register.
+    call: 1 if $in(drive_run_effective) == 1 else 0
+
+  - function: $in(_drive_speed_setpoint_raw)
+    name: encode_drive_speed_setpoint_raw
+    description: Encode the requested drive speed into the Altivar speed reference register.
+    call: int(round(
+            (
+              max(0.0, min($in(drive_speed_max_hz), $in(k__drive_speed_setpoint_hz)))
+              if $in(drive_run_effective) == 1
+              else 0.0
+            ) / max(0.001, $in(drive_speed_scale_hz_per_unit))
+          ))
+
+  - function: $in(drive_speed_actual_hz)
+    name: decode_drive_speed_actual_hz
+    description: Convert the Altivar raw speed feedback register into engineering units.
+    call: $in(drive_speed_actual_raw) * $in(drive_speed_scale_hz_per_unit)
+
+  - function: $in(drive_running)
+    name: compute_drive_running
+    description: Consider the drive running when the actual speed is measurably above zero.
+    call: 1 if abs($in(drive_speed_actual_hz)) >= 0.1 else 0
+
+  - function: $in(drive_fault_active)
+    name: decode_drive_fault_active
+    description: Decode the Altivar minimal fault bit from the lower status-word nibble.
+    call: 1 if (($in(drive_status_word_raw) % 16) >= 8) else 0
+
+polling:
+  interval: 0.2
+
+communication:
+  - modbus_master:
+      poll_interval: 0.2
+      timeout: 1.0
+      max_retries: 1
+      retry_delay: 0.1
+      bindings:
+        - name: query_drive_status_word
+          host: "$param(drive_host)"
+          port: "$param(drive_port)"
+          slave_id: "$param(drive_unit_id)"
+          area: h_r
+          address: 12741
+          length: 1
+          codec: uint_16
+          direction: inbound
+          attribute: drive_status_word_raw
+
+        - name: query_drive_speed_actual
+          host: "$param(drive_host)"
+          port: "$param(drive_port)"
+          slave_id: "$param(drive_unit_id)"
+          area: h_r
+          address: 12742
+          length: 1
+          codec: uint_16
+          direction: inbound
+          attribute: drive_speed_actual_raw
+
+        - name: set_drive_control_word
+          host: "$param(drive_host)"
+          port: "$param(drive_port)"
+          slave_id: "$param(drive_unit_id)"
+          area: h_r
+          address: 12761
+          length: 1
+          codec: uint_16
+          direction: outbound
+          attribute: _drive_control_word_raw
+
+        - name: set_drive_speed_reference
+          host: "$param(drive_host)"
+          port: "$param(drive_port)"
+          slave_id: "$param(drive_unit_id)"
+          area: h_r
+          address: 12762
+          length: 1
+          codec: uint_16
+          direction: outbound
+          attribute: _drive_speed_setpoint_raw
+
+        - name: query_meter_active_power_total
+          host: "$param(meter_host)"
+          port: "$param(meter_port)"
+          slave_id: "$param(meter_unit_id)"
+          area: i_r
+          address: 3060
+          length: 2
+          codec: float
+          direction: inbound
+          attribute: meter_active_power_total_kw
+
+        - name: query_meter_frequency
+          host: "$param(meter_host)"
+          port: "$param(meter_port)"
+          slave_id: "$param(meter_unit_id)"
+          area: i_r
+          address: 3110
+          length: 2
+          codec: float
+          direction: inbound
+          attribute: meter_frequency_hz
+
+        - name: query_meter_energy_import_total
+          host: "$param(meter_host)"
+          port: "$param(meter_port)"
+          slave_id: "$param(meter_unit_id)"
+          area: h_r
+          address: 45100
+          length: 2
+          codec: float
+          direction: inbound
+          attribute: meter_energy_import_total_kwh
+
+scenarios:
+  drive_run_nominal:
+    display_name: Drive Run Nominal
+    description: Enable the drive at a moderate speed with the power limit comfortably above the measured load.
+    duration: 20.0
+    overrides:
+      $in(k__drive_run_enable): 1
+      $in(k__drive_speed_setpoint_hz): 25.0
+      $in(k__power_limit_kw): 20.0
+
+  power_limit_stop:
+    display_name: Power-Limit Stop
+    description: Request the drive while keeping the PLC power limit below the measured meter load.
+    duration: 20.0
+    overrides:
+      $in(k__drive_run_enable): 1
+      $in(k__drive_speed_setpoint_hz): 25.0
+      $in(k__power_limit_kw): 3.0

--- a/library/industries/industrial_iiot_pack/MODELS.yaml
+++ b/library/industries/industrial_iiot_pack/MODELS.yaml
@@ -14,6 +14,11 @@ models:
   domain_group: energy
   device_class: meter
   vendor: generic
+- id: Energy.EnergyMeterIem3000.Modbus
+  path: library/domains/energy/meter/schneider/energy_meter_iem3000__modbus.yaml
+  domain_group: energy
+  device_class: meter
+  vendor: schneider
 - id: Energy.PowerMeter.AbbM1M.Modbus
   path: library/domains/energy/power_meter/abb/abb_m1m_power_meter__modbus.yaml
   domain_group: energy
@@ -49,6 +54,11 @@ models:
   domain_group: industrial
   device_class: io_module
   vendor: wago
+- id: Industrial.PlcController.ModbusMaster
+  path: library/domains/industrial/controller/generic/plc_controller__modbus_master.yaml
+  domain_group: industrial
+  device_class: controller
+  vendor: generic
 - id: Lab.Detector.PrevacMCD7.Modbus
   path: library/domains/lab/detector/prevac/prevac_mcd7__modbus.yaml
   domain_group: lab

--- a/library/industries/industrial_iiot_pack/README.md
+++ b/library/industries/industrial_iiot_pack/README.md
@@ -11,7 +11,9 @@ additional Redfish device twins can land alongside.
   * `Process.Workcell.OpcUa` – robotic/machining gniazdo z pomiarem cykli i alarmami.
   * `Process.PackagingLine.OpcUa` – linia pakująca z wrapperem, kolejką i alarmami.
   * `Process.ProcessCell.SiemensS7_1500.OpcUa` – vendor-specific process cell endpoint.
-- **Quickstart**: `profiles/industrial_iiot_pack/process_cell_quickstart.yaml`.
+- **Quickstarts**:
+  * `profiles/industrial_iiot_pack/process_cell_quickstart.yaml`
+  * `profiles/industrial_iiot_pack/modbus_master_plc_demo.yaml` - generic PLC-style `modbus_master` demo that supervises an Altivar 320 VFD and an iEM3000 energy meter over direct Modbus TCP slave endpoints.
 
 ## Connection matrix
 

--- a/library/industries/industrial_iiot_pack/SPEC.md
+++ b/library/industries/industrial_iiot_pack/SPEC.md
@@ -3,7 +3,7 @@
 Purpose: OPC UA/Modbus/MQTT/HTTP kit for line automation, process control, and factory monitoring.
 
 ## Scope
-- Profiles: `profiles/industrial_iiot_pack/process_cell_quickstart.yaml`, `profiles/industrial_iiot_pack/iiot_monitoring.yaml`
+- Profiles: `profiles/industrial_iiot_pack/process_cell_quickstart.yaml`, `profiles/industrial_iiot_pack/iiot_monitoring.yaml`, `profiles/industrial_iiot_pack/modbus_master_plc_demo.yaml`
 - Tests: `tests/packs/industrial_iiot_pack/integration`
 - Catalog entry: `library/catalog/industries.yaml` (industrial_iiot_pack)
 
@@ -11,7 +11,7 @@ Purpose: OPC UA/Modbus/MQTT/HTTP kit for line automation, process control, and f
 1. Add or update model YAML under `library/domains/...`.
 2. Update `library/catalog/models.yaml` (include `packages: [industrial_iiot_pack]` and any relevant `profiles`).
 3. Update `library/catalog/industries.yaml` if default instances or services need changes.
-4. Update `profiles/industrial_iiot_pack/process_cell_quickstart.yaml` or `profiles/industrial_iiot_pack/iiot_monitoring.yaml` if the quickstart should include the model.
+4. Update the relevant profile under `profiles/industrial_iiot_pack/` (for example `process_cell_quickstart.yaml`, `iiot_monitoring.yaml`, or `modbus_master_plc_demo.yaml`) if the pack demo should include the model.
 5. Update `library/industries/industrial_iiot_pack/README.md` if the pack scope or model list changes.
 6. Add or update tests under `tests/packs/industrial_iiot_pack/`.
 

--- a/profiles/industrial_iiot_pack/modbus_master_plc_demo.yaml
+++ b/profiles/industrial_iiot_pack/modbus_master_plc_demo.yaml
@@ -1,0 +1,9 @@
+name: modbus_master_plc_demo
+description: |
+  Minimal PLC-style Modbus master demo that supervises a Schneider Altivar 320
+  VFD and an iEM3000 energy meter over direct Modbus TCP slave endpoints.
+models:
+  - library/domains/industrial/controller/generic/plc_controller__modbus_master.yaml
+  - library/domains/industrial/drive/schneider/schneider_altivar_320__modbus.yaml
+  - library/domains/energy/meter/schneider/energy_meter_iem3000__modbus.yaml
+services: []

--- a/tests/packs/industrial_iiot_pack/integration/test_modbus_master_plc_demo_smoke.py
+++ b/tests/packs/industrial_iiot_pack/integration/test_modbus_master_plc_demo_smoke.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import os
+import socket
+import unittest
+from pathlib import Path
+from typing import Optional
+
+from tests.common.repo import repo_root
+from tests.common.spx_utils import (
+    ensure_instance,
+    ensure_model,
+    load_model_definition,
+    wait_for_condition,
+)
+
+
+SPX_BASE_URL = os.environ.get("SPX_BASE_URL", "http://localhost:8000")
+
+PLC_MODEL_ID = "Industrial.PlcController.ModbusMaster"
+PLC_INSTANCE_KEY = "spx_plc_controller_modbus_master_demo"
+DRIVE_MODEL_ID = "Motion.VFDrive.SchneiderAltivar320.Modbus"
+DRIVE_INSTANCE_KEY = "spx_altivar_320_vfd_plc_demo"
+METER_MODEL_ID = "Energy.EnergyMeterIem3000.Modbus"
+METER_INSTANCE_KEY = "spx_iem3000_meter_plc_demo"
+
+
+def _pick_free_port(host: str = "127.0.0.1") -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return int(sock.getsockname()[1])
+
+
+def _instance_state(instance) -> Optional[str]:
+    try:
+        state = instance.state
+    except Exception:
+        state = None
+    if isinstance(state, str):
+        return state
+
+    try:
+        doc = instance.get()
+    except Exception:
+        doc = None
+    if isinstance(doc, dict):
+        value = doc.get("state")
+        if isinstance(value, str):
+            return value
+        attr = doc.get("attr")
+        if isinstance(attr, dict):
+            state_attr = attr.get("state")
+            if isinstance(state_attr, dict):
+                state_value = state_attr.get("value")
+                if isinstance(state_value, str):
+                    return state_value
+    return None
+
+
+def _float_attr(attr) -> Optional[float]:
+    try:
+        value = attr.internal_value
+    except Exception:
+        value = None
+    if value is None:
+        value = attr
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int_attr(attr) -> Optional[int]:
+    value = _float_attr(attr)
+    if value is None:
+        return None
+    return int(round(value))
+
+
+class TestModbusMasterPlcDemoSmokeIntegration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import spx_python  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise unittest.SkipTest(f"spx_python not available: {exc}") from exc
+
+        product_key = os.environ.get("SPX_PRODUCT_KEY")
+        if not product_key:
+            raise unittest.SkipTest("SPX_PRODUCT_KEY must be set to run integration tests.")
+
+        cls._client = spx_python.init(address=SPX_BASE_URL, product_key=product_key)
+        root = repo_root()
+
+        cls._plc_def = load_model_definition(
+            Path(root / "library/domains/industrial/controller/generic/plc_controller__modbus_master.yaml")
+        )
+        cls._drive_def = load_model_definition(
+            Path(root / "library/domains/industrial/drive/schneider/schneider_altivar_320__modbus.yaml")
+        )
+        cls._meter_def = load_model_definition(
+            Path(root / "library/domains/energy/meter/schneider/energy_meter_iem3000__modbus.yaml")
+        )
+
+        ensure_model(cls._client, PLC_MODEL_ID, cls._plc_def)
+        ensure_model(cls._client, DRIVE_MODEL_ID, cls._drive_def)
+        ensure_model(cls._client, METER_MODEL_ID, cls._meter_def)
+
+        cls._drive_port = _pick_free_port()
+        cls._meter_port = _pick_free_port()
+        cls._drive_unit_id = 11
+        cls._meter_unit_id = 21
+
+        cls._drive = ensure_instance(
+            cls._client,
+            DRIVE_INSTANCE_KEY,
+            DRIVE_MODEL_ID,
+            model_def=cls._drive_def,
+            meta_parameters={
+                "modbus_port": cls._drive_port,
+                "modbus_unit_id": cls._drive_unit_id,
+            },
+            recreate=True,
+            ensure_running=True,
+        )
+        cls._meter = ensure_instance(
+            cls._client,
+            METER_INSTANCE_KEY,
+            METER_MODEL_ID,
+            model_def=cls._meter_def,
+            meta_parameters={
+                "modbus_port": cls._meter_port,
+                "modbus_unit_id": cls._meter_unit_id,
+            },
+            recreate=True,
+            ensure_running=True,
+        )
+        cls._plc = ensure_instance(
+            cls._client,
+            PLC_INSTANCE_KEY,
+            PLC_MODEL_ID,
+            model_def=cls._plc_def,
+            meta_parameters={
+                "drive_host": "127.0.0.1",
+                "drive_port": cls._drive_port,
+                "drive_unit_id": cls._drive_unit_id,
+                "meter_host": "127.0.0.1",
+                "meter_port": cls._meter_port,
+                "meter_unit_id": cls._meter_unit_id,
+            },
+            recreate=True,
+            ensure_running=True,
+        )
+
+        for instance in (cls._drive, cls._meter, cls._plc):
+            ready = wait_for_condition(
+                lambda inst=instance: (_instance_state(inst) or "").lower() == "running",
+                timeout=10.0,
+                interval=0.2,
+            )
+            if not ready:
+                raise AssertionError(f"Instance did not reach RUNNING: {instance}")
+
+    @classmethod
+    def tearDownClass(cls):
+        for key in (PLC_INSTANCE_KEY, DRIVE_INSTANCE_KEY, METER_INSTANCE_KEY):
+            try:
+                instance = cls._client["instances"][key]
+            except Exception:
+                instance = None
+            if instance is None:
+                continue
+            try:
+                instance.stop()
+            except Exception:
+                pass
+            try:
+                del cls._client["instances"][key]
+            except Exception:
+                pass
+
+    def test_master_reads_drive_and_meter_feedback(self):
+        plc_attrs = self._plc["attributes"]
+
+        meter_ready = wait_for_condition(
+            lambda: (_float_attr(plc_attrs["meter_active_power_total_kw"]) or 0.0) > 1.0,
+            timeout=10.0,
+            interval=0.2,
+        )
+        self.assertTrue(meter_ready, "PLC did not read active power from the iEM3000 meter.")
+
+        frequency_ready = wait_for_condition(
+            lambda: abs((_float_attr(plc_attrs["meter_frequency_hz"]) or 0.0) - 50.0) <= 1.0,
+            timeout=10.0,
+            interval=0.2,
+        )
+        self.assertTrue(frequency_ready, "PLC did not read frequency from the iEM3000 meter.")
+
+        drive_status_ready = wait_for_condition(
+            lambda: (_int_attr(plc_attrs["drive_status_word_raw"]) or 0) >= 1,
+            timeout=10.0,
+            interval=0.2,
+        )
+        self.assertTrue(drive_status_ready, "PLC did not read the Altivar status word.")
+
+    def test_master_controls_drive_and_enforces_power_limit(self):
+        plc_attrs = self._plc["attributes"]
+        drive_attrs = self._drive["attributes"]
+
+        plc_attrs["k__power_limit_kw"].internal_value = 20.0
+        plc_attrs["k__drive_speed_setpoint_hz"].internal_value = 24.0
+        plc_attrs["k__drive_run_enable"].internal_value = 1
+
+        drive_run_written = wait_for_condition(
+            lambda: (_int_attr(drive_attrs["cmd__control_word_raw"]) or 0) == 1,
+            timeout=10.0,
+            interval=0.2,
+        )
+        self.assertTrue(drive_run_written, "PLC did not write the Altivar run command.")
+
+        drive_speed_written = wait_for_condition(
+            lambda: (_int_attr(drive_attrs["k__speed_setpoint_raw"]) or -1) == 24,
+            timeout=10.0,
+            interval=0.2,
+        )
+        self.assertTrue(drive_speed_written, "PLC did not write the Altivar speed reference.")
+
+        drive_feedback_ready = wait_for_condition(
+            lambda: (_float_attr(plc_attrs["drive_speed_actual_hz"]) or 0.0) > 0.5,
+            timeout=10.0,
+            interval=0.2,
+        )
+        self.assertTrue(drive_feedback_ready, "PLC did not read the Altivar speed feedback.")
+
+        plc_attrs["k__power_limit_kw"].internal_value = 3.0
+
+        limit_active = wait_for_condition(
+            lambda: (_int_attr(plc_attrs["power_limit_active"]) or 0) == 1,
+            timeout=10.0,
+            interval=0.2,
+        )
+        self.assertTrue(limit_active, "PLC power-limit interlock did not activate.")
+
+        drive_stopped = wait_for_condition(
+            lambda: _int_attr(drive_attrs["cmd__control_word_raw"]) == 0,
+            timeout=10.0,
+            interval=0.2,
+        )
+        self.assertTrue(drive_stopped, "PLC did not clear the Altivar run command on power limit.")

--- a/tests/packs/industrial_iiot_pack/unit/test_pack_catalog.py
+++ b/tests/packs/industrial_iiot_pack/unit/test_pack_catalog.py
@@ -21,7 +21,10 @@ PACK_ID = "industrial_iiot_pack"
 REQUIRED_SMOKE_TESTS = {
     "Energy.PowerMeter.AbbM1M.Modbus": Path(
         "tests/packs/industrial_iiot_pack/integration/test_modbus_abb_m1m_smoke.py"
-    )
+    ),
+    "Industrial.PlcController.ModbusMaster": Path(
+        "tests/packs/industrial_iiot_pack/integration/test_modbus_master_plc_demo_smoke.py"
+    ),
 }
 
 
@@ -81,6 +84,12 @@ def test_pack_includes_abb_m1m_power_meter() -> None:
     models = models_for_pack(PACK_ID)
     model_ids = {entry.get("id") for entry in models}
     assert "Energy.PowerMeter.AbbM1M.Modbus" in model_ids
+
+
+def test_pack_includes_plc_modbus_master_controller() -> None:
+    models = models_for_pack(PACK_ID)
+    model_ids = {entry.get("id") for entry in models}
+    assert "Industrial.PlcController.ModbusMaster" in model_ids
 
 
 def test_pack_default_instances_include_abb_m1m_power_meter() -> None:


### PR DESCRIPTION
This pull request adds a new generic PLC-style Modbus master demo to the `industrial_iiot_pack`. It introduces a reusable PLC controller model that supervises a Schneider Altivar 320 VFD and an iEM3000 energy meter using Modbus TCP, along with a profile, catalog entries, documentation, and integration tests to support and validate the demo.

**New PLC Modbus Master Demo and Model Integration:**

* Added a new profile `modbus_master_plc_demo.yaml` that demonstrates a PLC-style Modbus master supervising a VFD and energy meter (`profiles/industrial_iiot_pack/modbus_master_plc_demo.yaml`).
* Introduced the `Industrial.PlcController.ModbusMaster` model, a generic PLC controller with Modbus master bindings, including logic for drive control, interlock, and meter telemetry (`library/domains/industrial/controller/generic/plc_controller__modbus_master.yaml`).
* Registered the new PLC controller and demo profile in all relevant catalog and pack files, ensuring discoverability and correct linkage in `models.yaml`, `industries.yaml`, and `MODELS.yaml` (`library/catalog/models.yaml`, `library/catalog/industries.yaml`, `library/industries/industrial_iiot_pack/MODELS.yaml`). [[1]](diffhunk://#diff-dd15b348f16b1b8e263817886ca46bd2461685c86c43cc2e9ee497517e8d5c4aR954-R967) [[2]](diffhunk://#diff-dd15b348f16b1b8e263817886ca46bd2461685c86c43cc2e9ee497517e8d5c4aL908-R909) [[3]](diffhunk://#diff-4cf1c750b53c9a8c8b2ae74df4529ad7cd70c4b996f105863f0f2fdcc4ff0f95R142) [[4]](diffhunk://#diff-dd15b348f16b1b8e263817886ca46bd2461685c86c43cc2e9ee497517e8d5c4aR997-R1000) [[5]](diffhunk://#diff-f8425721809a3f409d21b8e651315296760f4cd886d0c59d3612064d10d3d73bR57-R61)

**Documentation Updates:**

* Updated documentation to list the new demo profile and clarify instructions for adding models to the pack (`library/industries/industrial_iiot_pack/README.md`, `library/industries/industrial_iiot_pack/SPEC.md`). [[1]](diffhunk://#diff-b1c64f45bb129219c0771c7c1956b9d8dd2a63ebfb1ed4baba57aceb1e9b267dL14-R16) [[2]](diffhunk://#diff-7cd0e12850209e372b3e243494d15e35080f5834f39135a1581275b8609f3bfbL6-R14)

**Testing:**

* Added a comprehensive integration smoke test for the new demo, verifying PLC-to-drive and PLC-to-meter communication, drive control, and interlock logic (`tests/packs/industrial_iiot_pack/integration/test_modbus_master_plc_demo_smoke.py`).
* Registered the new test and model in the pack's unit test catalog and added a unit test to ensure the model is included (`tests/packs/industrial_iiot_pack/unit/test_pack_catalog.py`). [[1]](diffhunk://#diff-efc3dc96b47666051fcb09f659b17dd8ab537dee41c2083f7d93d2579db99d5eL24-R27) [[2]](diffhunk://#diff-efc3dc96b47666051fcb09f659b17dd8ab537dee41c2083f7d93d2579db99d5eR89-R94)

This PR provides a full-featured, tested, and documented example of a PLC-style Modbus master controller, expanding the industrial IIoT pack's capabilities for demo and integration use cases.