### PR TITLE
fix(installer): polish setup wizard UX

### DIFF
--- a/installer/cli.py
+++ b/installer/cli.py
@@ -263,7 +263,7 @@ def _build_noninteractive_selection(
         protocols=protocols,
         install_examples=install_examples,
         install_spx_ui=install_spx_ui,
-        offline_bundle=True,
+        offline_bundle=not bool(getattr(args, "start", False)),
         license_key=product_key,
         model_ids=compatibility.model_ids,
         service_ids=compatibility.service_ids,
@@ -354,8 +354,7 @@ def run(args: argparse.Namespace) -> int:
         if noninteractive or getattr(args, "no_start", False):
             return 0
 
-        launch = input("\nStart the stack now? [Y/n]: ").strip().lower()
-        if launch in {"", "y", "yes"}:
+        if not selection.offline_bundle:
             _launch_stack(output_dir, stream=info_stream)
         return 0
     if args.command == "bootstrap":

--- a/installer/wizard.py
+++ b/installer/wizard.py
@@ -11,12 +11,22 @@ from typing import Dict, List, Sequence
 
 from .manifest import IndustryManifest, ManifestIndex, ManifestLoader
 from .selection import resolve_default_instances, resolve_model_ids, resolve_service_ids
-from .selection import apply_platform_compatibility
+from .selection import apply_platform_compatibility, current_platform_name
 from . import ui
 
 DEFAULT_PROTOCOLS = ("modbus", "ascii", "scpi")
 PROTOCOL_ALIASES = {"ascii": "scpi"}
 PROTOCOL_LABELS = {"scpi": "scpi (ASCII)"}
+THIRD_PARTY_SERVICE_NOTICES = {
+    "mqtt_broker": "MQTT Broker pulls Eclipse Mosquitto under separate open-source license terms.",
+    "lwm2m_server": "LwM2M Server pulls Eclipse Leshan under separate open-source license terms.",
+    "knx_gateway": (
+        "KNX Gateway pulls knxd-based container images under separate open-source license terms; "
+        "review redistribution obligations before mirroring or bundling them."
+    ),
+    "homeassistant_bridge": "Home Assistant Bridge pulls Home Assistant under separate open-source license terms.",
+    "matter_server": "Matter Server pulls python-matter-server under separate open-source license terms.",
+}
 
 
 @dataclass(frozen=True)
@@ -53,8 +63,10 @@ class InstallerWizard:
         install_instances = False
         start_instances: List[str] = []
         if not protocol_only:
+            profiles = self._prompt_profiles(packages, index)
+            selection_label = "selected packages and profiles" if profiles else "selected packages"
             install_models = self._prompt_yes_no(
-                "\nAdd models from selected packages? [Y/n]: ",
+                f"\nAdd models from {selection_label}? [Y/n]: ",
                 default=True,
             )
             if install_models:
@@ -65,10 +77,11 @@ class InstallerWizard:
                 if install_instances:
                     start_instances = self._prompt_start_instances(packages, index)
         install_spx_ui = self._prompt_yes_no("Include SPX UI frontend container? [Y/n]: ", default=True)
-        offline_bundle = self._prompt_yes_no(
-            "Prepare offline installation bundle instead of immediate launch? [y/N]: ",
+        start_now = self._prompt_yes_no(
+            "Start the stack immediately after generation? [y/N]: ",
             default=False,
         )
+        offline_bundle = not start_now
         license_key = self._prompt_license_key()
 
         if protocol_only:
@@ -106,6 +119,16 @@ class InstallerWizard:
             for warning in compatibility.warnings:
                 print(f"  - {warning}")
 
+        runtime_notices = self._build_runtime_notices(
+            service_ids=service_ids,
+            install_spx_ui=install_spx_ui,
+            index=index,
+        )
+        if runtime_notices:
+            print(ui.warn("\nRuntime & third-party notices:"))
+            for notice in runtime_notices:
+                print(f"  - {notice}")
+
         self._print_summary(
             packages,
             profiles,
@@ -113,7 +136,7 @@ class InstallerWizard:
             install_models,
             install_instances,
             install_spx_ui,
-            offline_bundle,
+            start_now,
             license_key,
             model_ids,
             service_ids,
@@ -442,6 +465,57 @@ class InstallerWizard:
                 continue
             return sorted(set(values))
 
+    def _build_runtime_notices(
+        self,
+        *,
+        service_ids: Sequence[str],
+        install_spx_ui: bool,
+        index: ManifestIndex,
+    ) -> List[str]:
+        notices: List[str] = []
+        seen: set[str] = set()
+        normalized_platform = current_platform_name()
+
+        if normalized_platform in {"windows", "macos"}:
+            notices.append(
+                "SPX runs as a Docker-based stack. Docker Desktop is required on this platform and "
+                "is licensed separately by Docker; some organizations need a paid subscription."
+            )
+        else:
+            notices.append(
+                "SPX runs as a Docker-based stack. Make sure Docker Engine and Compose are installed "
+                "before starting the generated environment."
+            )
+
+        if install_spx_ui:
+            notices.append(
+                "SPX UI is installed as part of the generated container stack and starts through Docker."
+            )
+
+        for service_id in service_ids:
+            notice = THIRD_PARTY_SERVICE_NOTICES.get(service_id)
+            if notice and notice not in seen:
+                notices.append(notice)
+                seen.add(notice)
+
+            manifest = index.services.get(service_id)
+            deployment = manifest.deployment if manifest is not None else None
+            if deployment is None or deployment.runtime != "native":
+                continue
+
+            instruction = (deployment.instructions or {}).get(normalized_platform)
+            if not instruction:
+                continue
+
+            native_notice = (
+                f"{manifest.name} requires host-side setup on {normalized_platform}: {instruction}"
+            )
+            if native_notice not in seen:
+                notices.append(native_notice)
+                seen.add(native_notice)
+
+        return notices
+
     def _print_summary(
         self,
         packages: Sequence[str],
@@ -450,7 +524,7 @@ class InstallerWizard:
         install_models: bool,
         install_instances: bool,
         install_spx_ui: bool,
-        offline_bundle: bool,
+        start_now: bool,
         license_key: str,
         model_ids: Sequence[str],
         service_ids: Sequence[str],
@@ -479,7 +553,7 @@ class InstallerWizard:
         print(f"\nInstall models: {ui.success('yes') if install_models else ui.warn('no')}")
         print(f"Install instances: {ui.success('yes') if install_instances else ui.warn('no')}")
         print(f"Include SPX UI: {ui.success('yes') if install_spx_ui else ui.warn('no')}")
-        print(f"Offline bundle: {ui.success('yes') if offline_bundle else ui.warn('no')}")
+        print(f"Start stack now: {ui.success('yes') if start_now else ui.warn('no')}")
         print(f"SPX product key: {ui.heading(self._mask_secret(license_key))}")
         print("\nModels:")
         for model_id in model_ids:

--- a/installer/wizard.py
+++ b/installer/wizard.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 import getpass
 import os
+import re
 from dataclasses import dataclass
 from shutil import get_terminal_size
+from textwrap import shorten
 from typing import Dict, List, Sequence
 
 from .manifest import IndustryManifest, ManifestIndex, ManifestLoader
+from . import paths
 from .selection import resolve_default_instances, resolve_model_ids, resolve_service_ids
 from .selection import apply_platform_compatibility, current_platform_name
 from . import ui
@@ -17,6 +20,28 @@ from . import ui
 DEFAULT_PROTOCOLS = ("modbus", "ascii", "scpi")
 PROTOCOL_ALIASES = {"ascii": "scpi"}
 PROTOCOL_LABELS = {"scpi": "scpi (ASCII)"}
+PROTOCOL_BADGE_LABELS = {
+    "ascii": "ASCII",
+    "opcua": "OPC UA",
+    "modbus": "Modbus",
+    "mqtt": "MQTT",
+    "bacnet": "BACnet",
+    "knx": "KNX",
+    "matter": "Matter",
+    "lwm2m": "LwM2M",
+    "http": "HTTP",
+    "ocpp": "OCPP",
+    "ble": "BLE",
+    "scpi": "SCPI",
+}
+PACKAGE_PROTOCOL_HIGHLIGHTS = {
+    "embedded_lab_pack": ("ascii", "scpi", "ble", "modbus"),
+    "industrial_iiot_pack": ("opcua", "modbus", "mqtt"),
+    "smart_building_pack": ("bacnet", "knx", "mqtt"),
+}
+PACKAGE_DISPLAY_SUMMARIES = {
+    "embedded_lab_pack": "Modbus TCP, SCPI, BLE, MQTT/LwM2M for firmware CI and hardware-in-the-loop labs.",
+}
 THIRD_PARTY_SERVICE_NOTICES = {
     "mqtt_broker": "MQTT Broker pulls Eclipse Mosquitto under separate open-source license terms.",
     "lwm2m_server": "LwM2M Server pulls Eclipse Leshan under separate open-source license terms.",
@@ -128,6 +153,9 @@ class InstallerWizard:
             print(ui.warn("\nRuntime & third-party notices:"))
             for notice in runtime_notices:
                 print(f"  - {notice}")
+            self._prompt_continue(
+                "\nPress ENTER to continue after reviewing these notices (or q to quit): "
+            )
 
         self._print_summary(
             packages,
@@ -163,14 +191,27 @@ class InstallerWizard:
     def _print_banner(self) -> None:
         width = max(60, min(get_terminal_size((80, 20)).columns, 120))
         bar = ui.hr("=", width)
+        version = self._resolve_installer_version()
         print(bar)
         print(ui.heading(" SPX Installation Wizard ".center(width)))
+        print(ui.accent(f" Version {version} ".center(width)))
         print(bar)
         print(
             ui.accent(
                 "Select packages or protocols, then customize optional components.\n"
             )
         )
+
+    def _resolve_installer_version(self) -> str:
+        pyproject = paths.repo_root() / "pyproject.toml"
+        if not pyproject.exists():
+            return "dev"
+
+        content = pyproject.read_text(encoding="utf-8")
+        match = re.search(r'^\s*version\s*=\s*"([^"]+)"', content, flags=re.MULTILINE)
+        if not match:
+            return "dev"
+        return match.group(1).strip() or "dev"
 
     def _available_protocols(self, index: ManifestIndex) -> List[str]:
         protocol_set = {
@@ -206,16 +247,14 @@ class InstallerWizard:
         entries.sort(key=lambda ind: ind.name.lower())
         default_protocols = self._resolve_default_protocols(index)
         default_protocol_label = ", ".join(self._format_protocol_label(p) for p in default_protocols)
+        width = max(60, min(get_terminal_size((80, 20)).columns, 120))
 
         print(ui.heading("Available packages:\n"))
         for idx, ind in enumerate(entries, start=1):
-            print(f"  [{ui.accent(str(idx))}] {ui.heading(ind.name)}")
-            print(f"      {ind.description}")
-            if ind.protocols:
-                print(f"      Protocols: {', '.join(ind.protocols)}")
-            if ind.services:
-                print(f"      Services: {', '.join(ind.services)}")
-            print()
+            print(
+                f"  [{ui.accent(str(idx))}] {ui.heading(ind.name)}"
+                f" {self._format_package_overview(ind, width)}"
+            )
 
         if default_protocol_label:
             print(
@@ -271,22 +310,41 @@ class InstallerWizard:
         ]
         if not available_profiles:
             return []
+        width = max(60, min(get_terminal_size((80, 20)).columns, 120))
 
-        print(ui.heading("\nQuickstart profiles matching your packages:\n"))
+        print(ui.heading("\nOptional starter scenarios for your package:\n"))
         for idx, profile_id in enumerate(sorted(available_profiles), start=1):
             profile = index.profiles[profile_id]
-            print(f"  [{ui.accent(str(idx))}] {ui.heading(profile.name)} (pack: {profile.pack_id})")
-            print(f"      {profile.description}")
-            if profile.services:
-                print(f"      Extra services: {', '.join(profile.services)}")
-            print()
+            print(
+                f"  [{ui.accent(str(idx))}] {ui.heading(profile.name)} "
+                f"(pack: {profile.pack_id}) {self._format_profile_overview(profile, width)}"
+            )
 
-        choices = self._prompt_indices(
-            "Select quickstart profiles (comma-separated, ENTER to skip, q to quit): ",
-            len(available_profiles),
-            allow_empty=True,
-        )
-        return [sorted(available_profiles)[i - 1] for i in choices]
+        while True:
+            raw = input(
+                "Select starter scenarios (comma-separated, ENTER to use package defaults only, a for all, q to quit): "
+            ).strip()
+            self._check_quit(raw)
+            if not raw:
+                return []
+            if raw.lower() in {"a", "all"}:
+                return sorted(available_profiles)
+            try:
+                values = [
+                    int(token)
+                    for token in raw.split(",")
+                    if token.strip()
+                ]
+            except ValueError:
+                print(ui.warn("  Invalid input. Please enter numbers separated by commas, or 'a' for all."))
+                continue
+            if not values:
+                print(ui.warn("  Please select at least one entry."))
+                continue
+            if any(v < 1 or v > len(available_profiles) for v in values):
+                print(ui.warn(f"  Values must be between 1 and {len(available_profiles)}."))
+                continue
+            return [sorted(available_profiles)[i - 1] for i in sorted(set(values))]
 
     def _prompt_start_instances(
         self,
@@ -336,6 +394,10 @@ class InstallerWizard:
             if raw in {"n", "no"}:
                 return False
             print(ui.warn("  Please enter 'y' or 'n'."))
+
+    def _prompt_continue(self, prompt: str) -> None:
+        raw = input(prompt).strip()
+        self._check_quit(raw)
 
     def _prompt_protocols(self, index: ManifestIndex) -> List[str]:
         sorted_protocols = self._available_protocols(index)
@@ -464,6 +526,41 @@ class InstallerWizard:
                 print(ui.warn(f"  Values must be between 1 and {max_index}."))
                 continue
             return sorted(set(values))
+
+    def _format_package_overview(self, manifest: IndustryManifest, width: int) -> str:
+        desc = PACKAGE_DISPLAY_SUMMARIES.get(manifest.id, manifest.description or "")
+        desc = " ".join(str(desc).split())
+        badges = ", ".join(self._package_protocol_badges(manifest))
+        counts = f"{badges} | {len(manifest.protocols)} protocols, {len(manifest.services)} services"
+        return self._format_compact_overview(desc, counts, width)
+
+    def _format_profile_overview(self, profile, width: int) -> str:
+        desc = " ".join(str(profile.description or "").split())
+        counts = f"{len(profile.models)} models, {len(profile.services)} extra services"
+        return self._format_compact_overview(desc, counts, width)
+
+    def _format_compact_overview(self, description: str, counts: str, width: int) -> str:
+        suffix = f" [{counts}]"
+        available = max(20, width - len(suffix) - 12)
+        compact_description = shorten(description, width=available, placeholder="...")
+        if not compact_description:
+            return suffix
+        return f"- {compact_description}{suffix}"
+
+    def _package_protocol_badges(self, manifest: IndustryManifest) -> List[str]:
+        preferred = PACKAGE_PROTOCOL_HIGHLIGHTS.get(manifest.id)
+        protocol_ids: List[str]
+        if preferred:
+            protocol_ids = [proto for proto in preferred if self._protocol_present(proto, manifest.protocols)]
+        else:
+            protocol_ids = list(manifest.protocols[:3])
+        return [PROTOCOL_BADGE_LABELS.get(proto, proto.upper()) for proto in protocol_ids]
+
+    def _protocol_present(self, protocol: str, available_protocols: Sequence[str]) -> bool:
+        if protocol in available_protocols:
+            return True
+        alias_target = PROTOCOL_ALIASES.get(protocol)
+        return bool(alias_target and alias_target in available_protocols)
 
     def _build_runtime_notices(
         self,

--- a/spx-install.ps1
+++ b/spx-install.ps1
@@ -4,6 +4,54 @@ Set-StrictMode -Version Latest
 
 $RepoDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
+function Exit-WithMessage {
+    param(
+        [string]$Message,
+        [int]$ExitCode = 1
+    )
+
+    [Console]::Error.WriteLine($Message)
+    exit $ExitCode
+}
+
+function Invoke-NativeCapture {
+    param(
+        [string]$Command,
+        [string[]]$ArgumentList = @()
+    )
+
+    $stdoutPath = [System.IO.Path]::GetTempFileName()
+    $stderrPath = [System.IO.Path]::GetTempFileName()
+
+    try {
+        $process = Start-Process `
+            -FilePath $Command `
+            -ArgumentList $ArgumentList `
+            -NoNewWindow `
+            -Wait `
+            -PassThru `
+            -RedirectStandardOutput $stdoutPath `
+            -RedirectStandardError $stderrPath
+
+        $stdoutText = ""
+        $stderrText = ""
+        if (Test-Path $stdoutPath) {
+            $stdoutText = Get-Content -Path $stdoutPath -Raw -ErrorAction SilentlyContinue
+        }
+        if (Test-Path $stderrPath) {
+            $stderrText = Get-Content -Path $stderrPath -Raw -ErrorAction SilentlyContinue
+        }
+
+        return [PSCustomObject]@{
+            ExitCode = $process.ExitCode
+            StdOut = $stdoutText
+            StdErr = $stderrText
+        }
+    } finally {
+        Remove-Item $stdoutPath, $stderrPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Resolve-Python {
     function Test-PythonCommand {
         param([string]$Command)
@@ -85,13 +133,33 @@ function Check-PythonModules {
 
 function Check-Docker {
     Need-Command "docker"
-    docker info | Out-Null
-    if ($LASTEXITCODE -ne 0) {
-        throw "[spx-install] Docker daemon not reachable. Start Docker Desktop/service and retry."
+    $dockerInfo = Invoke-NativeCapture -Command "docker" -ArgumentList @("info")
+    if ($dockerInfo.ExitCode -ne 0) {
+        $dockerInfoLines = @(
+            (($dockerInfo.StdErr + "`n" + $dockerInfo.StdOut) -split "`r?`n") | ForEach-Object { "$_".Trim() } | Where-Object {
+            $_ -and $_ -notmatch "errors pretty printing info"
+            }
+        )
+        if ($dockerInfoLines.Count -gt 0) {
+            [Console]::Error.WriteLine("[spx-install] Docker detail: $($dockerInfoLines[0])")
+        }
+        $detail = ($dockerInfoLines -join " ")
+        if ($detail -match "manually paused") {
+            throw "[spx-install] Docker Desktop is paused. Open Docker Desktop and unpause it, then retry."
+        }
+        if (
+            $detail -match "failed to connect to the docker api" -or
+            $detail -match "daemon is running" -or
+            $detail -match "dockerdesktoplinuxengine" -or
+            $detail -match "the system cannot find the file specified"
+        ) {
+            throw "[spx-install] Docker Desktop or the Docker daemon is not running. Start Docker Desktop, wait until it is fully started, and retry."
+        }
+        throw "[spx-install] Docker daemon not reachable. Start or unpause Docker Desktop/service and retry."
     }
 
-    & docker compose version | Out-Null
-    if ($LASTEXITCODE -eq 0) {
+    $dockerComposeVersion = Invoke-NativeCapture -Command "docker" -ArgumentList @("compose", "version")
+    if ($dockerComposeVersion.ExitCode -eq 0) {
         return "docker compose"
     }
 
@@ -102,22 +170,30 @@ function Check-Docker {
     throw "[spx-install] Neither 'docker compose' nor 'docker-compose' is available."
 }
 
-Need-Command $PythonBin
-$DockerCompose = Check-Docker
-Check-PythonModules
+try {
+    Need-Command $PythonBin
+    $DockerCompose = Check-Docker
+    Check-PythonModules
 
-Set-Location -Path $RepoDir
+    Set-Location -Path $RepoDir
 
-if ($args.Count -eq 0) {
-    $installerArgs = @("generate", "--output", "build/spx-generated")
-} else {
-    $installerArgs = $args
-}
+    if ($args.Count -eq 0) {
+        $installerArgs = @("generate", "--output", "build/spx-generated")
+    } else {
+        $installerArgs = $args
+    }
 
-$argsDisplay = $installerArgs -join ' '
-Write-Host "[spx-install] Running installer CLI: $PythonBin -m installer $argsDisplay"
+    $argsDisplay = $installerArgs -join ' '
+    Write-Host "[spx-install] Running installer CLI: $PythonBin -m installer $argsDisplay"
 
-& $PythonBin -m installer @installerArgs
-if ($LASTEXITCODE -ne 0) {
-    throw "[spx-install] Installer CLI failed with exit code $LASTEXITCODE"
+    & $PythonBin -m installer @installerArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "[spx-install] Installer CLI failed with exit code $LASTEXITCODE"
+    }
+} catch {
+    $message = $_.Exception.Message
+    if (-not $message) {
+        $message = "[spx-install] Installation failed."
+    }
+    Exit-WithMessage $message 1
 }

--- a/tests/installer/test_wizard.py
+++ b/tests/installer/test_wizard.py
@@ -98,7 +98,7 @@ def test_wizard_with_inputs(
 
     wizard = InstallerWizard(loader=FakeLoader())
 
-    inputs = iter(["1", "", "", "n", "n"])
+    inputs = iter(["1", "", "", "", "n", "n"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     selection = wizard.run()
@@ -110,7 +110,7 @@ def test_wizard_with_inputs(
     assert selection.instances == []
     assert selection.start_instances == []
     assert selection.install_spx_ui is False
-    assert selection.offline_bundle is False
+    assert selection.offline_bundle is True
     assert selection.license_key == "TEST-KEY"
     assert selection.model_ids == ["sensor"]
     assert selection.service_ids == ["mqtt_broker"]
@@ -125,7 +125,7 @@ def test_wizard_can_opt_in_to_default_instances(
 
     wizard = InstallerWizard(loader=FakeLoader())
 
-    inputs = iter(["1", "", "y", "", "n", "n"])
+    inputs = iter(["1", "", "", "y", "", "n", "n"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     selection = wizard.run()
@@ -134,6 +134,29 @@ def test_wizard_can_opt_in_to_default_instances(
     assert selection.install_examples is True
     assert selection.instances == [{"model_id": "sensor", "instance_key": "pack_a_sensor_01"}]
     assert selection.start_instances == ["pack_a_sensor_01"]
+    assert selection.offline_bundle is True
+
+
+def test_wizard_can_select_quickstart_profiles(
+    monkeypatch: pytest.MonkeyPatch, manifest_index: manifest.ManifestIndex
+) -> None:
+    class FakeLoader:
+        def load(self):
+            return manifest_index
+
+    wizard = InstallerWizard(loader=FakeLoader())
+
+    inputs = iter(["1", "1", "", "", "n", "n"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    selection = wizard.run()
+
+    assert selection.packages == ["pack_a"]
+    assert selection.profiles == ["profile_a"]
+    assert selection.install_examples is True
+    assert selection.model_ids == ["sensor"]
+    assert selection.service_ids == ["mqtt_broker"]
+    assert selection.offline_bundle is True
 
 
 def test_wizard_protocol_selection(
@@ -144,7 +167,7 @@ def test_wizard_protocol_selection(
             return manifest_index
 
     wizard = InstallerWizard(loader=FakeLoader())
-    inputs = iter(["0", "1", "", "y", ""])
+    inputs = iter(["0", "1", "", "", ""])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     selection = wizard.run()
@@ -169,7 +192,7 @@ def test_wizard_masks_product_key_in_output(
 
     wizard = InstallerWizard(loader=FakeLoader())
 
-    inputs = iter(["1", "", "", "n", "n"])
+    inputs = iter(["1", "", "", "", "n", "n"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
     monkeypatch.setattr(
         "getpass.getpass",
@@ -194,7 +217,7 @@ def test_wizard_masks_env_product_key_in_output(
 
     wizard = InstallerWizard(loader=FakeLoader())
 
-    inputs = iter(["1", "", "", "n", "n"])
+    inputs = iter(["1", "", "", "", "n", "n"])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     selection = wizard.run()
@@ -204,3 +227,23 @@ def test_wizard_masks_env_product_key_in_output(
     assert "Detected SPX_PRODUCT_KEY in environment:" in captured.out
     assert "TEST-KEY" not in captured.out
     assert "****-KEY" in captured.out
+
+
+def test_wizard_prints_runtime_notices(
+    monkeypatch: pytest.MonkeyPatch, manifest_index: manifest.ManifestIndex, capsys
+) -> None:
+    class FakeLoader:
+        def load(self):
+            return manifest_index
+
+    wizard = InstallerWizard(loader=FakeLoader())
+    inputs = iter(["1", "", "", "", "n", "n"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    monkeypatch.setattr("installer.wizard.current_platform_name", lambda: "windows")
+
+    wizard.run()
+    captured = capsys.readouterr()
+
+    assert "Runtime & third-party notices:" in captured.out
+    assert "Docker Desktop is required on this platform" in captured.out
+    assert "Eclipse Mosquitto" in captured.out

--- a/tests/installer/test_wizard.py
+++ b/tests/installer/test_wizard.py
@@ -98,7 +98,7 @@ def test_wizard_with_inputs(
 
     wizard = InstallerWizard(loader=FakeLoader())
 
-    inputs = iter(["1", "", "", "", "n", "n"])
+    inputs = iter(["1", "", "", "", "n", "n", ""])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     selection = wizard.run()
@@ -125,7 +125,7 @@ def test_wizard_can_opt_in_to_default_instances(
 
     wizard = InstallerWizard(loader=FakeLoader())
 
-    inputs = iter(["1", "", "", "y", "", "n", "n"])
+    inputs = iter(["1", "", "", "y", "", "n", "n", ""])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     selection = wizard.run()
@@ -146,7 +146,7 @@ def test_wizard_can_select_quickstart_profiles(
 
     wizard = InstallerWizard(loader=FakeLoader())
 
-    inputs = iter(["1", "1", "", "", "n", "n"])
+    inputs = iter(["1", "1", "", "", "n", "n", ""])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     selection = wizard.run()
@@ -159,6 +159,24 @@ def test_wizard_can_select_quickstart_profiles(
     assert selection.offline_bundle is True
 
 
+def test_wizard_can_select_all_quickstart_profiles(
+    monkeypatch: pytest.MonkeyPatch, manifest_index: manifest.ManifestIndex
+) -> None:
+    class FakeLoader:
+        def load(self):
+            return manifest_index
+
+    wizard = InstallerWizard(loader=FakeLoader())
+
+    inputs = iter(["1", "a", "", "", "n", "n", ""])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    selection = wizard.run()
+
+    assert selection.packages == ["pack_a"]
+    assert selection.profiles == ["profile_a"]
+
+
 def test_wizard_protocol_selection(
     monkeypatch: pytest.MonkeyPatch, manifest_index: manifest.ManifestIndex, capsys
 ) -> None:
@@ -167,7 +185,7 @@ def test_wizard_protocol_selection(
             return manifest_index
 
     wizard = InstallerWizard(loader=FakeLoader())
-    inputs = iter(["0", "1", "", "", ""])
+    inputs = iter(["0", "1", "", "", "", ""])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     selection = wizard.run()
@@ -192,7 +210,7 @@ def test_wizard_masks_product_key_in_output(
 
     wizard = InstallerWizard(loader=FakeLoader())
 
-    inputs = iter(["1", "", "", "", "n", "n"])
+    inputs = iter(["1", "", "", "", "n", "n", ""])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
     monkeypatch.setattr(
         "getpass.getpass",
@@ -217,7 +235,7 @@ def test_wizard_masks_env_product_key_in_output(
 
     wizard = InstallerWizard(loader=FakeLoader())
 
-    inputs = iter(["1", "", "", "", "n", "n"])
+    inputs = iter(["1", "", "", "", "n", "n", ""])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     selection = wizard.run()
@@ -237,7 +255,7 @@ def test_wizard_prints_runtime_notices(
             return manifest_index
 
     wizard = InstallerWizard(loader=FakeLoader())
-    inputs = iter(["1", "", "", "", "n", "n"])
+    inputs = iter(["1", "", "", "", "n", "n", ""])
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
     monkeypatch.setattr("installer.wizard.current_platform_name", lambda: "windows")
 
@@ -247,3 +265,79 @@ def test_wizard_prints_runtime_notices(
     assert "Runtime & third-party notices:" in captured.out
     assert "Docker Desktop is required on this platform" in captured.out
     assert "Eclipse Mosquitto" in captured.out
+
+
+def test_wizard_banner_includes_installer_version(
+    monkeypatch: pytest.MonkeyPatch, manifest_index: manifest.ManifestIndex, capsys
+) -> None:
+    class FakeLoader:
+        def load(self):
+            return manifest_index
+
+    wizard = InstallerWizard(loader=FakeLoader())
+    inputs = iter(["1", "", "", "", "n", "n", ""])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    monkeypatch.setattr(wizard, "_resolve_installer_version", lambda: "9.9.9-test")
+
+    wizard.run()
+    captured = capsys.readouterr()
+
+    assert "SPX Installation Wizard" in captured.out
+    assert "Version 9.9.9-test" in captured.out
+
+
+def test_prompt_packages_uses_compact_overview(
+    monkeypatch: pytest.MonkeyPatch, manifest_index: manifest.ManifestIndex, capsys
+) -> None:
+    class FakeLoader:
+        def load(self):
+            return manifest_index
+
+    wizard = InstallerWizard(loader=FakeLoader())
+    monkeypatch.setattr("builtins.input", lambda _: "1")
+
+    packages, protocols = wizard._prompt_packages(manifest_index.industries, manifest_index)
+    captured = capsys.readouterr()
+
+    assert packages == ["pack_a"]
+    assert protocols == []
+    assert "Pack description" in captured.out
+    assert "[MQTT | 1 protocols, 1 services]" in captured.out
+    assert "Protocols:" not in captured.out
+    assert "Services:" not in captured.out
+
+
+def test_package_protocol_badges_use_embedded_lab_highlights(
+    manifest_index: manifest.ManifestIndex,
+) -> None:
+    wizard = InstallerWizard()
+    manifest_value = manifest.IndustryManifest(
+        id="embedded_lab_pack",
+        name="Embedded & Lab Pack",
+        description="BLE, MQTT/LwM2M and SCPI devices for firmware CI and hardware-in-the-loop labs.",
+        protocols=["ble", "mqtt", "lwm2m", "coap", "scpi", "modbus"],
+        services=["btvirt_adapter", "mqtt_broker", "lwm2m_server", "scpi_tcp_stack", "modbus_tcp_gateway"],
+        profiles=["mhealth_ci"],
+        path="library/industries/embedded_lab_pack",
+    )
+
+    badges = wizard._package_protocol_badges(manifest_value)
+
+    assert badges == ["ASCII", "SCPI", "BLE", "Modbus"]
+
+
+def test_package_overview_uses_embedded_lab_display_summary() -> None:
+    wizard = InstallerWizard()
+    manifest_value = manifest.IndustryManifest(
+        id="embedded_lab_pack",
+        name="Embedded & Lab Pack",
+        description="BLE, MQTT/LwM2M and SCPI devices for firmware CI and hardware-in-the-loop labs.",
+        protocols=["ble", "mqtt", "lwm2m", "coap", "scpi", "modbus"],
+        services=["btvirt_adapter", "mqtt_broker", "lwm2m_server", "scpi_tcp_stack", "modbus_tcp_gateway"],
+        profiles=["mhealth_ci"],
+        path="library/industries/embedded_lab_pack",
+    )
+
+    overview = wizard._format_package_overview(manifest_value, 120)
+
+    assert "Modbus TCP, SCPI, BLE, MQTT/LwM2M" in overview


### PR DESCRIPTION
## Summary
- improve the shared SPX Setup wizard header and compact the package/profile selection screens
- clarify optional starter scenarios, runtime/third-party notices, and the review stop before summary
- make Windows PowerShell installer errors around Docker Desktop clearer and remove raw script trace output

## Testing
- poetry run pytest tests/installer/test_wizard.py -q
- poetry run pytest tests/installer/test_cli_generate.py -q
- PowerShell parser validation for spx-install.ps1
