### PR TITLE
fix(installer): harden Linux installer flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Industry packs group models, services, and quickstart profiles around a specific
 - `docker compose up` fails to bind port `502` on Linux/rootless Docker — remap the host port in `docker-compose.yml` (e.g. `1502:502`) or run Docker with privileges to bind privileged ports.
 - Modbus slave + HTTP endpoint models use per-model ports defined in their YAML (e.g. `communication.modbus_slave.port`, `communication.http_endpoint.port`) — if you run with plain `docker-compose.yml`, expose those ports manually or use the installer (it auto-exposes Modbus `5020-5120` when Modbus is enabled).
 - Integration tests skip or return 404s — confirm `SPX_PRODUCT_KEY` (available after logging in to [simplephysx.com](https://simplephysx.com) and selecting a subscription type) and `SPX_BASE_URL` if you are not using `http://localhost:8000`.
+- On Ubuntu/Debian, if the installer reports that pip cannot be bootstrapped inside the runtime venv, install the distro Python support packages and retry: `python3-venv` and, if needed, `python3-pip`.
 
 ## Installer workflow (recommended)
 

--- a/installer/runtime_bootstrap.py
+++ b/installer/runtime_bootstrap.py
@@ -160,11 +160,10 @@ def ensure_runtime(venv_dir: Path, packages: list[str]) -> Path:
         )
         run_command([sys.executable, "-m", "venv", str(venv_dir)])
         python_bin = venv_python_path(venv_dir)
-
-    ensure_pip_available(python_bin)
     current_state = read_stamp(stamp_path)
     if current_state != desired_state:
         if packages:
+            ensure_pip_available(python_bin)
             print(
                 f"[runtime] Installing Python packages into {venv_dir}",
                 file=sys.stderr,

--- a/installer/runtime_bootstrap.py
+++ b/installer/runtime_bootstrap.py
@@ -54,6 +54,48 @@ def run_command(argv: list[str]) -> None:
     subprocess.run(argv, check=True, stdout=sys.stderr, stderr=sys.stderr)
 
 
+def has_module(python_bin: Path, module_name: str) -> bool:
+    try:
+        subprocess.run(
+            [
+                str(python_bin),
+                "-c",
+                (
+                    "import importlib.util, sys; "
+                    f"sys.exit(0 if importlib.util.find_spec({module_name!r}) else 1)"
+                ),
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+    return True
+
+
+def ensure_pip_available(python_bin: Path) -> None:
+    if has_module(python_bin, "pip"):
+        return
+
+    print(
+        f"[runtime] Bootstrapping pip in {python_bin.parent.parent}",
+        file=sys.stderr,
+    )
+    try:
+        run_command([str(python_bin), "-m", "ensurepip", "--upgrade"])
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "Python virtual environment does not include pip and ensurepip failed. "
+            "Install the distro Python venv/pip support packages and retry."
+        ) from exc
+
+    if not has_module(python_bin, "pip"):
+        raise RuntimeError(
+            "Python virtual environment was created, but pip is still unavailable after ensurepip."
+        )
+
+
 def is_healthy_virtualenv(venv_dir: Path) -> bool:
     python_bin = venv_python_path(venv_dir)
     if not python_bin.exists():
@@ -119,6 +161,7 @@ def ensure_runtime(venv_dir: Path, packages: list[str]) -> Path:
         run_command([sys.executable, "-m", "venv", str(venv_dir)])
         python_bin = venv_python_path(venv_dir)
 
+    ensure_pip_available(python_bin)
     current_state = read_stamp(stamp_path)
     if current_state != desired_state:
         if packages:

--- a/installer/wizard.py
+++ b/installer/wizard.py
@@ -103,8 +103,8 @@ class InstallerWizard:
                     start_instances = self._prompt_start_instances(packages, index)
         install_spx_ui = self._prompt_yes_no("Include SPX UI frontend container? [Y/n]: ", default=True)
         start_now = self._prompt_yes_no(
-            "Start the stack immediately after generation? [y/N]: ",
-            default=False,
+            "Start the stack immediately after generation? [Y/n]: ",
+            default=True,
         )
         offline_bundle = not start_now
         license_key = self._prompt_license_key()

--- a/scripts/build_installer_package.sh
+++ b/scripts/build_installer_package.sh
@@ -90,6 +90,30 @@ for entry in "${copy_entries[@]}"; do
   rsync "${rsync_opts[@]}" "${src}" "${PACKAGE_DIR}/"
 done
 
+normalize_text_line_endings() {
+  local package_dir="$1"
+  python3 - "$package_dir" <<'PY'
+from __future__ import annotations
+
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+extensions = {".sh", ".desktop", ".command", ".ps1", ".md", ".toml", ".yaml", ".yml", ".py"}
+for path in root.rglob("*"):
+    if not path.is_file():
+        continue
+    if path.suffix.lower() not in extensions:
+        continue
+    text = path.read_text(encoding="utf-8", errors="surrogatepass")
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    if normalized != text:
+        path.write_text(normalized, encoding="utf-8", newline="\n")
+PY
+}
+
+normalize_text_line_endings "${PACKAGE_DIR}"
+
 cat > "${PACKAGE_DIR}/INSTALLER_README.md" <<'EOF'
 # SPX Installer Package
 

--- a/scripts/build_installer_package.sh
+++ b/scripts/build_installer_package.sh
@@ -102,6 +102,7 @@ without cloning the full spx-examples repository.
 - Python 3.9+ with `pip`
 - Docker Desktop / Docker Engine with Compose V2
 - Python 3.10+ if you want to bootstrap the local Codex MCP workspace
+- On Ubuntu/Debian, if the runtime venv cannot bootstrap pip, install `python3-venv` and, if needed, `python3-pip`
 
 ## Usage
 

--- a/spx-install.sh
+++ b/spx-install.sh
@@ -88,6 +88,14 @@ bootstrap_python_runtime() {
     --package colorama
 }
 
+print_python_runtime_hint() {
+  case "$(uname -s)" in
+    Linux)
+      echo "[spx-install] On Ubuntu/Debian, install 'python3-venv' and, if needed, 'python3-pip', then retry." >&2
+      ;;
+  esac
+}
+
 check_docker() {
   need_cmd docker
   if ! docker info >/dev/null 2>&1; then
@@ -107,7 +115,18 @@ check_docker() {
 SYSTEM_PYTHON_BIN="$(resolve_system_python)"
 need_cmd "$SYSTEM_PYTHON_BIN"
 check_docker
-PYTHON_BIN="$(bootstrap_python_runtime "$SYSTEM_PYTHON_BIN" "$(resolve_runtime_root)")"
+BOOTSTRAP_LOG="$(mktemp)"
+trap 'rm -f "$BOOTSTRAP_LOG"' EXIT
+if PYTHON_BIN="$(
+  bootstrap_python_runtime "$SYSTEM_PYTHON_BIN" "$(resolve_runtime_root)" \
+    2>"$BOOTSTRAP_LOG"
+)"; then
+  :
+else
+  cat "$BOOTSTRAP_LOG" >&2
+  print_python_runtime_hint
+  exit 1
+fi
 if [ ! -x "${PYTHON_BIN}" ]; then
   echo "[spx-install] Python runtime bootstrap did not return an executable interpreter." >&2
   exit 1

--- a/tests/installer/test_runtime_bootstrap.py
+++ b/tests/installer/test_runtime_bootstrap.py
@@ -19,8 +19,9 @@ def test_is_healthy_virtualenv_rejects_missing_pyvenv_cfg(tmp_path: Path) -> Non
 
 def test_ensure_runtime_recreates_broken_virtualenv(tmp_path: Path, monkeypatch) -> None:
     venv_dir = tmp_path / ".venv"
-    (venv_dir / "bin").mkdir(parents=True)
-    (venv_dir / "bin" / "python").write_text("", encoding="utf-8")
+    python_path = runtime_bootstrap.venv_python_path(venv_dir)
+    python_path.parent.mkdir(parents=True)
+    python_path.write_text("", encoding="utf-8")
     stale_path = venv_dir / "stale.txt"
     stale_path.write_text("stale", encoding="utf-8")
 
@@ -29,8 +30,8 @@ def test_ensure_runtime_recreates_broken_virtualenv(tmp_path: Path, monkeypatch)
     def fake_run_command(argv: list[str]) -> None:
         calls.append(argv)
         assert argv == [runtime_bootstrap.sys.executable, "-m", "venv", str(venv_dir)]
-        (venv_dir / "bin").mkdir(parents=True, exist_ok=True)
-        (venv_dir / "bin" / "python").write_text("#!/usr/bin/env python\n", encoding="utf-8")
+        python_path.parent.mkdir(parents=True, exist_ok=True)
+        python_path.write_text("#!/usr/bin/env python\n", encoding="utf-8")
         (venv_dir / "pyvenv.cfg").write_text("home = /tmp/python\n", encoding="utf-8")
 
     monkeypatch.setattr(runtime_bootstrap, "run_command", fake_run_command)
@@ -43,7 +44,7 @@ def test_ensure_runtime_recreates_broken_virtualenv(tmp_path: Path, monkeypatch)
     python_bin = runtime_bootstrap.ensure_runtime(venv_dir, [])
 
     assert calls == [[runtime_bootstrap.sys.executable, "-m", "venv", str(venv_dir)]]
-    assert python_bin == venv_dir / "bin" / "python"
+    assert python_bin == python_path
     assert stale_path.exists() is False
     assert (venv_dir / "pyvenv.cfg").exists() is True
     assert json.loads((venv_dir / ".spx-runtime.json").read_text(encoding="utf-8")) == {
@@ -57,8 +58,9 @@ def test_ensure_runtime_reuses_healthy_virtualenv_without_recreate(
     monkeypatch,
 ) -> None:
     venv_dir = tmp_path / ".venv"
-    (venv_dir / "bin").mkdir(parents=True)
-    (venv_dir / "bin" / "python").write_text("#!/usr/bin/env python\n", encoding="utf-8")
+    python_path = runtime_bootstrap.venv_python_path(venv_dir)
+    python_path.parent.mkdir(parents=True)
+    python_path.write_text("#!/usr/bin/env python\n", encoding="utf-8")
     (venv_dir / "pyvenv.cfg").write_text("home = /tmp/python\n", encoding="utf-8")
     (venv_dir / ".spx-runtime.json").write_text(
         json.dumps(
@@ -77,5 +79,5 @@ def test_ensure_runtime_reuses_healthy_virtualenv_without_recreate(
 
     python_bin = runtime_bootstrap.ensure_runtime(venv_dir, [])
 
-    assert python_bin == venv_dir / "bin" / "python"
+    assert python_bin == python_path
     assert calls == []


### PR DESCRIPTION
Summary:\n- Bootstrap pip inside the runtime venv when it is missing, using ensurepip first.\n- Add a Linux fallback hint for Ubuntu/Debian when distro Python support packages are missing.\n- Normalize Unix line endings in the portable tgz bundle so bash shebangs work on Ubuntu.\n- Restore the setup wizard default to start the stack immediately after generation.\n\nValidation:\n- python -m compileall installer/runtime_bootstrap.py\n- Test bootstrap on a venv created with --without-pip\n- Verified generated tgz contains LF line endings in spx-install.sh