### PR TITLE
fix(installer): align installer licensing terms

### DIFF
--- a/THIRD_PARTY_NOTICE.txt
+++ b/THIRD_PARTY_NOTICE.txt
@@ -1,0 +1,20 @@
+SPX Third-Party Notice
+======================
+
+This distribution may include or install third-party software components.
+Those components remain subject to their own license terms and notices.
+
+Current third-party component called by the installer:
+
+1. Python 3.12 Windows offline installer
+   - Supplier: Python Software Foundation
+   - Used by: the Windows Burn bundle as a prerequisite package
+   - License information: https://docs.python.org/3/license.html
+   - Additional notices may be included in the upstream Python distribution.
+
+Repository components distributed under open-source licenses remain subject
+to their applicable license texts, including the MIT license included in the
+repository root LICENSE file.
+
+This notice is provided for convenience and does not replace the full license
+terms that apply to any third-party component.

--- a/packaging/windows/LICENSE.rtf
+++ b/packaging/windows/LICENSE.rtf
@@ -6,7 +6,7 @@ Copyright (c) 2025 HammerHeads Engineers Sp. z o.o. and contributors.\par
 \par
 This installer and the installed SPX package may include both (1) components distributed under open-source licenses and (2) proprietary SPX components, trademarks, hosted services, and subscription-gated features owned or controlled by HammerHeads Engineers Sp. z o.o.\par
 \par
-Open-source components remain subject to their own license terms. Nothing in these installer terms removes or limits any rights already granted to you under those open-source licenses. The applicable notices and license texts are included with the package or installed files, including the MIT license included with this package.\par
+Open-source components remain subject to their own license terms. Nothing in these installer terms removes or limits any rights already granted to you under those open-source licenses. The applicable notices and license texts are included with the package or installed files, including the MIT license and THIRD_PARTY_NOTICE.txt included with this package.\par
 \par
 Proprietary SPX components, branding, hosted services, license keys, and subscription-gated features are provided only under the applicable commercial agreement, subscription terms, or other written authorization issued by HammerHeads Engineers Sp. z o.o.\par
 \par

--- a/packaging/windows/LICENSE.rtf
+++ b/packaging/windows/LICENSE.rtf
@@ -1,16 +1,18 @@
 {\rtf1\ansi\deff0
 {\fonttbl{\f0\fswiss Segoe UI;}}
-\viewkind4\uc1\pard\f0\fs20 SPX Distribution Terms\par
+\viewkind4\uc1\pard\f0\fs20 SPX Installer Terms\par
 \par
-Copyright (c) 2025 HammerHeads Engineers Sp. z o.o. All rights reserved.\par
+Copyright (c) 2025 HammerHeads Engineers Sp. z o.o. and contributors.\par
 \par
-SPX and the accompanying installer payload are proprietary software of HammerHeads Engineers Sp. z o.o. This installer does not grant any ownership rights in the software.\par
+This installer and the installed SPX package may include both (1) components distributed under open-source licenses and (2) proprietary SPX components, trademarks, hosted services, and subscription-gated features owned or controlled by HammerHeads Engineers Sp. z o.o.\par
 \par
-Use of the software is permitted only under a valid subscription, license key, or other written authorization issued by HammerHeads Engineers Sp. z o.o.\par
+Open-source components remain subject to their own license terms. Nothing in these installer terms removes or limits any rights already granted to you under those open-source licenses. The applicable notices and license texts are included with the package or installed files, including the MIT license included with this package.\par
 \par
-The scope of permitted use, enabled features, deployment rights, support terms, and any user or company limits depends on the subscription or commercial agreement associated with the license key used with the software.\par
+Proprietary SPX components, branding, hosted services, license keys, and subscription-gated features are provided only under the applicable commercial agreement, subscription terms, or other written authorization issued by HammerHeads Engineers Sp. z o.o.\par
 \par
-Except as expressly permitted by the applicable subscription, commercial agreement, or other written authorization from HammerHeads Engineers Sp. z o.o., you may not use, distribute, sublicense, or make the software available to third parties.\par
+Unless expressly permitted by an applicable open-source license or by a separate commercial agreement with HammerHeads Engineers Sp. z o.o., you may not redistribute proprietary SPX components, trademarks, hosted service credentials, or subscription entitlements.\par
 \par
-By continuing with this installation, you acknowledge that use of the software is governed by the applicable subscription, commercial agreement, and license key terms provided by HammerHeads Engineers Sp. z o.o.\par
+By continuing with this installation, you confirm that you have the right to install this software and that you will comply with the applicable open-source license notices and any commercial terms governing proprietary SPX features or services.\par
+\par
+To the maximum extent permitted by law, the software is provided "as is" unless a separate commercial agreement states otherwise.\par
 }

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -67,7 +67,7 @@ powershell -ExecutionPolicy Bypass -File .\packaging\windows\Build.ps1 `
 ```
 
 Artifacts are written under `build/windows/artifacts/`. The user-facing bundle file is emitted as `spx-installer-<version>.exe`, while its display name in the installer UI and Windows Apps is `SPX Tools`. The installed environment wizard remains `SPX Setup`, so its name is no longer overloaded with the bootstrap bundle.
-The Burn license dialog is sourced from `packaging/windows/LICENSE.rtf` and is intentionally installer-specific; it does not change the repository-wide `MIT` license files.
+The Burn license dialog is sourced from `packaging/windows/LICENSE.rtf` and is intentionally installer-specific; it does not change the repository-wide `MIT` license files. Third-party distribution notes for installer-bundled dependencies are shipped in `THIRD_PARTY_NOTICE.txt`.
 
 If you are upgrading from an older preview that installed into `Program Files\SPX`, uninstall that preview first before testing the per-user layout. The current bundle now blocks installation when it detects that legacy machine-wide preview, because Windows otherwise merges the old all-users Start Menu folder with the new per-user one and shows duplicate `SPX` shortcuts.
 

--- a/scripts/build_installer_package.sh
+++ b/scripts/build_installer_package.sh
@@ -58,6 +58,7 @@ copy_entries=(
   "tools"
   "docs"
   "AGENTS.md"
+  "LICENSE"
   "spx-setup.command"
   "spx-setup.desktop"
   "spx-setup.sh"
@@ -127,6 +128,11 @@ without cloning the full spx-examples repository.
 - Docker Desktop / Docker Engine with Compose V2
 - Python 3.10+ if you want to bootstrap the local Codex MCP workspace
 - On Ubuntu/Debian, if the runtime venv cannot bootstrap pip, install `python3-venv` and, if needed, `python3-pip`
+
+## Licensing
+
+- Open-source license notices bundled with this package apply to the corresponding components, including the included `LICENSE` file.
+- Proprietary SPX features, branding, hosted services, and subscription-gated functionality may require separate commercial terms or authorization.
 
 ## Usage
 

--- a/scripts/build_installer_package.sh
+++ b/scripts/build_installer_package.sh
@@ -59,6 +59,7 @@ copy_entries=(
   "docs"
   "AGENTS.md"
   "LICENSE"
+  "THIRD_PARTY_NOTICE.txt"
   "spx-setup.command"
   "spx-setup.desktop"
   "spx-setup.sh"
@@ -132,6 +133,7 @@ without cloning the full spx-examples repository.
 ## Licensing
 
 - Open-source license notices bundled with this package apply to the corresponding components, including the included `LICENSE` file.
+- Third-party distribution notes for installer-bundled dependencies are included in `THIRD_PARTY_NOTICE.txt`.
 - Proprietary SPX features, branding, hosted services, and subscription-gated functionality may require separate commercial terms or authorization.
 
 ## Usage

--- a/tools/stage_windows_payload.py
+++ b/tools/stage_windows_payload.py
@@ -22,6 +22,7 @@ DEFAULT_PAYLOAD_ENTRIES = (
     "docs",
     "AGENTS.md",
     "LICENSE",
+    "THIRD_PARTY_NOTICE.txt",
     "spx-setup.command",
     "spx-setup.desktop",
     "spx-setup.sh",


### PR DESCRIPTION
## Summary
- align the Windows installer acceptance text with the repository MIT license and the commercial service model
- ship the repository LICENSE and THIRD_PARTY_NOTICE.txt in portable/macOS and Windows installer payloads
- document the third-party notice file in the Windows installer README and generated installer README

## Validation
- static inspection of payload entry lists and installer texts
- verified notice file references in packaging scripts and Windows docs

## Notes
- this change adds a dedicated THIRD_PARTY_NOTICE.txt covering the Windows-bundled Python prerequisite