### PR TITLE
chore(license): add SPDX headers to source files

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: CI
 
 on:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 {
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 {
     "python.testing.unittestArgs": [
         "-v",

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/examples/ascii_scpi/__init__.py
+++ b/examples/ascii_scpi/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/examples/ascii_scpi/models/scpi_dmm.yaml
+++ b/examples/ascii_scpi/models/scpi_dmm.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: scpi_dmm
 description: |
   Example SCPI digital multimeter model for ASCII/TCP demos.

--- a/examples/ascii_scpi/models/scpi_psu.yaml
+++ b/examples/ascii_scpi/models/scpi_psu.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: scpi_psu
 description: |
   Example SCPI bench power supply model for ASCII/TCP demos.

--- a/examples/ascii_scpi/scripts/__init__.py
+++ b/examples/ascii_scpi/scripts/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/examples/ascii_scpi/scripts/dmm_read_voltage.py
+++ b/examples/ascii_scpi/scripts/dmm_read_voltage.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Read DMM voltage via SCPI using the SPX-hosted model."""
 
 from __future__ import annotations

--- a/examples/ascii_scpi/scripts/psu_set_voltage.py
+++ b/examples/ascii_scpi/scripts/psu_set_voltage.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Set PSU voltage/current via SCPI using the SPX-hosted model."""
 
 from __future__ import annotations

--- a/examples/ascii_scpi/scripts/psu_toggle_output.py
+++ b/examples/ascii_scpi/scripts/psu_toggle_output.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Toggle PSU output on/off via SCPI using the SPX-hosted model."""
 
 from __future__ import annotations

--- a/examples/ascii_scpi/sim/__init__.py
+++ b/examples/ascii_scpi/sim/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/examples/ascii_scpi/sim/common.py
+++ b/examples/ascii_scpi/sim/common.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Shared ASCII/SCPI simulator helpers."""
 
 from __future__ import annotations

--- a/examples/ascii_scpi/sim/dmm_sim.py
+++ b/examples/ascii_scpi/sim/dmm_sim.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Simple SCPI digital multimeter simulator."""
 
 from __future__ import annotations

--- a/examples/ascii_scpi/sim/psu_sim.py
+++ b/examples/ascii_scpi/sim/psu_sim.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Simple SCPI bench power supply simulator."""
 
 from __future__ import annotations

--- a/examples/ascii_scpi/spx/__init__.py
+++ b/examples/ascii_scpi/spx/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/examples/ascii_scpi/spx/config.yaml
+++ b/examples/ascii_scpi/spx/config.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 mode: tcp
 host: 127.0.0.1
 port: 5025

--- a/examples/ascii_scpi/spx/spx_utils.py
+++ b/examples/ascii_scpi/spx/spx_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """SPX client helpers for ASCII/SCPI examples."""
 
 from __future__ import annotations

--- a/examples/ascii_scpi/spx/transport.py
+++ b/examples/ascii_scpi/spx/transport.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Thin ASCII/SCPI transport used by the example scripts."""
 
 from __future__ import annotations

--- a/examples/core/modbus_example.ipynb
+++ b/examples/core/modbus_example.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "spdx-license-header",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SPDX-License-Identifier: MIT\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "65c2ac6c",
    "metadata": {},

--- a/examples/packs/embedded_lab_pack/load_ble_temperature_sensor.py
+++ b/examples/packs/embedded_lab_pack/load_ble_temperature_sensor.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Load BLE models from YAML and spin up an instance for quick inspection."""
 
 import argparse

--- a/examples/packs/industrial_iiot_pack/industrial_pack_eurotherm_setpoints.ipynb
+++ b/examples/packs/industrial_iiot_pack/industrial_pack_eurotherm_setpoints.ipynb
@@ -1,147 +1,157 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Industrial Pack - Eurotherm Setpoints\n",
-        "\n",
-        "This notebook shows how to:\n",
-        "1. Connect to SPX with `spx-python`\n",
-        "2. Ensure Eurotherm instances are running\n",
-        "3. Update temperature and pressure setpoints\n",
-        "\n",
-        "Prerequisites:\n",
-        "- SPX server running at `http://localhost:8000`\n",
-        "- Industrial Pack installed (profile `process_cell_quickstart`)\n",
-        "- `SPX_PRODUCT_KEY` set in your environment\n",
-        "- Instance keys: `spx_eurotherm_3216_temp`, `spx_eurotherm_3504_pressure`\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Connected to http://localhost:8000\n"
-          ]
-        }
-      ],
-      "source": [
-        "import os\n",
-        "import spx_python\n",
-        "\n",
-        "SPX_BASE_URL = os.environ.get(\"SPX_BASE_URL\", \"http://localhost:8000\")\n",
-        "PRODUCT_KEY = os.environ.get(\"SPX_PRODUCT_KEY\")\n",
-        "EURO_3216_INSTANCE = \"spx_eurotherm_3216_temp\"\n",
-        "EURO_3504_INSTANCE = \"spx_eurotherm_3504_pressure\"\n",
-        "\n",
-        "if not PRODUCT_KEY:\n",
-        "    raise ValueError(\"SPX_PRODUCT_KEY is required.\")\n",
-        "\n",
-        "client = spx_python.init(address=SPX_BASE_URL, product_key=PRODUCT_KEY)\n",
-        "print(f\"Connected to {SPX_BASE_URL}\")\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "spx_eurotherm_3216_temp: RUNNING\n",
-            "spx_eurotherm_3504_pressure: RUNNING\n"
-          ]
-        }
-      ],
-      "source": [
-        "def ensure_running(instance_key: str):\n",
-        "    try:\n",
-        "        instance = client[\"instances\"][instance_key]\n",
-        "    except Exception as exc:\n",
-        "        raise RuntimeError(\n",
-        "            f\"Instance {instance_key!r} not found. Start the Industrial Pack first.\"\n",
-        "        ) from exc\n",
-        "\n",
-        "    state = instance.state\n",
-        "    print(f\"{instance_key}: {state}\")\n",
-        "    if (state or \"\").lower() != \"running\":\n",
-        "        instance.start()\n",
-        "        print(f\"{instance_key}: started\")\n",
-        "    return instance\n",
-        "\n",
-        "euro_3216 = ensure_running(EURO_3216_INSTANCE)\n",
-        "euro_3504 = ensure_running(EURO_3504_INSTANCE)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Before update:\n",
-            "  Eurotherm 3216 k__setpoint_c = 30\n",
-            "  Eurotherm 3504 pressure_sp_bar = 10.0\n",
-            "After update:\n",
-            "  Eurotherm 3216 k__setpoint_c = 60\n",
-            "  Eurotherm 3504 pressure_sp_bar = 10.0\n"
-          ]
-        }
-      ],
-      "source": [
-        "attrs_3216 = euro_3216[\"attributes\"]\n",
-        "attrs_3504 = euro_3504[\"attributes\"]\n",
-        "\n",
-        "temp_sp = attrs_3216[\"k__setpoint_c\"]\n",
-        "pressure_sp = attrs_3504[\"pressure_sp_bar\"]\n",
-        "\n",
-        "# Ensure auto mode (0 = auto, 1 = manual)\n",
-        "attrs_3216[\"k__auto_man\"].internal_value = 0\n",
-        "attrs_3504[\"auto_man_raw\"].internal_value = 0\n",
-        "\n",
-        "print(\"Before update:\")\n",
-        "print(\"  Eurotherm 3216 k__setpoint_c =\", temp_sp.external_value)\n",
-        "print(\"  Eurotherm 3504 pressure_sp_bar =\", pressure_sp.external_value)\n",
-        "\n",
-        "temp_sp.internal_value = 60.0\n",
-        "pressure_sp.internal_value = 2.5\n",
-        "\n",
-        "print(\"After update:\")\n",
-        "print(\"  Eurotherm 3216 k__setpoint_c =\", temp_sp.external_value)\n",
-        "print(\"  Eurotherm 3504 pressure_sp_bar =\", pressure_sp.external_value)\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "spx-examples-py3.10 (3.10.6)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.10.6"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "spdx-license-header",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SPDX-License-Identifier: MIT\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Industrial Pack - Eurotherm Setpoints\n",
+    "\n",
+    "This notebook shows how to:\n",
+    "1. Connect to SPX with `spx-python`\n",
+    "2. Ensure Eurotherm instances are running\n",
+    "3. Update temperature and pressure setpoints\n",
+    "\n",
+    "Prerequisites:\n",
+    "- SPX server running at `http://localhost:8000`\n",
+    "- Industrial Pack installed (profile `process_cell_quickstart`)\n",
+    "- `SPX_PRODUCT_KEY` set in your environment\n",
+    "- Instance keys: `spx_eurotherm_3216_temp`, `spx_eurotherm_3504_pressure`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to http://localhost:8000\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import spx_python\n",
+    "\n",
+    "SPX_BASE_URL = os.environ.get(\"SPX_BASE_URL\", \"http://localhost:8000\")\n",
+    "PRODUCT_KEY = os.environ.get(\"SPX_PRODUCT_KEY\")\n",
+    "EURO_3216_INSTANCE = \"spx_eurotherm_3216_temp\"\n",
+    "EURO_3504_INSTANCE = \"spx_eurotherm_3504_pressure\"\n",
+    "\n",
+    "if not PRODUCT_KEY:\n",
+    "    raise ValueError(\"SPX_PRODUCT_KEY is required.\")\n",
+    "\n",
+    "client = spx_python.init(address=SPX_BASE_URL, product_key=PRODUCT_KEY)\n",
+    "print(f\"Connected to {SPX_BASE_URL}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "spx_eurotherm_3216_temp: RUNNING\n",
+      "spx_eurotherm_3504_pressure: RUNNING\n"
+     ]
+    }
+   ],
+   "source": [
+    "def ensure_running(instance_key: str):\n",
+    "    try:\n",
+    "        instance = client[\"instances\"][instance_key]\n",
+    "    except Exception as exc:\n",
+    "        raise RuntimeError(\n",
+    "            f\"Instance {instance_key!r} not found. Start the Industrial Pack first.\"\n",
+    "        ) from exc\n",
+    "\n",
+    "    state = instance.state\n",
+    "    print(f\"{instance_key}: {state}\")\n",
+    "    if (state or \"\").lower() != \"running\":\n",
+    "        instance.start()\n",
+    "        print(f\"{instance_key}: started\")\n",
+    "    return instance\n",
+    "\n",
+    "euro_3216 = ensure_running(EURO_3216_INSTANCE)\n",
+    "euro_3504 = ensure_running(EURO_3504_INSTANCE)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Before update:\n",
+      "  Eurotherm 3216 k__setpoint_c = 30\n",
+      "  Eurotherm 3504 pressure_sp_bar = 10.0\n",
+      "After update:\n",
+      "  Eurotherm 3216 k__setpoint_c = 60\n",
+      "  Eurotherm 3504 pressure_sp_bar = 10.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "attrs_3216 = euro_3216[\"attributes\"]\n",
+    "attrs_3504 = euro_3504[\"attributes\"]\n",
+    "\n",
+    "temp_sp = attrs_3216[\"k__setpoint_c\"]\n",
+    "pressure_sp = attrs_3504[\"pressure_sp_bar\"]\n",
+    "\n",
+    "# Ensure auto mode (0 = auto, 1 = manual)\n",
+    "attrs_3216[\"k__auto_man\"].internal_value = 0\n",
+    "attrs_3504[\"auto_man_raw\"].internal_value = 0\n",
+    "\n",
+    "print(\"Before update:\")\n",
+    "print(\"  Eurotherm 3216 k__setpoint_c =\", temp_sp.external_value)\n",
+    "print(\"  Eurotherm 3504 pressure_sp_bar =\", pressure_sp.external_value)\n",
+    "\n",
+    "temp_sp.internal_value = 60.0\n",
+    "pressure_sp.internal_value = 2.5\n",
+    "\n",
+    "print(\"After update:\")\n",
+    "print(\"  Eurotherm 3216 k__setpoint_c =\", temp_sp.external_value)\n",
+    "print(\"  Eurotherm 3504 pressure_sp_bar =\", pressure_sp.external_value)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "spx-examples-py3.10 (3.10.6)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/examples/packs/smart_building_pack/smart_building_pack_weather_gateway.ipynb
+++ b/examples/packs/smart_building_pack/smart_building_pack_weather_gateway.ipynb
@@ -1,134 +1,144 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Smart Building Pack - Weather Gateway (MQTT)\n",
-        "\n",
-        "This notebook shows how to:\n",
-        "1. Connect to SPX with `spx-python`\n",
-        "2. Check the instance state\n",
-        "3. Update `k__outdoor_temperature_c` and `k__brightness_lux` on the weather gateway instance\n",
-        "\n",
-        "Prerequisites:\n",
-        "- SPX server running at `http://localhost:8000`\n",
-        "- Smart Building Pack installed (profile `bms_quickstart`)\n",
-        "- `SPX_PRODUCT_KEY` set in your environment\n",
-        "- Instance key: `spx_weather_gateway_wago_pfc200_vaisala_wxt530_mqtt`\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Connected to http://localhost:8000\n"
-          ]
-        }
-      ],
-      "source": [
-        "import os\n",
-        "import spx_python\n",
-        "\n",
-        "SPX_BASE_URL = os.environ.get(\"SPX_BASE_URL\", \"http://localhost:8000\")\n",
-        "PRODUCT_KEY = os.environ.get(\"SPX_PRODUCT_KEY\")\n",
-        "INSTANCE_KEY = \"spx_weather_gateway_wago_pfc200_vaisala_wxt530_mqtt\"\n",
-        "\n",
-        "if not PRODUCT_KEY:\n",
-        "    raise ValueError(\"SPX_PRODUCT_KEY is required.\")\n",
-        "\n",
-        "client = spx_python.init(address=SPX_BASE_URL, product_key=PRODUCT_KEY)\n",
-        "print(f\"Connected to {SPX_BASE_URL}\")\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Instance state: RUNNING\n"
-          ]
-        }
-      ],
-      "source": [
-        "try:\n",
-        "    instance = client[\"instances\"][INSTANCE_KEY]\n",
-        "except Exception as exc:\n",
-        "    raise RuntimeError(\n",
-        "        f\"Instance {INSTANCE_KEY!r} not found. Start the Smart Building Pack first.\"\n",
-        "    ) from exc\n",
-        "\n",
-        "state = instance.state\n",
-        "print(f\"Instance state: {state}\")\n",
-        "if (state or \"\").lower() != \"running\":\n",
-        "    instance.start()\n",
-        "    print(\"Instance started.\")\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Before update:\n",
-            "  k__outdoor_temperature_c = 12.5\n",
-            "  k__brightness_lux = 14981.476728825395\n",
-            "After update:\n",
-            "  k__outdoor_temperature_c = 12.5\n",
-            "  k__brightness_lux = 14935.403845306431\n"
-          ]
-        }
-      ],
-      "source": [
-        "attrs = instance[\"attributes\"]\n",
-        "outdoor_temp = attrs[\"k__outdoor_temperature_c\"]\n",
-        "brightness = attrs[\"k__brightness_lux\"]\n",
-        "\n",
-        "print(\"Before update:\")\n",
-        "print(\"  k__outdoor_temperature_c =\", outdoor_temp.external_value)\n",
-        "print(\"  k__brightness_lux =\", brightness.external_value)\n",
-        "\n",
-        "outdoor_temp.internal_value = 12.5\n",
-        "brightness.internal_value = 15000.0\n",
-        "\n",
-        "print(\"After update:\")\n",
-        "print(\"  k__outdoor_temperature_c =\", outdoor_temp.external_value)\n",
-        "print(\"  k__brightness_lux =\", brightness.external_value)"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "spx-examples-py3.10 (3.10.6)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.10.6"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "spdx-license-header",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SPDX-License-Identifier: MIT\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Smart Building Pack - Weather Gateway (MQTT)\n",
+    "\n",
+    "This notebook shows how to:\n",
+    "1. Connect to SPX with `spx-python`\n",
+    "2. Check the instance state\n",
+    "3. Update `k__outdoor_temperature_c` and `k__brightness_lux` on the weather gateway instance\n",
+    "\n",
+    "Prerequisites:\n",
+    "- SPX server running at `http://localhost:8000`\n",
+    "- Smart Building Pack installed (profile `bms_quickstart`)\n",
+    "- `SPX_PRODUCT_KEY` set in your environment\n",
+    "- Instance key: `spx_weather_gateway_wago_pfc200_vaisala_wxt530_mqtt`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to http://localhost:8000\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import spx_python\n",
+    "\n",
+    "SPX_BASE_URL = os.environ.get(\"SPX_BASE_URL\", \"http://localhost:8000\")\n",
+    "PRODUCT_KEY = os.environ.get(\"SPX_PRODUCT_KEY\")\n",
+    "INSTANCE_KEY = \"spx_weather_gateway_wago_pfc200_vaisala_wxt530_mqtt\"\n",
+    "\n",
+    "if not PRODUCT_KEY:\n",
+    "    raise ValueError(\"SPX_PRODUCT_KEY is required.\")\n",
+    "\n",
+    "client = spx_python.init(address=SPX_BASE_URL, product_key=PRODUCT_KEY)\n",
+    "print(f\"Connected to {SPX_BASE_URL}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Instance state: RUNNING\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    instance = client[\"instances\"][INSTANCE_KEY]\n",
+    "except Exception as exc:\n",
+    "    raise RuntimeError(\n",
+    "        f\"Instance {INSTANCE_KEY!r} not found. Start the Smart Building Pack first.\"\n",
+    "    ) from exc\n",
+    "\n",
+    "state = instance.state\n",
+    "print(f\"Instance state: {state}\")\n",
+    "if (state or \"\").lower() != \"running\":\n",
+    "    instance.start()\n",
+    "    print(\"Instance started.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Before update:\n",
+      "  k__outdoor_temperature_c = 12.5\n",
+      "  k__brightness_lux = 14981.476728825395\n",
+      "After update:\n",
+      "  k__outdoor_temperature_c = 12.5\n",
+      "  k__brightness_lux = 14935.403845306431\n"
+     ]
+    }
+   ],
+   "source": [
+    "attrs = instance[\"attributes\"]\n",
+    "outdoor_temp = attrs[\"k__outdoor_temperature_c\"]\n",
+    "brightness = attrs[\"k__brightness_lux\"]\n",
+    "\n",
+    "print(\"Before update:\")\n",
+    "print(\"  k__outdoor_temperature_c =\", outdoor_temp.external_value)\n",
+    "print(\"  k__brightness_lux =\", brightness.external_value)\n",
+    "\n",
+    "outdoor_temp.internal_value = 12.5\n",
+    "brightness.internal_value = 15000.0\n",
+    "\n",
+    "print(\"After update:\")\n",
+    "print(\"  k__outdoor_temperature_c =\", outdoor_temp.external_value)\n",
+    "print(\"  k__brightness_lux =\", brightness.external_value)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "spx-examples-py3.10 (3.10.6)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/extensions/contact_fault.py
+++ b/extensions/contact_fault.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # Minimal implementation of a custom action that simulates intermittent
 # contact faults on a PT100-like sensor. It randomly injects either a
 # drop-to-zero or a spike to a configured value. Typical usage maps this

--- a/extensions/py_temp_sensor.py
+++ b/extensions/py_temp_sensor.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # extensions/py_temp_sensor.py
 import math
 import time

--- a/installer/macos/spx_cleanup_launcher.applescript
+++ b/installer/macos/spx_cleanup_launcher.applescript
@@ -1,3 +1,4 @@
+-- SPDX-License-Identifier: MIT
 property appTitle : "SPX Cleanup"
 property generatedDirRelativePath : "Library/Application Support/SPX/generated"
 property runtimeDirRelativePath : "Library/Application Support/SPX/runtime"

--- a/installer/macos/spx_mcp_setup_launcher.applescript
+++ b/installer/macos/spx_mcp_setup_launcher.applescript
@@ -1,3 +1,4 @@
+-- SPDX-License-Identifier: MIT
 property appTitle : "SPX MCP Setup"
 property setupAppName : "SPX Setup.app"
 property payloadDirName : "spx-installer"

--- a/installer/macos/spx_setup_launcher.applescript
+++ b/installer/macos/spx_setup_launcher.applescript
@@ -1,3 +1,4 @@
+-- SPDX-License-Identifier: MIT
 property appTitle : "SPX Setup"
 property payloadDirName : "spx-installer"
 property launcherName : "spx-setup.command"

--- a/installer/macos/spx_start_launcher.applescript
+++ b/installer/macos/spx_start_launcher.applescript
@@ -1,3 +1,4 @@
+-- SPDX-License-Identifier: MIT
 property appTitle : "SPX Start"
 property generatedLauncherRelativePath : "Library/Application Support/SPX/generated/spx-start.command"
 

--- a/installer/macos/spx_stop_launcher.applescript
+++ b/installer/macos/spx_stop_launcher.applescript
@@ -1,3 +1,4 @@
+-- SPDX-License-Identifier: MIT
 property appTitle : "SPX Stop"
 property generatedLauncherRelativePath : "Library/Application Support/SPX/generated/spx-stop.command"
 

--- a/installer/macos/spx_uninstall_launcher.applescript
+++ b/installer/macos/spx_uninstall_launcher.applescript
@@ -1,3 +1,4 @@
+-- SPDX-License-Identifier: MIT
 property appTitle : "SPX Uninstall"
 property packageId : "com.hammerheadsengineers.spx.installer"
 property supportDirRelativePath : "Library/Application Support/SPX"

--- a/library/assets/homeassistant/config/automations.yaml
+++ b/library/assets/homeassistant/config/automations.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 - id: '1767345066240'
   alias: 'Blinds: night by brightness + temp; sunny shading; otherwise open'
   triggers:

--- a/library/assets/homeassistant/config/blueprints/automation/homeassistant/motion_light.yaml
+++ b/library/assets/homeassistant/config/blueprints/automation/homeassistant/motion_light.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 blueprint:
   name: Motion-activated Light
   description: Turn on a light when motion is detected.

--- a/library/assets/homeassistant/config/blueprints/automation/homeassistant/notify_leaving_zone.yaml
+++ b/library/assets/homeassistant/config/blueprints/automation/homeassistant/notify_leaving_zone.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 blueprint:
   name: Zone Notification
   description: Send a notification to a device when a person leaves a specific zone.

--- a/library/assets/homeassistant/config/blueprints/script/homeassistant/confirmable_notification.yaml
+++ b/library/assets/homeassistant/config/blueprints/script/homeassistant/confirmable_notification.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 blueprint:
   name: Confirmable Notification
   description: >-

--- a/library/assets/homeassistant/config/configuration.yaml
+++ b/library/assets/homeassistant/config/configuration.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 
 # Loads default set of integrations. Do not remove.
 default_config:

--- a/library/assets/homeassistant/config/scenes.yaml
+++ b/library/assets/homeassistant/config/scenes.yaml
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/library/assets/homeassistant/config/scripts.yaml
+++ b/library/assets/homeassistant/config/scripts.yaml
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/library/assets/homeassistant/config/themes/spx_default.yaml
+++ b/library/assets/homeassistant/config/themes/spx_default.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # Minimal theme to ensure Home Assistant loads the themes folder without errors.
 spx_default:
   primary-color: "#03a9f4"

--- a/library/catalog/domains.yaml
+++ b/library/catalog/domains.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 domains:
 - id: building
   name: Building Systems

--- a/library/catalog/industries.yaml
+++ b/library/catalog/industries.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 industries:
   - id: smart_building_pack
     name: Smart-Building Pack (BMS)

--- a/library/catalog/models.yaml
+++ b/library/catalog/models.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 models:
 - id: Env.EnvSensor.Mqtt
   name: MQTT Environment Sensor

--- a/library/catalog/services.yaml
+++ b/library/catalog/services.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 services:
   - id: mqtt_broker
     name: MQTT Broker

--- a/library/domains/lab/digital_multimeter/generic/digital_multimeter__scpi.yaml
+++ b/library/domains/lab/digital_multimeter/generic/digital_multimeter__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: digital_multimeter__scpi
 description: |
   Generic SCPI digital multimeter with DC voltage and resistance measurements,

--- a/library/domains/lab/digital_multimeter/rohde_schwarz/rohde_schwarz_hmc8012__scpi.yaml
+++ b/library/domains/lab/digital_multimeter/rohde_schwarz/rohde_schwarz_hmc8012__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: rohde_schwarz_hmc8012__scpi
 description: |
   Virtual Rohde & Schwarz HMC8012 digital multimeter with a focused SCPI

--- a/library/domains/lab/digital_multimeter/siglent/siglent_sdm3055__scpi.yaml
+++ b/library/domains/lab/digital_multimeter/siglent/siglent_sdm3055__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: siglent_sdm3055__scpi
 description: |
   Virtual Siglent SDM3055 digital multimeter exposing a compact SCPI command

--- a/library/domains/lab/digital_multimeter/tektronix/tektronix_dmm4050__scpi.yaml
+++ b/library/domains/lab/digital_multimeter/tektronix/tektronix_dmm4050__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: tektronix_dmm4050__scpi
 description: |
   Virtual Tektronix DMM4050 digital multimeter exposing a focused SCPI command

--- a/library/domains/lab/electronic_load/siglent/siglent_sdl1000x__scpi.yaml
+++ b/library/domains/lab/electronic_load/siglent/siglent_sdl1000x__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: siglent_sdl1000x__scpi
 description: |
   Virtual Siglent SDL1000X series programmable DC electronic load exposing

--- a/library/domains/lab/function_generator/siglent/siglent_sdg1032x__scpi.yaml
+++ b/library/domains/lab/function_generator/siglent/siglent_sdg1032x__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: siglent_sdg1032x__scpi
 description: |
   Virtual Siglent SDG1000X series function generator (modeled after SDG1032X)

--- a/library/domains/lab/instrument/generic/multimeter__scpi.yaml
+++ b/library/domains/lab/instrument/generic/multimeter__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: multimeter__scpi
 description: |
   Virtual SCPI multimeter providing a compact set of measurement and

--- a/library/domains/lab/oscilloscope/keysight/keysight_infiniivision_1000x__scpi.yaml
+++ b/library/domains/lab/oscilloscope/keysight/keysight_infiniivision_1000x__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: keysight_infiniivision_1000x__scpi
 description: |
   Keysight InfiniiVision 1000 X-Series oscilloscope model driven by SCPI

--- a/library/domains/lab/oscilloscope/rigol/rigol_ds1000z__scpi.yaml
+++ b/library/domains/lab/oscilloscope/rigol/rigol_ds1000z__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: rigol_ds1000z__scpi
 description: |
   Virtual Rigol DS1000Z-series oscilloscope exposing a subset of the SCPI

--- a/library/domains/lab/oscilloscope/rigol/rigol_mso5000__scpi.yaml
+++ b/library/domains/lab/oscilloscope/rigol/rigol_mso5000__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: rigol_mso5000__scpi
 description: |
   Virtual Rigol MSO5000-series oscilloscope exposing a subset of the SCPI

--- a/library/domains/lab/oscilloscope/rohde_schwarz/rohde_schwarz_hmo1002__scpi.yaml
+++ b/library/domains/lab/oscilloscope/rohde_schwarz/rohde_schwarz_hmo1002__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: rohde_schwarz_hmo1002__scpi
 description: |
   Virtual Rohde & Schwarz HMO1002 oscilloscope with SCPI commands for

--- a/library/domains/lab/oscilloscope/siglent/siglent_sds1000x_e__scpi.yaml
+++ b/library/domains/lab/oscilloscope/siglent/siglent_sds1000x_e__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: siglent_sds1000x_e__scpi
 description: |
   Virtual Siglent SDS1000X-E series oscilloscope exposing a subset of the

--- a/library/domains/lab/oscilloscope/siglent/siglent_sds2000x_hd__scpi.yaml
+++ b/library/domains/lab/oscilloscope/siglent/siglent_sds2000x_hd__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: siglent_sds2000x_hd__scpi
 description: |
   Virtual Siglent SDS2000X HD series oscilloscope exposing a subset of the

--- a/library/domains/lab/oscilloscope/tektronix/tektronix_mdo3000__scpi.yaml
+++ b/library/domains/lab/oscilloscope/tektronix/tektronix_mdo3000__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: tektronix_mdo3000__scpi
 description: |
   Tektronix MDO3000 Series mixed domain oscilloscope model driven by SCPI

--- a/library/domains/lab/power_analyzer/rohde_schwarz/rohde_schwarz_hmc8015__scpi.yaml
+++ b/library/domains/lab/power_analyzer/rohde_schwarz/rohde_schwarz_hmc8015__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: rohde_schwarz_hmc8015__scpi
 description: |
   Virtual Rohde & Schwarz HMC8015 power analyzer with SCPI measurements for

--- a/library/domains/lab/power_supply/generic/bench_power_supply__scpi.yaml
+++ b/library/domains/lab/power_supply/generic/bench_power_supply__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: bench_power_supply__scpi
 description: |
   Generic bench power supply with a compact SCPI command set for

--- a/library/domains/lab/power_supply/keysight/keysight_e36312a__scpi.yaml
+++ b/library/domains/lab/power_supply/keysight/keysight_e36312a__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: keysight_e36312a__scpi
 description: |
   Keysight E36312A triple-output DC power supply model driven by SCPI

--- a/library/domains/lab/power_supply/rigol/rigol_dp800__scpi.yaml
+++ b/library/domains/lab/power_supply/rigol/rigol_dp800__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: rigol_dp800__scpi
 description: |
   Virtual Rigol DP800-series programmable linear power supply exposing a

--- a/library/domains/lab/power_supply/rohde_schwarz/rohde_schwarz_hmp4040__scpi.yaml
+++ b/library/domains/lab/power_supply/rohde_schwarz/rohde_schwarz_hmp4040__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: rohde_schwarz_hmp4040__scpi
 description: |
   Virtual Rohde & Schwarz HMP4040 programmable power supply with a focused

--- a/library/domains/lab/power_supply/siglent/siglent_spd1000x__scpi.yaml
+++ b/library/domains/lab/power_supply/siglent/siglent_spd1000x__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: siglent_spd1000x__scpi
 description: |
   Siglent SPD1000X series single-channel programmable DC power supply driven by

--- a/library/domains/lab/spectrum_analyzer/siglent/siglent_ssa3000x__scpi.yaml
+++ b/library/domains/lab/spectrum_analyzer/siglent/siglent_ssa3000x__scpi.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: siglent_ssa3000x__scpi
 description: |
   Virtual Siglent SSA3000X series spectrum analyzer exposing a subset of the

--- a/library/industries/embedded_lab_pack/MODELS.yaml
+++ b/library/industries/embedded_lab_pack/MODELS.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 models:
 - id: Embedded.HealthMonitor.BleGatt
   path: library/domains/lab/monitor/generic/vital_signs_monitor__ble_gatt.yaml

--- a/library/industries/energy_pack/MODELS.yaml
+++ b/library/industries/energy_pack/MODELS.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 models:
 - id: Energy.CSMS.Ocpp
   path: library/domains/energy/csms/generic/csms__ocpp.yaml

--- a/library/industries/industrial_iiot_pack/MODELS.yaml
+++ b/library/industries/industrial_iiot_pack/MODELS.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 models:
 - id: Condition.ConditionMonitor.Mqtt
   path: library/domains/industrial/monitor/generic/condition_monitor__mqtt.yaml

--- a/library/industries/smart_building_pack/MODELS.yaml
+++ b/library/industries/smart_building_pack/MODELS.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 models:
 - id: Building.BMSController.OpcUa
   path: library/domains/building/controller/generic/bms_controller__opcua.yaml

--- a/packaging/windows/Build.ps1
+++ b/packaging/windows/Build.ps1
@@ -1,4 +1,5 @@
 #!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
 param(
     [string]$Configuration = "Release",
     [string]$RuntimeIdentifier = "win-x64",

--- a/packaging/windows/launcher/Program.cs
+++ b/packaging/windows/launcher/Program.cs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 using System.Diagnostics;
 
 namespace SpxLauncher;

--- a/packaging/windows/launcher/SpxLauncher.csproj
+++ b/packaging/windows/launcher/SpxLauncher.csproj
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: MIT -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/packaging/windows/wix/SPX.Bundle.wxs
+++ b/packaging/windows/wix/SPX.Bundle.wxs
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-License-Identifier: MIT -->
 <Wix
   xmlns="http://wixtoolset.org/schemas/v4/wxs"
   xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal"

--- a/packaging/windows/wix/SPX.Product.wxs
+++ b/packaging/windows/wix/SPX.Product.wxs
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-License-Identifier: MIT -->
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package
     Name="$(var.ProductName)"

--- a/packaging/windows/wix/theme/RtfTheme.wxl
+++ b/packaging/windows/wix/theme/RtfTheme.wxl
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: MIT -->
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
   <String Id="Caption" Value="[WixBundleName] Setup" />
   <String Id="Title" Value="[WixBundleName]" />

--- a/packaging/windows/wix/theme/RtfTheme.xml
+++ b/packaging/windows/wix/theme/RtfTheme.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-License-Identifier: MIT -->
 <!--
   Custom Burn theme derived from the standard WiX RTF theme layout.
   Purpose: allow SPX-specific logo sizing and title alignment.

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: MIT
 [virtualenvs]
 in-project = true

--- a/profiles/embedded_lab_pack/mhealth_ci.yaml
+++ b/profiles/embedded_lab_pack/mhealth_ci.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: mhealth_ci
 description: |
   BLE health wearable regression profile pairing the vital signs monitor with

--- a/profiles/embedded_lab_pack/scpi_lab.yaml
+++ b/profiles/embedded_lab_pack/scpi_lab.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: scpi_lab
 description: |
   SCPI-focused lab harness bundling the virtual multimeter, oscilloscope, and

--- a/profiles/energy_pack/ev_csms_demo.yaml
+++ b/profiles/energy_pack/ev_csms_demo.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: ev_csms_demo
 description: |
   Minimal EV/DER orchestration profile showcasing the built-in OCPP 1.6 handshake

--- a/profiles/industrial_iiot_pack/iiot_monitoring.yaml
+++ b/profiles/industrial_iiot_pack/iiot_monitoring.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: iiot_monitoring
 description: |
   Monitoring-oriented profile that feeds MQTT/HTTP telemetry from the building

--- a/profiles/industrial_iiot_pack/modbus_master_plc_demo.yaml
+++ b/profiles/industrial_iiot_pack/modbus_master_plc_demo.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: modbus_master_plc_demo
 description: |
   Minimal PLC-style Modbus master demo that supervises a Schneider Altivar 320

--- a/profiles/industrial_iiot_pack/process_cell_quickstart.yaml
+++ b/profiles/industrial_iiot_pack/process_cell_quickstart.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: process_cell_quickstart
 description: |
   Quick baseline for motion/process control containing the stepper axis, thermal

--- a/profiles/smart_building_pack/bms_quickstart.yaml
+++ b/profiles/smart_building_pack/bms_quickstart.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 name: bms_quickstart
 description: |
   Minimal smart-building baseline containing environmental telemetry, HVAC control

--- a/scripts/mqtt2aas_bridge.py
+++ b/scripts/mqtt2aas_bridge.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import json
 import paho.mqtt.client as mqtt
 import requests

--- a/scripts/read_comfort_index.py
+++ b/scripts/read_comfort_index.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """Subscribe to comfort index updates published by the MQTT environment sensor."""
 
 from __future__ import annotations

--- a/spx-install.ps1
+++ b/spx-install.ps1
@@ -1,4 +1,5 @@
 #!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 

--- a/spx-install.sh
+++ b/spx-install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/spx-mcp-setup.command
+++ b/spx-mcp-setup.command
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR" || exit 1

--- a/spx-mcp-setup.sh
+++ b/spx-mcp-setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/spx-setup.bat
+++ b/spx-setup.bat
@@ -1,3 +1,4 @@
+@REM SPDX-License-Identifier: MIT
 @echo off
 setlocal
 

--- a/spx-setup.command
+++ b/spx-setup.command
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR" || exit 1

--- a/spx-setup.desktop
+++ b/spx-setup.desktop
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 [Desktop Entry]
 Type=Application
 Name=SPX Setup

--- a/spx-setup.sh
+++ b/spx-setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tools/check_model_branch_guard.py
+++ b/tools/check_model_branch_guard.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """Guard rails for model-yaml automation branch drift and duplicate additions.
 
 This script is designed to prevent the automation/model-yaml branch from

--- a/tools/render_pack_indexes.py
+++ b/tools/render_pack_indexes.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """Render pack model indexes from the catalog source of truth."""
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ except ImportError as exc:  # pragma: no cover - import guard for CLI use
     ) from exc
 
 PACK_INDEX_FIELDS = ("id", "path", "domain_group", "device_class", "vendor")
+SPDX_HEADER = "# SPDX-License-Identifier: MIT\n"
 
 
 def _load_yaml(path: Path) -> Any:
@@ -69,7 +71,7 @@ def render_pack_indexes(root: Path) -> list[Path]:
         pack_index_path = pack_dir / "MODELS.yaml"
         payload = {"models": _pack_index_rows(models, pack_id)}
         pack_index_path.write_text(
-            yaml.safe_dump(payload, sort_keys=False, allow_unicode=False),
+            SPDX_HEADER + yaml.safe_dump(payload, sort_keys=False, allow_unicode=False),
             encoding="utf-8",
         )
         written.append(pack_index_path)

--- a/tools/validate_models.py
+++ b/tools/validate_models.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """Lightweight validation for model YAML files and catalog references."""
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- add MIT SPDX headers to missing executable and configuration source files across installer, packaging, tooling, models, profiles, examples, and extensions
- update the pack index generator so rendered MODELS.yaml files keep the SPDX header on regeneration
- regenerate library/industries/*/MODELS.yaml with the new header

## Validation
- reran the focused SPDX scan for source-like file types and got zero missing headers in scope
- ran python tools/render_pack_indexes.py
- ran git diff --check

## Notes
- this pass intentionally leaves Markdown/docs and pure JSON example files out of scope
- two example notebooks were rewritten by the notebook JSON update while adding the SPDX cell