### PR TITLE
fix(installer): add macOS license screen and prefer runtime_mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,9 @@ a packaged location such as `/Applications/SPX Tools/`. Once they have
 generated a local environment, they can later manage it via the companion
 launchers in the same folder:
 
+The macOS installer now also uses the native Installer.app license step. Its
+content is sourced from `packaging/macos/resources/English.lproj/License.rtf`.
+
 - `SPX MCP Setup.app` creates `~/Documents/SPX Codex Workspace`, prepares a
   local `.venv`, writes `.codex/config.toml`, and opens that folder for Codex.
   During setup the user chooses a work mode:

--- a/installer/mcp_workspace.py
+++ b/installer/mcp_workspace.py
@@ -120,6 +120,12 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Semantic work mode: runtime_mcp or repo_dev.",
     )
     parser.add_argument(
+        "--suggested-work-mode",
+        choices=(WORK_MODE_RUNTIME_MCP, WORK_MODE_REPO_DEV),
+        default=None,
+        help="Suggested default work mode for interactive packaged launchers.",
+    )
+    parser.add_argument(
         "--python",
         required=False,
         default=sys.executable,
@@ -629,6 +635,7 @@ def resolve_workspace_selection(
     workspace_dir: Path,
     explicit_workspace_kind: Optional[str],
     explicit_work_mode: Optional[str],
+    suggested_work_mode: Optional[str] = None,
 ) -> tuple[str, str]:
     if explicit_workspace_kind is not None or explicit_work_mode is not None:
         return resolve_workspace_contract(
@@ -642,10 +649,24 @@ def resolve_workspace_selection(
         explicit_workspace_kind=None,
         explicit_work_mode=None,
     )
+
+    prompt_default_mode = work_mode
+    normalized_suggested_mode = normalize_work_mode(suggested_work_mode)
+    local_work_mode = read_workspace_mode_file(workspace_dir)
+    marker_work_mode = marker_default_work_mode(read_workspace_marker(workspace_dir))
+    should_apply_suggestion = (
+        normalized_suggested_mode is not None
+        and local_work_mode is None
+        and marker_work_mode is None
+        and not is_git_workspace(workspace_dir)
+    )
+    if should_apply_suggestion:
+        prompt_default_mode = normalized_suggested_mode
+
     if is_interactive_session():
-        selected_mode = prompt_work_mode(work_mode)
+        selected_mode = prompt_work_mode(prompt_default_mode)
         return workspace_kind_for_work_mode(selected_mode), selected_mode
-    return workspace_kind, work_mode
+    return workspace_kind_for_work_mode(prompt_default_mode), prompt_default_mode
 
 
 def assert_workspace_ready_for_managed_bootstrap(workspace_dir: Path) -> None:
@@ -1093,6 +1114,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         workspace_dir=workspace_dir,
         explicit_workspace_kind=args.workspace_kind,
         explicit_work_mode=args.work_mode,
+        suggested_work_mode=args.suggested_work_mode,
     )
 
     if workspace_kind == WORKSPACE_KIND_GIT:

--- a/packaging/macos/resources/English.lproj/License.rtf
+++ b/packaging/macos/resources/English.lproj/License.rtf
@@ -1,0 +1,15 @@
+{\rtf1\ansi\deff0
+{\fonttbl{\f0\fswiss Helvetica;}}
+\fs24
+\b SPX Installer Terms\par
+\b0\par
+This installer and the installed SPX package may include both (1) components distributed under open-source licenses and (2) proprietary SPX components, trademarks, hosted services, and subscription-gated features owned or controlled by HammerHeads Engineers Sp. z o.o.\par
+\par
+Open-source components remain subject to their own license terms. Nothing in these installer terms removes or limits any rights already granted to you under those open-source licenses. The applicable notices and license texts are included with the package or installed files, including the MIT license and THIRD_PARTY_NOTICE.txt included with this package.\par
+\par
+Proprietary SPX components, branding, hosted services, license keys, and subscription-gated features are provided only under the applicable commercial agreement, subscription terms, or other written authorization issued by HammerHeads Engineers Sp. z o.o.\par
+\par
+Unless expressly permitted by an applicable open-source license or by a separate commercial agreement with HammerHeads Engineers Sp. z o.o., you may not redistribute proprietary SPX components, trademarks, hosted service credentials, or subscription entitlements.\par
+\par
+By continuing with this installation, you confirm that you have the right to install this software and that you will comply with the applicable open-source license notices and any commercial terms governing proprietary SPX features or services.\par
+}

--- a/packaging/windows/launcher/Program.cs
+++ b/packaging/windows/launcher/Program.cs
@@ -135,6 +135,8 @@ internal static class Program
             pythonExecutable,
             "--server-name",
             "spx",
+            "--suggested-work-mode",
+            "runtime_mcp",
         };
         if (!hasSeedEnv)
         {

--- a/scripts/build_macos_pkg.sh
+++ b/scripts/build_macos_pkg.sh
@@ -92,6 +92,35 @@ EOF
   chmod +x "${scripts_dir}/postinstall"
 }
 
+write_distribution_file() {
+  local distribution_path="$1"
+  local package_id="$2"
+  local package_file_name="$3"
+  local version="$4"
+  local title="$5"
+
+  cat > "${distribution_path}" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="1">
+    <title>${title}</title>
+    <license file="License.rtf"/>
+    <pkg-ref id="${package_id}"/>
+    <options customize="never" require-scripts="false" hostArchitectures="x86_64,arm64"/>
+    <domains enable_anywhere="false" enable_currentUserHome="false" enable_localSystem="true"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="${package_id}"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="${package_id}" visible="false">
+        <pkg-ref id="${package_id}"/>
+    </choice>
+    <pkg-ref id="${package_id}" version="${version}" onConclusion="none">${package_file_name}</pkg-ref>
+</installer-gui-script>
+EOF
+}
+
 OUTPUT_DIR="dist"
 STAGING_DIR="build/macos-pkg"
 PKG_NAME="spx-installer-macos"
@@ -115,6 +144,7 @@ APP_SIGN_IDENTITY=""
 SIGN_IDENTITY=""
 KEYCHAIN_PATH=""
 NOTARYTOOL_PROFILE=""
+PRODUCT_TITLE="SPX Tools"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -190,6 +220,7 @@ APP_ROOT="${STAGING_ROOT}/root"
 APP_OUTPUT_DIR="${STAGING_DIR}/root/${TOOLS_DIR_NAME}"
 APP_INSTALL_ROOT="${APP_ROOT}/${TOOLS_DIR_NAME}"
 PKG_SCRIPTS_DIR="${STAGING_ROOT}/pkg-scripts"
+MACOS_RESOURCES_DIR="${REPO_ROOT}/packaging/macos/resources"
 
 if [[ -z "${VERSION}" ]]; then
   VERSION="$(resolve_version)"
@@ -210,11 +241,17 @@ if [[ -n "${SIGN_IDENTITY}" && "${SIGN_IDENTITY}" != Developer\ ID\ Installer:* 
 fi
 
 require_command pkgbuild
+require_command productbuild
 require_command pkgutil
 require_command sed
 require_command /usr/libexec/PlistBuddy
 require_command chflags
 require_command xattr
+
+if [[ ! -d "${MACOS_RESOURCES_DIR}" ]]; then
+  echo "Missing macOS installer resources directory: ${MACOS_RESOURCES_DIR}" >&2
+  exit 1
+fi
 
 mkdir -p "${DEST_DIR}"
 rm -rf "${APP_ROOT}"
@@ -307,8 +344,12 @@ write_pkg_scripts "${PKG_SCRIPTS_DIR}" "${INSTALL_LOCATION}" "${TOOLS_DIR_NAME}"
 
 PKG_PATH="${DEST_DIR}/${PKG_NAME}-${VERSION}.pkg"
 COMPONENT_PLIST="${STAGING_ROOT}/component.plist"
+COMPONENT_PKG_PATH="${STAGING_ROOT}/${PKG_NAME}-${VERSION}-component.pkg"
+DISTRIBUTION_PATH="${STAGING_ROOT}/Distribution.xml"
 rm -f "${PKG_PATH}"
 rm -f "${COMPONENT_PLIST}"
+rm -f "${COMPONENT_PKG_PATH}"
+rm -f "${DISTRIBUTION_PATH}"
 
 pkgbuild --analyze --root "${APP_ROOT}" "${COMPONENT_PLIST}"
 
@@ -335,7 +376,30 @@ if [[ -n "${SIGN_IDENTITY}" ]]; then
   fi
 fi
 
-pkgbuild "${pkgbuild_args[@]}" "${PKG_PATH}"
+pkgbuild "${pkgbuild_args[@]}" "${COMPONENT_PKG_PATH}"
+
+write_distribution_file \
+  "${DISTRIBUTION_PATH}" \
+  "${IDENTIFIER}" \
+  "$(basename "${COMPONENT_PKG_PATH}")" \
+  "${VERSION}" \
+  "${PRODUCT_TITLE}"
+
+productbuild_args=(
+  --distribution "${DISTRIBUTION_PATH}"
+  --resources "${MACOS_RESOURCES_DIR}"
+  --package-path "${STAGING_ROOT}"
+  --version "${VERSION}"
+)
+
+if [[ -n "${SIGN_IDENTITY}" ]]; then
+  productbuild_args+=(--sign "${SIGN_IDENTITY}")
+  if [[ -n "${KEYCHAIN_PATH}" ]]; then
+    productbuild_args+=(--keychain "${KEYCHAIN_PATH}")
+  fi
+fi
+
+productbuild "${productbuild_args[@]}" "${PKG_PATH}"
 
 echo "Created macOS package: ${PKG_PATH}"
 

--- a/spx-mcp-setup.sh
+++ b/spx-mcp-setup.sh
@@ -8,6 +8,7 @@ SERVER_NAME="${SPX_MCP_SERVER_NAME:-spx}"
 WORK_MODE="${SPX_MCP_WORK_MODE:-}"
 WORKSPACE_KIND="${SPX_MCP_WORKSPACE_KIND:-}"
 LEGACY_WORKSPACE_MODE="${SPX_MCP_WORKSPACE_MODE:-}"
+SUGGESTED_WORK_MODE="${SPX_MCP_SUGGESTED_WORK_MODE:-runtime_mcp}"
 GIT_REMOTE_URL="${SPX_MCP_GIT_REMOTE_URL:-https://github.com/HammerHeads-Engineers/spx-examples.git}"
 GIT_BRANCH="${SPX_MCP_GIT_BRANCH:-develop}"
 REPLACE_EXISTING_WORKSPACE="${SPX_MCP_REPLACE_EXISTING_WORKSPACE:-0}"
@@ -379,7 +380,13 @@ resolve_suggested_work_mode() {
     return 0
   fi
 
-  printf '%s\n' "repo_dev"
+  suggested_mode="$(normalize_work_mode "${SUGGESTED_WORK_MODE}" || true)"
+  if [[ -n "${suggested_mode}" ]]; then
+    printf '%s\n' "${suggested_mode}"
+    return 0
+  fi
+
+  printf '%s\n' "runtime_mcp"
 }
 
 prompt_work_mode() {

--- a/tests/installer/test_mcp_workspace.py
+++ b/tests/installer/test_mcp_workspace.py
@@ -226,9 +226,57 @@ def test_resolve_workspace_selection_prompts_and_can_override_suggested_mode(
         workspace_dir=workspace,
         explicit_workspace_kind=None,
         explicit_work_mode=None,
+        suggested_work_mode=mcp_workspace.WORK_MODE_RUNTIME_MCP,
+    )
+
+    assert prompted_defaults == [mcp_workspace.WORK_MODE_RUNTIME_MCP]
+    assert workspace_kind == mcp_workspace.WORKSPACE_KIND_MANAGED
+    assert work_mode == mcp_workspace.WORK_MODE_RUNTIME_MCP
+
+
+def test_resolve_workspace_selection_keeps_existing_repo_dev_as_prompt_default(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".git").mkdir()
+    prompted_defaults: list[str] = []
+
+    monkeypatch.setattr(mcp_workspace, "is_interactive_session", lambda: True)
+    monkeypatch.setattr(
+        mcp_workspace,
+        "prompt_work_mode",
+        lambda default_mode: prompted_defaults.append(default_mode) or mcp_workspace.WORK_MODE_REPO_DEV,
+    )
+
+    workspace_kind, work_mode = mcp_workspace.resolve_workspace_selection(
+        workspace_dir=workspace,
+        explicit_workspace_kind=None,
+        explicit_work_mode=None,
+        suggested_work_mode=mcp_workspace.WORK_MODE_RUNTIME_MCP,
     )
 
     assert prompted_defaults == [mcp_workspace.WORK_MODE_REPO_DEV]
+    assert workspace_kind == mcp_workspace.WORKSPACE_KIND_GIT
+    assert work_mode == mcp_workspace.WORK_MODE_REPO_DEV
+
+
+def test_resolve_workspace_selection_uses_suggested_mode_noninteractive_for_clean_workspace(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+
+    monkeypatch.setattr(mcp_workspace, "is_interactive_session", lambda: False)
+
+    workspace_kind, work_mode = mcp_workspace.resolve_workspace_selection(
+        workspace_dir=workspace,
+        explicit_workspace_kind=None,
+        explicit_work_mode=None,
+        suggested_work_mode=mcp_workspace.WORK_MODE_RUNTIME_MCP,
+    )
+
     assert workspace_kind == mcp_workspace.WORKSPACE_KIND_MANAGED
     assert work_mode == mcp_workspace.WORK_MODE_RUNTIME_MCP
 


### PR DESCRIPTION
## Summary
- add a native macOS Installer.app license step by switching the final `.pkg` assembly to `productbuild --distribution --resources`
- add the installer-specific macOS license text under `packaging/macos/resources/English.lproj/License.rtf`
- make packaged `spx-mcp-setup` suggest `runtime_mcp` on ENTER while still prompting the user to choose between `runtime_mcp` and `repo_dev`
- pass the same suggested default through the Windows packaged `mcp-setup` launcher for consistency

## Testing
- poetry run pytest tests/installer/test_mcp_workspace.py
- scripts/build_macos_pkg.sh
- scripts/build_macos_pkg.sh --app-sign "Developer ID Application: HAMMERHEADS ENGINEERS SP Z O O (CWL752HNG5)" --sign "Developer ID Installer: HAMMERHEADS ENGINEERS SP Z O O (CWL752HNG5)" --notarytool-profile spx-notary
- pkgutil --check-signature dist/spx-installer-macos-1.1.0-rc.40.pkg
- spctl -a -vv -t install dist/spx-installer-macos-1.1.0-rc.40.pkg