### PR TITLE
chore(installer): bump spx-server to v1.0.0-rc.64

### DIFF
--- a/installer/generator.py
+++ b/installer/generator.py
@@ -18,7 +18,7 @@ from . import paths
 
 
 SPX_SERVER_SERVICE_NAME = "spx-server"
-SPX_SERVER_IMAGE = "simplephysx/spx-server:v1.0.0-rc.63"
+SPX_SERVER_IMAGE = "simplephysx/spx-server:v1.0.0-rc.64"
 # SPX_SERVER_IMAGE = "spx-server:trial"
 SPX_UI_SERVICE_NAME = "spx-ui"
 SPX_UI_IMAGE = "simplephysx/spx-ui:v1.0.0-rc.67"


### PR DESCRIPTION
This pull request updates the default Docker image tag for the `spx-server` service in the installer configuration.

- Dependency update:
  * Updated the `SPX_SERVER_IMAGE` version from `v1.0.0-rc.63` to `v1.0.0-rc.64` in `installer/generator.py` to use the latest server image.